### PR TITLE
Minor bugfixes for CCPP v6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/grantfirl/fv3atm
-  branch = 20220523_ccpp_v6_needs
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/grantfirl/fv3atm
+  branch = 20220523_ccpp_v6_needs
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,16 +1,16 @@
-Thu May 19 21:56:36 MDT 2022
+Tue May 24 19:31:18 MDT 2022
 Start Regression test
 
-Compile 001 elapsed time 408 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 426 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 827 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 210 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 529 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 307 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 007 elapsed time 307 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 398 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 404 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 826 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 200 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 526 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 292 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 007 elapsed time 298 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -57,14 +57,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 267.966265
-0:The maximum resident set size (KB)                   = 433532
+0:The total amount of wall time                        = 272.683869
+0:The maximum resident set size (KB)                   = 433520
 
 Test 001 control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,14 +103,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 137.852054
-0:The maximum resident set size (KB)                   = 183348
+0:The total amount of wall time                        = 137.182975
+0:The maximum resident set size (KB)                   = 183296
 
 Test 002 control_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -149,14 +149,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 814.763921
-0:The maximum resident set size (KB)                   = 674116
+0:The total amount of wall time                        = 816.522118
+0:The maximum resident set size (KB)                   = 674244
 
 Test 003 control_c48 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -167,14 +167,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 174.140918
-0:The maximum resident set size (KB)                   = 427664
+0:The total amount of wall time                        = 175.709891
+0:The maximum resident set size (KB)                   = 427716
 
 Test 004 control_stochy PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_flake
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_flake
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -185,14 +185,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 338.921932
-0:The maximum resident set size (KB)                   = 485664
+0:The total amount of wall time                        = 337.040156
+0:The maximum resident set size (KB)                   = 485388
 
 Test 005 control_flake PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_thompson
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -203,14 +203,14 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 369.695972
-0:The maximum resident set size (KB)                   = 795264
+0:The total amount of wall time                        = 377.574145
+0:The maximum resident set size (KB)                   = 795292
 
 Test 006 control_thompson PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_thompson_no_aero
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -221,14 +221,14 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 359.757995
-0:The maximum resident set size (KB)                   = 789152
+0:The total amount of wall time                        = 357.269362
+0:The maximum resident set size (KB)                   = 789128
 
 Test 007 control_thompson_no_aero PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_ras
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_ras
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_ras
 Checking test 008 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -239,14 +239,14 @@ Checking test 008 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 288.127725
-0:The maximum resident set size (KB)                   = 446332
+0:The total amount of wall time                        = 290.336685
+0:The maximum resident set size (KB)                   = 446340
 
 Test 008 control_ras PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_p8
 Checking test 009 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -293,14 +293,14 @@ Checking test 009 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 317.546166
-0:The maximum resident set size (KB)                   = 817880
+0:The total amount of wall time                        = 319.898931
+0:The maximum resident set size (KB)                   = 817884
 
 Test 009 control_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_control
 Checking test 010 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -347,14 +347,14 @@ Checking test 010 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 701.175800
-0:The maximum resident set size (KB)                   = 774764
+0:The total amount of wall time                        = 703.343609
+0:The maximum resident set size (KB)                   = 774464
 
 Test 010 rap_control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_2threads
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_2threads
 Checking test 011 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -401,14 +401,14 @@ Checking test 011 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1235.809887
-0:The maximum resident set size (KB)                   = 842928
+0:The total amount of wall time                        = 1236.305548
+0:The maximum resident set size (KB)                   = 842976
 
 Test 011 rap_2threads PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_restart
 Checking test 012 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -447,14 +447,14 @@ Checking test 012 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 348.614268
-0:The maximum resident set size (KB)                   = 522504
+0:The total amount of wall time                        = 350.567338
+0:The maximum resident set size (KB)                   = 522484
 
 Test 012 rap_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_sfcdiff
 Checking test 013 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -501,14 +501,14 @@ Checking test 013 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 704.045535
-0:The maximum resident set size (KB)                   = 774240
+0:The total amount of wall time                        = 702.507788
+0:The maximum resident set size (KB)                   = 774244
 
 Test 013 rap_sfcdiff PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_sfcdiff_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_sfcdiff_restart
 Checking test 014 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -547,14 +547,14 @@ Checking test 014 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 352.628228
-0:The maximum resident set size (KB)                   = 522148
+0:The total amount of wall time                        = 351.420484
+0:The maximum resident set size (KB)                   = 522144
 
 Test 014 rap_sfcdiff_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/hrrr_control
 Checking test 015 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -601,14 +601,14 @@ Checking test 015 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 678.944587
-0:The maximum resident set size (KB)                   = 771868
+0:The total amount of wall time                        = 679.978699
+0:The maximum resident set size (KB)                   = 771900
 
 Test 015 hrrr_control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_v1beta
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rrfs_v1beta
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -655,14 +655,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 696.768454
-0:The maximum resident set size (KB)                   = 771576
+0:The total amount of wall time                        = 694.793088
+0:The maximum resident set size (KB)                   = 771532
 
 Test 016 rrfs_v1beta PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rrfs_conus13km_hrrr_warm
 Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -671,14 +671,14 @@ Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 318.015784
-0:The maximum resident set size (KB)                   = 593320
+0:The total amount of wall time                        = 316.615855
+0:The maximum resident set size (KB)                   = 593816
 
 Test 017 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rrfs_conus13km_radar_tten_warm
 Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -687,14 +687,14 @@ Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 319.026038
-0:The maximum resident set size (KB)                   = 596008
+0:The total amount of wall time                        = 319.434205
+0:The maximum resident set size (KB)                   = 595912
 
 Test 018 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rrfs_smoke_conus13km_hrrr_warm
 Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -703,236 +703,236 @@ Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 342.835410
-0:The maximum resident set size (KB)                   = 607160
+0:The total amount of wall time                        = 343.053929
+0:The maximum resident set size (KB)                   = 606788
 
 Test 019 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 80.556999
-0:The maximum resident set size (KB)                   = 424740
+0:The total amount of wall time                        = 82.199070
+0:The maximum resident set size (KB)                   = 424600
 
 Test 020 control_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 88.556484
-0:The maximum resident set size (KB)                   = 482428
+0:The total amount of wall time                        = 86.757240
+0:The maximum resident set size (KB)                   = 482400
 
 Test 021 control_diag_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/fv3_regional_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/regional_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 133.986731
-0:The maximum resident set size (KB)                   = 536632
+0:The total amount of wall time                        = 131.489140
+0:The maximum resident set size (KB)                   = 536608
 
 Test 022 regional_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 146.534228
-0:The maximum resident set size (KB)                   = 796800
+0:The total amount of wall time                        = 145.983190
+0:The maximum resident set size (KB)                   = 796716
 
 Test 023 rap_control_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.518628
-0:The maximum resident set size (KB)                   = 879300
+0:The total amount of wall time                        = 155.111850
+0:The maximum resident set size (KB)                   = 879236
 
 Test 024 rap_diag_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 235.540788
+0:The total amount of wall time                        = 236.251464
 0:The maximum resident set size (KB)                   = 795368
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rap_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 146.923557
-0:The maximum resident set size (KB)                   = 796776
+0:The total amount of wall time                        = 147.616233
+0:The maximum resident set size (KB)                   = 796824
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/rrfs_v1beta_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.314005
-0:The maximum resident set size (KB)                   = 791340
+0:The total amount of wall time                        = 145.733946
+0:The maximum resident set size (KB)                   = 791272
 
 Test 027 rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 95.464157
-0:The maximum resident set size (KB)                   = 782236
+0:The total amount of wall time                        = 95.381644
+0:The maximum resident set size (KB)                   = 782200
 
 Test 028 control_thompson_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_thompson_no_aero_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.737279
-0:The maximum resident set size (KB)                   = 777608
+0:The total amount of wall time                        = 91.637637
+0:The maximum resident set size (KB)                   = 777592
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_thompson_extdiag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 102.361170
-0:The maximum resident set size (KB)                   = 823484
+0:The total amount of wall time                        = 102.109237
+0:The maximum resident set size (KB)                   = 823464
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 95.757068
-0:The maximum resident set size (KB)                   = 782208
+0:The total amount of wall time                        = 96.257223
+0:The maximum resident set size (KB)                   = 782236
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_ras_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_ras_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_ras_debug
 Checking test 032 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.157756
-0:The maximum resident set size (KB)                   = 434648
+0:The total amount of wall time                        = 84.501981
+0:The maximum resident set size (KB)                   = 434668
 
 Test 032 control_ras_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_stochy_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_stochy_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_stochy_debug
 Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 92.035605
-0:The maximum resident set size (KB)                   = 428948
+0:The total amount of wall time                        = 91.465681
+0:The maximum resident set size (KB)                   = 428892
 
 Test 033 control_stochy_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_debug_p8
 Checking test 034 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.137427
+0:The total amount of wall time                        = 93.230024
 0:The maximum resident set size (KB)                   = 808604
 
 Test 034 control_debug_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/control_wam_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/control_wam_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/control_wam_debug
 Checking test 035 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 142.936206
-0:The maximum resident set size (KB)                   = 170812
+0:The total amount of wall time                        = 142.695661
+0:The maximum resident set size (KB)                   = 170780
 
 Test 035 control_wam_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/cpld_control_c96_noaero_p8
 Checking test 036 cpld_control_c96_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -994,14 +994,14 @@ Checking test 036 cpld_control_c96_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 291.711365
-0:The maximum resident set size (KB)                   = 783392
+0:The total amount of wall time                        = 292.785561
+0:The maximum resident set size (KB)                   = 783428
 
 Test 036 cpld_control_c96_noaero_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/cpld_debug_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/cpld_debug_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/cpld_debug_noaero_p8
 Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1051,25 +1051,25 @@ Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 265.551015
-0:The maximum resident set size (KB)                   = 801588
+0:The total amount of wall time                        = 271.146197
+0:The maximum resident set size (KB)                   = 803156
 
 Test 037 cpld_debug_noaero_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_16895/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_14016/datm_cdeps_control_cfsr
 Checking test 038 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 173.287009
-0:The maximum resident set size (KB)                   = 646000
+0:The total amount of wall time                        = 173.917569
+0:The maximum resident set size (KB)                   = 649120
 
 Test 038 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu May 19 22:43:05 MDT 2022
-Elapsed time: 00h:46m:30s. Have a nice day!
+Tue May 24 20:06:32 MDT 2022
+Elapsed time: 00h:35m:14s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,25 +1,25 @@
-Fri May 20 07:30:20 MDT 2022
+Tue May 24 19:16:15 MDT 2022
 Start Regression test
 
-Compile 001 elapsed time 1182 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 430 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 696 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 792 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 759 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 585 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 360 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 314 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 312 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 276 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 924 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 941 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 435 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 228 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 794 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 638 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1185 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 412 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 684 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 767 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 736 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 572 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 348 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 291 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 303 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 265 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 897 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 880 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 427 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 216 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 759 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 620 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 310.010054
-0:The maximum resident set size (KB)                   = 4401384
+0:The total amount of wall time                        = 310.215165
+0:The maximum resident set size (KB)                   = 4401436
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_2threads_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -146,14 +146,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 648.985497
-0:The maximum resident set size (KB)                   = 4801024
+0:The total amount of wall time                        = 633.358868
+0:The maximum resident set size (KB)                   = 4802824
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_decomp_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -207,14 +207,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 309.178886
-0:The maximum resident set size (KB)                   = 4390164
+0:The total amount of wall time                        = 309.919710
+0:The maximum resident set size (KB)                   = 4390152
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_mpi_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -268,14 +268,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 276.412893
-0:The maximum resident set size (KB)                   = 4273516
+0:The total amount of wall time                        = 276.886032
+0:The maximum resident set size (KB)                   = 4273408
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_bmark_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_bmark_p8
 Checking test 005 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -321,14 +321,14 @@ Checking test 005 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 1307.646791
-0:The maximum resident set size (KB)                   = 5358924
+0:The total amount of wall time                        = 1469.854810
+0:The maximum resident set size (KB)                   = 5359144
 
 Test 005 cpld_bmark_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_control_c96_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_control_c96_p8
 Checking test 006 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 300.978974
-0:The maximum resident set size (KB)                   = 4395672
+0:The total amount of wall time                        = 306.889362
+0:The maximum resident set size (KB)                   = 4395840
 
 Test 006 cpld_control_c96_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_restart_c96_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_restart_c96_p8
 Checking test 007 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -449,14 +449,14 @@ Checking test 007 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 183.767083
-0:The maximum resident set size (KB)                   = 4354768
+0:The total amount of wall time                        = 187.139079
+0:The maximum resident set size (KB)                   = 4354828
 
 Test 007 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_control_c192_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -507,14 +507,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 1470.466318
-0:The maximum resident set size (KB)                   = 4543784
+0:The total amount of wall time                        = 1463.211957
+0:The maximum resident set size (KB)                   = 4543628
 
 Test 008 cpld_control_c192_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_restart_c192_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -565,14 +565,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 986.059723
-0:The maximum resident set size (KB)                   = 4508244
+0:The total amount of wall time                        = 968.613780
+0:The maximum resident set size (KB)                   = 4508016
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_control_c384_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_control_c384_p8
 Checking test 010 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -616,14 +616,14 @@ Checking test 010 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 1413.314078
-0:The maximum resident set size (KB)                   = 5355508
+0:The total amount of wall time                        = 1602.684193
+0:The maximum resident set size (KB)                   = 5355340
 
 Test 010 cpld_control_c384_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_restart_c384_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_restart_c384_p8
 Checking test 011 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -667,14 +667,14 @@ Checking test 011 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 824.718527
-0:The maximum resident set size (KB)                   = 5318488
+0:The total amount of wall time                        = 976.653624
+0:The maximum resident set size (KB)                   = 5319048
 
 Test 011 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/cpld_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -725,14 +725,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 736.994629
-0:The maximum resident set size (KB)                   = 4481728
+0:The total amount of wall time                        = 736.925765
+0:The maximum resident set size (KB)                   = 4481456
 
 Test 012 cpld_debug_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control
 Checking test 013 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -779,14 +779,14 @@ Checking test 013 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 141.807382
-0:The maximum resident set size (KB)                   = 454804
+0:The total amount of wall time                        = 142.242950
+0:The maximum resident set size (KB)                   = 454900
 
 Test 013 control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_decomp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_decomp
 Checking test 014 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -829,28 +829,28 @@ Checking test 014 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 145.769496
-0:The maximum resident set size (KB)                   = 451316
+0:The total amount of wall time                        = 144.453442
+0:The maximum resident set size (KB)                   = 451488
 
 Test 014 control_decomp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_2dwrtdecomp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_2dwrtdecomp
 Checking test 015 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 133.484380
-0:The maximum resident set size (KB)                   = 455484
+0:The total amount of wall time                        = 133.570457
+0:The maximum resident set size (KB)                   = 455432
 
 Test 015 control_2dwrtdecomp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_2threads
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -893,14 +893,14 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 362.218331
-0:The maximum resident set size (KB)                   = 499896
+0:The total amount of wall time                        = 364.749191
+0:The maximum resident set size (KB)                   = 499752
 
 Test 016 control_2threads PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -939,14 +939,14 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 73.316887
-0:The maximum resident set size (KB)                   = 194168
+0:The total amount of wall time                        = 72.543901
+0:The maximum resident set size (KB)                   = 193812
 
 Test 017 control_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_fhzero
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -989,14 +989,14 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 131.953375
-0:The maximum resident set size (KB)                   = 455064
+0:The total amount of wall time                        = 132.710956
+0:The maximum resident set size (KB)                   = 454828
 
 Test 018 control_fhzero PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_CubedSphereGrid
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1023,14 +1023,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 137.428352
-0:The maximum resident set size (KB)                   = 452296
+0:The total amount of wall time                        = 134.740969
+0:The maximum resident set size (KB)                   = 452024
 
 Test 019 control_CubedSphereGrid PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_latlon
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_latlon
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1041,16 +1041,16 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 138.119362
-0:The maximum resident set size (KB)                   = 455092
+0:The total amount of wall time                        = 138.043280
+0:The maximum resident set size (KB)                   = 455072
 
 Test 020 control_latlon PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1059,14 +1059,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 140.039811
-0:The maximum resident set size (KB)                   = 454932
+0:The total amount of wall time                        = 140.812372
+0:The maximum resident set size (KB)                   = 454912
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1105,14 +1105,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 429.589404
-0:The maximum resident set size (KB)                   = 625328
+0:The total amount of wall time                        = 430.878660
+0:The maximum resident set size (KB)                   = 625332
 
 Test 022 control_c48 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c192
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_c192
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1123,14 +1123,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 568.268149
-0:The maximum resident set size (KB)                   = 557936
+0:The total amount of wall time                        = 569.579571
+0:The maximum resident set size (KB)                   = 558108
 
 Test 023 control_c192 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_c384
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1141,14 +1141,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1237.959489
-0:The maximum resident set size (KB)                   = 831100
+0:The total amount of wall time                        = 1230.892736
+0:The maximum resident set size (KB)                   = 831000
 
 Test 024 control_c384 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_c384gdas
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1307.875459
-0:The maximum resident set size (KB)                   = 967364
+0:The total amount of wall time                        = 1307.667774
+0:The maximum resident set size (KB)                   = 967832
 
 Test 025 control_c384gdas PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1209,28 +1209,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 90.534896
-0:The maximum resident set size (KB)                   = 458216
+0:The total amount of wall time                        = 91.271623
+0:The maximum resident set size (KB)                   = 458140
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_stochy_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 49.794301
-0:The maximum resident set size (KB)                   = 225372
+0:The total amount of wall time                        = 49.631221
+0:The maximum resident set size (KB)                   = 225664
 
 Test 027 control_stochy_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_lndp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1241,14 +1241,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 82.834809
-0:The maximum resident set size (KB)                   = 455664
+0:The total amount of wall time                        = 86.371781
+0:The maximum resident set size (KB)                   = 455752
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr4
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_iovr4
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1263,14 +1263,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 140.919419
-0:The maximum resident set size (KB)                   = 455076
+0:The total amount of wall time                        = 139.807180
+0:The maximum resident set size (KB)                   = 454908
 
 Test 029 control_iovr4 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr5
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_iovr5
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1285,14 +1285,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 142.449857
-0:The maximum resident set size (KB)                   = 454848
+0:The total amount of wall time                        = 140.643355
+0:The maximum resident set size (KB)                   = 454976
 
 Test 030 control_iovr5 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1339,14 +1339,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 184.157576
-0:The maximum resident set size (KB)                   = 849900
+0:The total amount of wall time                        = 183.007385
+0:The maximum resident set size (KB)                   = 849912
 
 Test 031 control_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_lndp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_p8_lndp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1365,14 +1365,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 344.243101
-0:The maximum resident set size (KB)                   = 850120
+0:The total amount of wall time                        = 340.544066
+0:The maximum resident set size (KB)                   = 850148
 
 Test 032 control_p8_lndp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_restart_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1411,14 +1411,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 93.945440
-0:The maximum resident set size (KB)                   = 579472
+0:The total amount of wall time                        = 96.999053
+0:The maximum resident set size (KB)                   = 579488
 
 Test 033 control_restart_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_decomp_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1461,14 +1461,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 187.110489
-0:The maximum resident set size (KB)                   = 843788
+0:The total amount of wall time                        = 187.270567
+0:The maximum resident set size (KB)                   = 843840
 
 Test 034 control_decomp_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_2threads_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1511,14 +1511,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 495.074533
-0:The maximum resident set size (KB)                   = 916144
+0:The total amount of wall time                        = 500.504790
+0:The maximum resident set size (KB)                   = 916084
 
 Test 035 control_2threads_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_p8_rrtmgp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1565,14 +1565,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 247.377760
+0:The total amount of wall time                        = 243.896824
 0:The maximum resident set size (KB)                   = 965548
 
 Test 036 control_p8_rrtmgp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,42 +1583,42 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 362.507528
-0:The maximum resident set size (KB)                   = 564560
+0:The total amount of wall time                        = 362.699970
+0:The maximum resident set size (KB)                   = 564572
 
 Test 037 regional_control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 199.865865
-0:The maximum resident set size (KB)                   = 556124
+0:The total amount of wall time                        = 199.003926
+0:The maximum resident set size (KB)                   = 556312
 
 Test 038 regional_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_control_2dwrtdecomp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 351.845054
-0:The maximum resident set size (KB)                   = 563348
+0:The total amount of wall time                        = 361.262862
+0:The maximum resident set size (KB)                   = 563740
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_noquilt
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1626,14 +1626,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 379.396493
-0:The maximum resident set size (KB)                   = 557668
+0:The total amount of wall time                        = 382.855003
+0:The maximum resident set size (KB)                   = 557664
 
 Test 040 regional_noquilt PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_2threads
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1644,28 +1644,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 1168.736414
-0:The maximum resident set size (KB)                   = 557936
+0:The total amount of wall time                        = 1171.841446
+0:The maximum resident set size (KB)                   = 558072
 
 Test 041 regional_2threads PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_netcdf_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 358.287133
-0:The maximum resident set size (KB)                   = 554440
+0:The total amount of wall time                        = 359.147229
+0:The maximum resident set size (KB)                   = 554452
 
 Test 042 regional_netcdf_parallel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_3km
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_3km
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 297.631522
-0:The maximum resident set size (KB)                   = 595700
+0:The total amount of wall time                        = 298.442483
+0:The maximum resident set size (KB)                   = 595704
 
 Test 043 regional_3km PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1730,14 +1730,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 463.025395
-0:The maximum resident set size (KB)                   = 822476
+0:The total amount of wall time                        = 457.258107
+0:The maximum resident set size (KB)                   = 822588
 
 Test 044 rap_control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_rrtmgp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1784,14 +1784,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 532.599862
-0:The maximum resident set size (KB)                   = 951056
+0:The total amount of wall time                        = 522.237935
+0:The maximum resident set size (KB)                   = 951008
 
 Test 045 rap_rrtmgp PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1802,14 +1802,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 696.799699
-0:The maximum resident set size (KB)                   = 931304
+0:The total amount of wall time                        = 700.541954
+0:The maximum resident set size (KB)                   = 931032
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_2threads
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1856,14 +1856,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1093.550822
-0:The maximum resident set size (KB)                   = 879756
+0:The total amount of wall time                        = 1095.794716
+0:The maximum resident set size (KB)                   = 879272
 
 Test 047 rap_2threads PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1902,14 +1902,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 233.674784
-0:The maximum resident set size (KB)                   = 566540
+0:The total amount of wall time                        = 232.662223
+0:The maximum resident set size (KB)                   = 566508
 
 Test 048 rap_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1956,14 +1956,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 460.589943
-0:The maximum resident set size (KB)                   = 822384
+0:The total amount of wall time                        = 457.392625
+0:The maximum resident set size (KB)                   = 822472
 
 Test 049 rap_sfcdiff PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_sfcdiff_restart
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2002,14 +2002,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 231.422004
-0:The maximum resident set size (KB)                   = 565888
+0:The total amount of wall time                        = 229.255971
+0:The maximum resident set size (KB)                   = 565716
 
 Test 050 rap_sfcdiff_restart PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2056,14 +2056,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 436.882314
-0:The maximum resident set size (KB)                   = 822268
+0:The total amount of wall time                        = 437.808007
+0:The maximum resident set size (KB)                   = 822436
 
 Test 051 hrrr_control PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_v1beta
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2110,14 +2110,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 449.288760
-0:The maximum resident set size (KB)                   = 817464
+0:The total amount of wall time                        = 449.382228
+0:The maximum resident set size (KB)                   = 817484
 
 Test 052 rrfs_v1beta PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_v1nssl
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2132,14 +2132,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 550.269431
-0:The maximum resident set size (KB)                   = 507132
+0:The total amount of wall time                        = 556.023892
+0:The maximum resident set size (KB)                   = 507468
 
 Test 053 rrfs_v1nssl PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2154,14 +2154,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 533.773237
-0:The maximum resident set size (KB)                   = 502612
+0:The total amount of wall time                        = 533.673038
+0:The maximum resident set size (KB)                   = 502116
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2170,14 +2170,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 194.033527
-0:The maximum resident set size (KB)                   = 638700
+0:The total amount of wall time                        = 195.115299
+0:The maximum resident set size (KB)                   = 638504
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2186,14 +2186,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 194.031134
-0:The maximum resident set size (KB)                   = 640212
+0:The total amount of wall time                        = 198.878126
+0:The maximum resident set size (KB)                   = 640252
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2202,14 +2202,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 208.023006
-0:The maximum resident set size (KB)                   = 653284
+0:The total amount of wall time                        = 209.889772
+0:The maximum resident set size (KB)                   = 653336
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_csawmg
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2220,14 +2220,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 385.084385
-0:The maximum resident set size (KB)                   = 530168
+0:The total amount of wall time                        = 388.444676
+0:The maximum resident set size (KB)                   = 530200
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_csawmgt
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2238,14 +2238,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 380.723267
-0:The maximum resident set size (KB)                   = 529944
+0:The total amount of wall time                        = 382.429921
+0:The maximum resident set size (KB)                   = 529928
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_flake
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_flake
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2256,14 +2256,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 235.526800
-0:The maximum resident set size (KB)                   = 525092
+0:The total amount of wall time                        = 251.118785
+0:The maximum resident set size (KB)                   = 525088
 
 Test 060 control_flake PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_ras
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2274,14 +2274,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 198.603926
-0:The maximum resident set size (KB)                   = 487232
+0:The total amount of wall time                        = 196.665997
+0:The maximum resident set size (KB)                   = 487656
 
 Test 061 control_ras PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_thompson
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 255.995516
-0:The maximum resident set size (KB)                   = 839072
+0:The total amount of wall time                        = 267.576196
+0:The maximum resident set size (KB)                   = 838884
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_thompson_no_aero
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2310,54 +2310,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 252.591106
-0:The maximum resident set size (KB)                   = 829992
+0:The total amount of wall time                        = 253.387409
+0:The maximum resident set size (KB)                   = 830396
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_wam
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 121.465963
-0:The maximum resident set size (KB)                   = 203596
+0:The total amount of wall time                        = 114.316876
+0:The maximum resident set size (KB)                   = 203652
 
 Test 064 control_wam PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 156.444654
-0:The maximum resident set size (KB)                   = 618972
+0:The total amount of wall time                        = 157.989809
+0:The maximum resident set size (KB)                   = 618936
 
 Test 065 control_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_2threads_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 276.107923
-0:The maximum resident set size (KB)                   = 668248
+0:The total amount of wall time                        = 276.203608
+0:The maximum resident set size (KB)                   = 668176
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2384,415 +2384,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.296951
-0:The maximum resident set size (KB)                   = 621148
+0:The total amount of wall time                        = 176.328684
+0:The maximum resident set size (KB)                   = 621104
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.328271
-0:The maximum resident set size (KB)                   = 618940
+0:The total amount of wall time                        = 160.754636
+0:The maximum resident set size (KB)                   = 618900
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_stochy_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 181.437172
-0:The maximum resident set size (KB)                   = 625208
+0:The total amount of wall time                        = 179.575934
+0:The maximum resident set size (KB)                   = 625396
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_lndp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 161.238179
-0:The maximum resident set size (KB)                   = 624044
+0:The total amount of wall time                        = 161.133158
+0:The maximum resident set size (KB)                   = 623564
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_csawmg_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 252.515029
-0:The maximum resident set size (KB)                   = 671416
+0:The total amount of wall time                        = 253.000558
+0:The maximum resident set size (KB)                   = 670848
 
 Test 071 control_csawmg_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_csawmgt_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 251.984132
-0:The maximum resident set size (KB)                   = 669264
+0:The total amount of wall time                        = 248.683624
+0:The maximum resident set size (KB)                   = 668900
 
 Test 072 control_csawmgt_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_ras_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.638560
-0:The maximum resident set size (KB)                   = 633128
+0:The total amount of wall time                        = 163.239238
+0:The maximum resident set size (KB)                   = 633080
 
 Test 073 control_ras_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 166.605614
-0:The maximum resident set size (KB)                   = 678844
+0:The total amount of wall time                        = 165.269406
+0:The maximum resident set size (KB)                   = 679104
 
 Test 074 control_diag_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 177.446571
-0:The maximum resident set size (KB)                   = 1014116
+0:The total amount of wall time                        = 178.033551
+0:The maximum resident set size (KB)                   = 1014480
 
 Test 075 control_debug_p8 PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 185.419031
-0:The maximum resident set size (KB)                   = 979140
+0:The total amount of wall time                        = 188.906661
+0:The maximum resident set size (KB)                   = 979124
 
 Test 076 control_thompson_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_thompson_no_aero_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 178.580085
-0:The maximum resident set size (KB)                   = 976588
+0:The total amount of wall time                        = 178.762936
+0:The maximum resident set size (KB)                   = 976632
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_thompson_extdiag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 194.678570
-0:The maximum resident set size (KB)                   = 1008412
+0:The total amount of wall time                        = 195.006837
+0:The maximum resident set size (KB)                   = 1008484
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 185.493624
-0:The maximum resident set size (KB)                   = 979444
+0:The total amount of wall time                        = 186.306819
+0:The maximum resident set size (KB)                   = 979596
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/regional_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 258.937482
-0:The maximum resident set size (KB)                   = 588216
+0:The total amount of wall time                        = 259.087327
+0:The maximum resident set size (KB)                   = 588268
 
 Test 080 regional_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.976766
-0:The maximum resident set size (KB)                   = 988888
+0:The total amount of wall time                        = 287.732490
+0:The maximum resident set size (KB)                   = 988092
 
 Test 081 rap_control_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_unified_drag_suite_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 290.043960
-0:The maximum resident set size (KB)                   = 988544
+0:The total amount of wall time                        = 289.518475
+0:The maximum resident set size (KB)                   = 988488
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 304.813419
-0:The maximum resident set size (KB)                   = 1070656
+0:The total amount of wall time                        = 300.008815
+0:The maximum resident set size (KB)                   = 1070700
 
 Test 083 rap_diag_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.895750
-0:The maximum resident set size (KB)                   = 986752
+0:The total amount of wall time                        = 291.852624
+0:The maximum resident set size (KB)                   = 986932
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_unified_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.529236
-0:The maximum resident set size (KB)                   = 988600
+0:The total amount of wall time                        = 292.330972
+0:The maximum resident set size (KB)                   = 988116
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_lndp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.591435
-0:The maximum resident set size (KB)                   = 989316
+0:The total amount of wall time                        = 288.921096
+0:The maximum resident set size (KB)                   = 989284
 
 Test 086 rap_lndp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_flake_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_flake_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.950991
-0:The maximum resident set size (KB)                   = 988464
+0:The total amount of wall time                        = 287.409378
+0:The maximum resident set size (KB)                   = 988552
 
 Test 087 rap_flake_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.867556
-0:The maximum resident set size (KB)                   = 988152
+0:The total amount of wall time                        = 288.289322
+0:The maximum resident set size (KB)                   = 988524
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_noah_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 282.066224
+0:The total amount of wall time                        = 281.354685
 0:The maximum resident set size (KB)                   = 987116
 
 Test 089 rap_noah_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_rrtmgp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 481.069488
-0:The maximum resident set size (KB)                   = 1117392
+0:The total amount of wall time                        = 482.242791
+0:The maximum resident set size (KB)                   = 1117024
 
 Test 090 rap_rrtmgp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_sfcdiff_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.828124
-0:The maximum resident set size (KB)                   = 987868
+0:The total amount of wall time                        = 285.896466
+0:The maximum resident set size (KB)                   = 988276
 
 Test 091 rap_sfcdiff_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 476.934398
-0:The maximum resident set size (KB)                   = 985952
+0:The total amount of wall time                        = 471.393960
+0:The maximum resident set size (KB)                   = 985976
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/rrfs_v1beta_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 283.271081
-0:The maximum resident set size (KB)                   = 983616
+0:The total amount of wall time                        = 283.660005
+0:The maximum resident set size (KB)                   = 983692
 
 Test 093 rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_wam_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 296.290595
-0:The maximum resident set size (KB)                   = 237416
+0:The total amount of wall time                        = 296.325093
+0:The maximum resident set size (KB)                   = 237388
 
 Test 094 control_wam_debug PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 584.838886
-0:The maximum resident set size (KB)                   = 685564
+0:The total amount of wall time                        = 587.207023
+0:The maximum resident set size (KB)                   = 685736
 
 Test 095 hafs_regional_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 650.668185
-0:The maximum resident set size (KB)                   = 1056656
+0:The total amount of wall time                        = 678.282254
+0:The maximum resident set size (KB)                   = 1055684
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_atm_ocn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2801,58 +2801,58 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 415.328232
-0:The maximum resident set size (KB)                   = 719584
+0:The total amount of wall time                        = 414.381074
+0:The maximum resident set size (KB)                   = 719504
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_atm_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 972.154962
-0:The maximum resident set size (KB)                   = 712180
+0:The total amount of wall time                        = 992.889180
+0:The maximum resident set size (KB)                   = 712480
 
 Test 098 hafs_regional_atm_wav PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1014.537338
-0:The maximum resident set size (KB)                   = 732744
+0:The total amount of wall time                        = 1056.020097
+0:The maximum resident set size (KB)                   = 732704
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1323.245646
-0:The maximum resident set size (KB)                   = 274900
+0:The total amount of wall time                        = 1323.970490
+0:The maximum resident set size (KB)                   = 274872
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2861,30 +2861,30 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1380.879794
-0:The maximum resident set size (KB)                   = 286952
+0:The total amount of wall time                        = 1384.449854
+0:The maximum resident set size (KB)                   = 287276
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_global_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 826.231346
-0:The maximum resident set size (KB)                   = 184724
+0:The total amount of wall time                        = 825.500216
+0:The maximum resident set size (KB)                   = 184612
 
 Test 102 hafs_global_1nest_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc .........OK
@@ -2893,44 +2893,44 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing sfc.nest04.f006.nc .........OK
  Comparing sfc.nest04.f006.nc .........OK
  Comparing atm.nest05.f006.nc .........OK
- Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest05.f006.nc .........OK
 
-0:The total amount of wall time                        = 1402.969409
-0:The maximum resident set size (KB)                   = 263024
+0:The total amount of wall time                        = 1390.146110
+0:The maximum resident set size (KB)                   = 262740
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 724.482098
-0:The maximum resident set size (KB)                   = 285908
+0:The total amount of wall time                        = 725.077733
+0:The maximum resident set size (KB)                   = 285640
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
- Comparing sfc.nest02.f006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 714.416938
-0:The maximum resident set size (KB)                   = 285552
+0:The total amount of wall time                        = 712.092597
+0:The maximum resident set size (KB)                   = 285468
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2939,14 +2939,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 728.320573
-0:The maximum resident set size (KB)                   = 318612
+0:The total amount of wall time                        = 730.714854
+0:The maximum resident set size (KB)                   = 318312
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2957,28 +2957,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1323.821193
-0:The maximum resident set size (KB)                   = 338436
+0:The total amount of wall time                        = 1345.553766
+0:The maximum resident set size (KB)                   = 338420
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 416.597660
-0:The maximum resident set size (KB)                   = 203232
+0:The total amount of wall time                        = 415.069460
+0:The maximum resident set size (KB)                   = 203112
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_docn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2986,14 +2986,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 361.959172
-0:The maximum resident set size (KB)                   = 736232
+0:The total amount of wall time                        = 354.094681
+0:The maximum resident set size (KB)                   = 736200
 
 Test 109 hafs_regional_docn PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_docn_oisst
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3001,118 +3001,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 361.767346
-0:The maximum resident set size (KB)                   = 715372
+0:The total amount of wall time                        = 357.833620
+0:The maximum resident set size (KB)                   = 716040
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1269.087787
-0:The maximum resident set size (KB)                   = 867648
+0:The total amount of wall time                        = 1278.163838
+0:The maximum resident set size (KB)                   = 867664
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.730661
-0:The maximum resident set size (KB)                   = 680528
+0:The total amount of wall time                        = 165.253439
+0:The maximum resident set size (KB)                   = 691664
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_restart_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 100.055536
-0:The maximum resident set size (KB)                   = 691904
+0:The total amount of wall time                        = 101.194789
+0:The maximum resident set size (KB)                   = 680812
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_control_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.783691
-0:The maximum resident set size (KB)                   = 578416
+0:The total amount of wall time                        = 161.229467
+0:The maximum resident set size (KB)                   = 578528
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 162.594078
-0:The maximum resident set size (KB)                   = 578472
+0:The total amount of wall time                        = 162.194668
+0:The maximum resident set size (KB)                   = 578412
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.868242
-0:The maximum resident set size (KB)                   = 578488
+0:The total amount of wall time                        = 165.353604
+0:The maximum resident set size (KB)                   = 578432
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.251505
-0:The maximum resident set size (KB)                   = 691704
+0:The total amount of wall time                        = 167.234267
+0:The maximum resident set size (KB)                   = 680620
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.691372
-0:The maximum resident set size (KB)                   = 578408
+0:The total amount of wall time                        = 159.698673
+0:The maximum resident set size (KB)                   = 578416
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3121,14 +3121,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 351.536593
-0:The maximum resident set size (KB)                   = 493484
+0:The total amount of wall time                        = 336.431126
+0:The maximum resident set size (KB)                   = 501728
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3137,64 +3137,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 345.735422
-0:The maximum resident set size (KB)                   = 475176
+0:The total amount of wall time                        = 346.542202
+0:The maximum resident set size (KB)                   = 475172
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_multiple_files_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.995883
-0:The maximum resident set size (KB)                   = 680652
+0:The total amount of wall time                        = 165.805088
+0:The maximum resident set size (KB)                   = 680604
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 253.135190
-0:The maximum resident set size (KB)                   = 1794748
+0:The total amount of wall time                        = 266.197240
+0:The maximum resident set size (KB)                   = 1794732
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_gfs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 234.361602
-0:The maximum resident set size (KB)                   = 1826664
+0:The total amount of wall time                        = 255.709467
+0:The maximum resident set size (KB)                   = 1794668
 
 Test 123 datm_cdeps_gfs PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 453.408209
-0:The maximum resident set size (KB)                   = 687844
+0:The total amount of wall time                        = 454.247926
+0:The maximum resident set size (KB)                   = 689588
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atmwav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_atmwav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3238,14 +3238,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 97.277627
-0:The maximum resident set size (KB)                   = 477560
+0:The total amount of wall time                        = 94.076200
+0:The maximum resident set size (KB)                   = 477556
 
 Test 125 control_atmwav PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atm_aerosols
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_37322/control_atm_aerosols
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57064/control_atm_aerosols
 Checking test 126 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3289,12 +3289,12 @@ Checking test 126 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 388.323370
-0:The maximum resident set size (KB)                   = 4360324
+0:The total amount of wall time                        = 404.263288
+0:The maximum resident set size (KB)                   = 4360656
 
 Test 126 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 08:49:49 MDT 2022
-Elapsed time: 01h:19m:29s. Have a nice day!
+Tue May 24 21:23:59 MDT 2022
+Elapsed time: 02h:07m:44s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,25 +1,25 @@
-Fri May 20 06:47:53 EDT 2022
+Tue May 24 21:19:25 EDT 2022
 Start Regression test
 
-Compile 001 elapsed time 662 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 250 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 442 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 461 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 442 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 413 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 219 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 202 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 205 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 200 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 571 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 590 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 240 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 137 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 522 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 423 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 694 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 261 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 462 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 465 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 464 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 411 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 235 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 218 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 218 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 596 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 593 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 252 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 156 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 553 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 417 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 435.338538
-  0: The maximum resident set size (KB)                   = 1628876
+  0: The total amount of wall time                        = 459.393672
+  0: The maximum resident set size (KB)                   = 1630964
 
-Test 001 cpld_control_p8 PASS
+Test 001 cpld_control_p8 PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_2threads_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -146,14 +146,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 586.459883
-  0: The maximum resident set size (KB)                   = 2533964
+  0: The total amount of wall time                        = 594.961346
+  0: The maximum resident set size (KB)                   = 2327372
 
-Test 002 cpld_2threads_p8 PASS
+Test 002 cpld_2threads_p8 PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_decomp_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -207,14 +207,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 432.377859
-  0: The maximum resident set size (KB)                   = 1665928
+  0: The total amount of wall time                        = 434.837122
+  0: The maximum resident set size (KB)                   = 1651764
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_mpi_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -268,14 +268,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 361.856425
-  0: The maximum resident set size (KB)                   = 1163760
+  0: The total amount of wall time                        = 372.907955
+  0: The maximum resident set size (KB)                   = 1159752
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_bmark_p8
 Checking test 005 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -321,14 +321,14 @@ Checking test 005 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1443.541917
-  0: The maximum resident set size (KB)                   = 2860976
+  0: The total amount of wall time                        = 1484.389342
+  0: The maximum resident set size (KB)                   = 2841036
 
 Test 005 cpld_bmark_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_control_c96_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_control_c96_p8
 Checking test 006 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 415.357950
-  0: The maximum resident set size (KB)                   = 1433344
+  0: The total amount of wall time                        = 426.985577
+  0: The maximum resident set size (KB)                   = 1433484
 
 Test 006 cpld_control_c96_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_restart_c96_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_restart_c96_p8
 Checking test 007 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -449,14 +449,14 @@ Checking test 007 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 262.682415
-  0: The maximum resident set size (KB)                   = 1398708
+  0: The total amount of wall time                        = 264.657058
+  0: The maximum resident set size (KB)                   = 1398292
 
 Test 007 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -507,14 +507,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1328.121700
-  0: The maximum resident set size (KB)                   = 1418536
+  0: The total amount of wall time                        = 1333.068017
+  0: The maximum resident set size (KB)                   = 1402184
 
-Test 008 cpld_control_c192_p8 PASS
+Test 008 cpld_control_c192_p8 PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_restart_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -565,14 +565,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 918.606537
-  0: The maximum resident set size (KB)                   = 1567960
+  0: The total amount of wall time                        = 924.301393
+  0: The maximum resident set size (KB)                   = 1570260
 
-Test 009 cpld_restart_c192_p8 PASS
+Test 009 cpld_restart_c192_p8 PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_control_c384_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_control_c384_p8
 Checking test 010 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -616,16 +616,65 @@ Checking test 010 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1647.927781
-  0: The maximum resident set size (KB)                   = 2874032
+  0: The total amount of wall time                        = 1626.190396
+  0: The maximum resident set size (KB)                   = 2944208
 
 Test 010 cpld_control_c384_p8 PASS
 
-Test 011 cpld_restart_c384_p8 FAIL
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_restart_c384_p8
+Checking test 011 cpld_restart_c384_p8 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing gocart.inst_aod.20210322_1200z.nc4 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2021-03-22-43200.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
+
+  0: The total amount of wall time                        = 1095.318992
+  0: The maximum resident set size (KB)                   = 2831004
+
+Test 011 cpld_restart_c384_p8 PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/cpld_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -676,14 +725,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1021.771265
-  0: The maximum resident set size (KB)                   = 1516180
+  0: The total amount of wall time                        = 1034.518900
+  0: The maximum resident set size (KB)                   = 1492780
 
-Test 012 cpld_debug_p8 PASS
+Test 012 cpld_debug_p8 PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control
 Checking test 013 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -730,14 +779,14 @@ Checking test 013 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 134.997131
-  0: The maximum resident set size (KB)                   = 435376
+  0: The total amount of wall time                        = 134.167737
+  0: The maximum resident set size (KB)                   = 435360
 
 Test 013 control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_decomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_decomp
 Checking test 014 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -780,28 +829,28 @@ Checking test 014 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 138.618970
-  0: The maximum resident set size (KB)                   = 433420
+  0: The total amount of wall time                        = 140.780114
+  0: The maximum resident set size (KB)                   = 433296
 
 Test 014 control_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_2dwrtdecomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_2dwrtdecomp
 Checking test 015 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 128.386221
-  0: The maximum resident set size (KB)                   = 435300
+  0: The total amount of wall time                        = 128.917144
+  0: The maximum resident set size (KB)                   = 435216
 
 Test 015 control_2dwrtdecomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -844,14 +893,14 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 171.893258
- 0: The maximum resident set size (KB)                   = 491124
+ 0: The total amount of wall time                        = 180.760382
+ 0: The maximum resident set size (KB)                   = 489684
 
 Test 016 control_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -890,14 +939,14 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 72.541317
-  0: The maximum resident set size (KB)                   = 171868
+  0: The total amount of wall time                        = 77.234129
+  0: The maximum resident set size (KB)                   = 171952
 
 Test 017 control_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_fhzero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -940,14 +989,14 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.469069
-  0: The maximum resident set size (KB)                   = 435280
+  0: The total amount of wall time                        = 128.529801
+  0: The maximum resident set size (KB)                   = 435248
 
 Test 018 control_fhzero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -974,14 +1023,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.613141
-  0: The maximum resident set size (KB)                   = 434916
+  0: The total amount of wall time                        = 130.475857
+  0: The maximum resident set size (KB)                   = 435104
 
 Test 019 control_CubedSphereGrid PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -992,14 +1041,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 132.327710
-  0: The maximum resident set size (KB)                   = 435128
+  0: The total amount of wall time                        = 139.686447
+  0: The maximum resident set size (KB)                   = 435204
 
 Test 020 control_latlon PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1010,14 +1059,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.558712
-  0: The maximum resident set size (KB)                   = 435296
+  0: The total amount of wall time                        = 137.802049
+  0: The maximum resident set size (KB)                   = 435180
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1056,14 +1105,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 358.767288
-0: The maximum resident set size (KB)                   = 631176
+0: The total amount of wall time                        = 361.547261
+0: The maximum resident set size (KB)                   = 631228
 
 Test 022 control_c48 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1074,14 +1123,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 544.903051
-  0: The maximum resident set size (KB)                   = 537704
+  0: The total amount of wall time                        = 549.186597
+  0: The maximum resident set size (KB)                   = 537592
 
 Test 023 control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1092,14 +1141,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 777.064517
-  0: The maximum resident set size (KB)                   = 810116
+  0: The total amount of wall time                        = 781.201134
+  0: The maximum resident set size (KB)                   = 810484
 
 Test 024 control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1142,14 +1191,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 724.164187
-  0: The maximum resident set size (KB)                   = 930968
+  0: The total amount of wall time                        = 737.574459
+  0: The maximum resident set size (KB)                   = 930260
 
 Test 025 control_c384gdas PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1160,28 +1209,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 88.300232
-  0: The maximum resident set size (KB)                   = 438608
+  0: The total amount of wall time                        = 92.253323
+  0: The maximum resident set size (KB)                   = 438596
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_stochy_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.725363
-  0: The maximum resident set size (KB)                   = 189660
+  0: The total amount of wall time                        = 49.768497
+  0: The maximum resident set size (KB)                   = 189516
 
 Test 027 control_stochy_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1192,14 +1241,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.246660
-  0: The maximum resident set size (KB)                   = 439288
+  0: The total amount of wall time                        = 82.288532
+  0: The maximum resident set size (KB)                   = 439312
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_iovr4
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1214,14 +1263,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.280822
-  0: The maximum resident set size (KB)                   = 435268
+  0: The total amount of wall time                        = 136.456797
+  0: The maximum resident set size (KB)                   = 435336
 
 Test 029 control_iovr4 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_iovr5
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1236,14 +1285,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.399835
-  0: The maximum resident set size (KB)                   = 435304
+  0: The total amount of wall time                        = 136.721656
+  0: The maximum resident set size (KB)                   = 435240
 
 Test 030 control_iovr5 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1290,14 +1339,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.910422
-  0: The maximum resident set size (KB)                   = 824556
+  0: The total amount of wall time                        = 213.016551
+  0: The maximum resident set size (KB)                   = 824584
 
 Test 031 control_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_p8_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1365,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 343.706662
-  0: The maximum resident set size (KB)                   = 801064
+  0: The total amount of wall time                        = 371.931384
+  0: The maximum resident set size (KB)                   = 824784
 
 Test 032 control_p8_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_restart_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1362,14 +1411,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 110.691625
-  0: The maximum resident set size (KB)                   = 545360
+  0: The total amount of wall time                        = 138.341904
+  0: The maximum resident set size (KB)                   = 559600
 
 Test 033 control_restart_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_decomp_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1412,14 +1461,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.868627
-  0: The maximum resident set size (KB)                   = 818136
+  0: The total amount of wall time                        = 202.658553
+  0: The maximum resident set size (KB)                   = 794472
 
 Test 034 control_decomp_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_2threads_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1462,14 +1511,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 237.653077
- 0: The maximum resident set size (KB)                   = 896196
+ 0: The total amount of wall time                        = 241.050269
+ 0: The maximum resident set size (KB)                   = 898336
 
 Test 035 control_2threads_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1516,14 +1565,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.362189
-  0: The maximum resident set size (KB)                   = 915680
+  0: The total amount of wall time                        = 243.054567
+  0: The maximum resident set size (KB)                   = 939612
 
 Test 036 control_p8_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1534,42 +1583,42 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 355.799793
- 0: The maximum resident set size (KB)                   = 544236
+ 0: The total amount of wall time                        = 356.811977
+ 0: The maximum resident set size (KB)                   = 544248
 
 Test 037 regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 199.182081
- 0: The maximum resident set size (KB)                   = 541840
+ 0: The total amount of wall time                        = 202.826565
+ 0: The maximum resident set size (KB)                   = 541976
 
 Test 038 regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_control_2dwrtdecomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 354.752513
- 0: The maximum resident set size (KB)                   = 544328
+ 0: The total amount of wall time                        = 359.578865
+ 0: The maximum resident set size (KB)                   = 544156
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1577,14 +1626,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 377.845704
- 0: The maximum resident set size (KB)                   = 548380
+ 0: The total amount of wall time                        = 376.099550
+ 0: The maximum resident set size (KB)                   = 548372
 
 Test 040 regional_noquilt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1595,28 +1644,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 276.561635
- 0: The maximum resident set size (KB)                   = 544168
+ 0: The total amount of wall time                        = 278.615262
+ 0: The maximum resident set size (KB)                   = 544292
 
 Test 041 regional_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 357.992618
- 0: The maximum resident set size (KB)                   = 541848
+ 0: The total amount of wall time                        = 360.636542
+ 0: The maximum resident set size (KB)                   = 541684
 
 Test 042 regional_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_3km
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_3km
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1627,14 +1676,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 277.471336
-  0: The maximum resident set size (KB)                   = 572652
+  0: The total amount of wall time                        = 283.019614
+  0: The maximum resident set size (KB)                   = 572688
 
 Test 043 regional_3km PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1681,14 +1730,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 449.550514
-  0: The maximum resident set size (KB)                   = 804288
+  0: The total amount of wall time                        = 451.280564
+  0: The maximum resident set size (KB)                   = 804324
 
 Test 044 rap_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1735,14 +1784,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 490.468496
-  0: The maximum resident set size (KB)                   = 922380
+  0: The total amount of wall time                        = 497.500052
+  0: The maximum resident set size (KB)                   = 922188
 
 Test 045 rap_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1753,14 +1802,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 346.868648
-  0: The maximum resident set size (KB)                   = 887644
+  0: The total amount of wall time                        = 355.438590
+  0: The maximum resident set size (KB)                   = 887696
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1807,14 +1856,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 566.460075
+ 0: The total amount of wall time                        = 566.614285
  0: The maximum resident set size (KB)                   = 868812
 
 Test 047 rap_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1853,14 +1902,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 292.021928
-  0: The maximum resident set size (KB)                   = 546408
+  0: The total amount of wall time                        = 233.737568
+  0: The maximum resident set size (KB)                   = 546492
 
 Test 048 rap_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1907,14 +1956,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 449.248015
-  0: The maximum resident set size (KB)                   = 804132
+  0: The total amount of wall time                        = 451.002023
+  0: The maximum resident set size (KB)                   = 804120
 
 Test 049 rap_sfcdiff PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_sfcdiff_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1953,14 +2002,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.893302
-  0: The maximum resident set size (KB)                   = 546128
+  0: The total amount of wall time                        = 240.541333
+  0: The maximum resident set size (KB)                   = 546176
 
 Test 050 rap_sfcdiff_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2007,14 +2056,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 429.957891
-  0: The maximum resident set size (KB)                   = 801796
+  0: The total amount of wall time                        = 431.617861
+  0: The maximum resident set size (KB)                   = 801868
 
 Test 051 hrrr_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2061,14 +2110,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.339466
-  0: The maximum resident set size (KB)                   = 798884
+  0: The total amount of wall time                        = 442.585651
+  0: The maximum resident set size (KB)                   = 798744
 
 Test 052 rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2083,14 +2132,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 534.446897
-  0: The maximum resident set size (KB)                   = 489336
+  0: The total amount of wall time                        = 533.438791
+  0: The maximum resident set size (KB)                   = 489248
 
 Test 053 rrfs_v1nssl PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2105,14 +2154,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 524.221633
-  0: The maximum resident set size (KB)                   = 481692
+  0: The total amount of wall time                        = 521.701447
+  0: The maximum resident set size (KB)                   = 481668
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2121,14 +2170,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 202.521709
-  0: The maximum resident set size (KB)                   = 615992
+  0: The total amount of wall time                        = 202.681906
+  0: The maximum resident set size (KB)                   = 616368
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2137,14 +2186,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 204.728099
-  0: The maximum resident set size (KB)                   = 618844
+  0: The total amount of wall time                        = 221.515572
+  0: The maximum resident set size (KB)                   = 618860
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2153,14 +2202,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 227.243244
-  0: The maximum resident set size (KB)                   = 626352
+  0: The total amount of wall time                        = 227.928823
+  0: The maximum resident set size (KB)                   = 626608
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_csawmgt
 Checking test 058 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2171,14 +2220,14 @@ Checking test 058 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 366.513213
-  0: The maximum resident set size (KB)                   = 503076
+  0: The total amount of wall time                        = 370.804665
+  0: The maximum resident set size (KB)                   = 503156
 
 Test 058 control_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_flake
 Checking test 059 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2189,14 +2238,14 @@ Checking test 059 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 243.870792
-  0: The maximum resident set size (KB)                   = 507916
+  0: The total amount of wall time                        = 246.654556
+  0: The maximum resident set size (KB)                   = 507860
 
 Test 059 control_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_ras
 Checking test 060 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2207,14 +2256,14 @@ Checking test 060 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 184.776029
-  0: The maximum resident set size (KB)                   = 470028
+  0: The total amount of wall time                        = 185.130416
+  0: The maximum resident set size (KB)                   = 469964
 
 Test 060 control_ras PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_thompson
 Checking test 061 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2225,14 +2274,14 @@ Checking test 061 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 252.201854
-  0: The maximum resident set size (KB)                   = 818648
+  0: The total amount of wall time                        = 276.169391
+  0: The maximum resident set size (KB)                   = 818756
 
 Test 061 control_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_thompson_no_aero
 Checking test 062 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2243,54 +2292,54 @@ Checking test 062 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 238.785721
-  0: The maximum resident set size (KB)                   = 813968
+  0: The total amount of wall time                        = 271.110600
+  0: The maximum resident set size (KB)                   = 814188
 
 Test 062 control_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_wam
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_wam
 Checking test 063 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.035596
-  0: The maximum resident set size (KB)                   = 184204
+  0: The total amount of wall time                        = 129.855034
+  0: The maximum resident set size (KB)                   = 184184
 
 Test 063 control_wam PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_debug
 Checking test 064 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.044261
-  0: The maximum resident set size (KB)                   = 601148
+  0: The total amount of wall time                        = 152.515834
+  0: The maximum resident set size (KB)                   = 601132
 
 Test 064 control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_2threads_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_2threads_debug
 Checking test 065 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 256.725674
- 0: The maximum resident set size (KB)                   = 654100
+ 0: The total amount of wall time                        = 258.934885
+ 0: The maximum resident set size (KB)                   = 654032
 
 Test 065 control_2threads_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_CubedSphereGrid_debug
 Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2317,415 +2366,405 @@ Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.264260
-  0: The maximum resident set size (KB)                   = 601840
+  0: The total amount of wall time                        = 162.692100
+  0: The maximum resident set size (KB)                   = 601608
 
 Test 066 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_wrtGauss_netcdf_parallel_debug
 Checking test 067 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.562747
-  0: The maximum resident set size (KB)                   = 601132
+  0: The total amount of wall time                        = 157.682256
+  0: The maximum resident set size (KB)                   = 601196
 
 Test 067 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_stochy_debug
 Checking test 068 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.524789
-  0: The maximum resident set size (KB)                   = 605384
+  0: The total amount of wall time                        = 174.505730
+  0: The maximum resident set size (KB)                   = 605408
 
-Test 068 control_stochy_debug PASS
+Test 068 control_stochy_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_lndp_debug
 Checking test 069 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.858117
-  0: The maximum resident set size (KB)                   = 603336
+  0: The total amount of wall time                        = 155.592459
+  0: The maximum resident set size (KB)                   = 603400
 
 Test 069 control_lndp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_csawmg_debug
 Checking test 070 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.288620
-  0: The maximum resident set size (KB)                   = 640712
+  0: The total amount of wall time                        = 255.520112
+  0: The maximum resident set size (KB)                   = 640660
 
 Test 070 control_csawmg_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_csawmgt_debug
 Checking test 071 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 244.236869
-  0: The maximum resident set size (KB)                   = 640980
+  0: The total amount of wall time                        = 252.131500
+  0: The maximum resident set size (KB)                   = 640932
 
 Test 071 control_csawmgt_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_ras_debug
 Checking test 072 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.330481
-  0: The maximum resident set size (KB)                   = 613988
+  0: The total amount of wall time                        = 159.284413
+  0: The maximum resident set size (KB)                   = 614100
 
 Test 072 control_ras_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.786650
-  0: The maximum resident set size (KB)                   = 655848
+  0: The total amount of wall time                        = 162.438004
+  0: The maximum resident set size (KB)                   = 655876
 
 Test 073 control_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_debug_p8
 Checking test 074 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.250517
-  0: The maximum resident set size (KB)                   = 988376
+  0: The total amount of wall time                        = 181.000363
+  0: The maximum resident set size (KB)                   = 946344
 
 Test 074 control_debug_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_thompson_debug
 Checking test 075 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.472489
-  0: The maximum resident set size (KB)                   = 959184
+  0: The total amount of wall time                        = 183.634932
+  0: The maximum resident set size (KB)                   = 959264
 
 Test 075 control_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_thompson_no_aero_debug
 Checking test 076 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.212381
-  0: The maximum resident set size (KB)                   = 955656
+  0: The total amount of wall time                        = 175.222471
+  0: The maximum resident set size (KB)                   = 955404
 
 Test 076 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_thompson_extdiag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_thompson_extdiag_debug
 Checking test 077 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.088186
-  0: The maximum resident set size (KB)                   = 988684
+  0: The total amount of wall time                        = 190.447996
+  0: The maximum resident set size (KB)                   = 988528
 
-Test 077 control_thompson_extdiag_debug PASS
+Test 077 control_thompson_extdiag_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_thompson_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_thompson_progcld_thompson_debug
 Checking test 078 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 182.647388
-  0: The maximum resident set size (KB)                   = 959352
+  0: The total amount of wall time                        = 186.432178
+  0: The maximum resident set size (KB)                   = 959136
 
-Test 078 control_thompson_progcld_thompson_debug PASS
+Test 078 control_thompson_progcld_thompson_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/regional_debug
 Checking test 079 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 256.614313
- 0: The maximum resident set size (KB)                   = 569188
+ 0: The total amount of wall time                        = 256.231316
+ 0: The maximum resident set size (KB)                   = 569220
 
 Test 079 regional_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_control_debug
 Checking test 080 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.559660
-  0: The maximum resident set size (KB)                   = 966988
+  0: The total amount of wall time                        = 282.934730
+  0: The maximum resident set size (KB)                   = 967528
 
 Test 080 rap_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_unified_drag_suite_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_unified_drag_suite_debug
 Checking test 081 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.232060
-  0: The maximum resident set size (KB)                   = 967144
+  0: The total amount of wall time                        = 286.331398
+  0: The maximum resident set size (KB)                   = 967252
 
-Test 081 rap_unified_drag_suite_debug PASS
+Test 081 rap_unified_drag_suite_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_diag_debug
 Checking test 082 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.214267
-  0: The maximum resident set size (KB)                   = 1050540
+  0: The total amount of wall time                        = 297.130455
+  0: The maximum resident set size (KB)                   = 1050492
 
 Test 082 rap_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_cires_ugwp_debug
 Checking test 083 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.527341
-  0: The maximum resident set size (KB)                   = 966056
+  0: The total amount of wall time                        = 289.035889
+  0: The maximum resident set size (KB)                   = 965952
 
 Test 083 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_unified_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_unified_ugwp_debug
 Checking test 084 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.920701
-  0: The maximum resident set size (KB)                   = 967728
+  0: The total amount of wall time                        = 293.241354
+  0: The maximum resident set size (KB)                   = 967340
 
-Test 084 rap_unified_ugwp_debug PASS
+Test 084 rap_unified_ugwp_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_lndp_debug
 Checking test 085 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.155797
-  0: The maximum resident set size (KB)                   = 967860
+  0: The total amount of wall time                        = 290.368963
+  0: The maximum resident set size (KB)                   = 968196
 
 Test 085 rap_lndp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_flake_debug
 Checking test 086 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.896660
-  0: The maximum resident set size (KB)                   = 967496
+  0: The total amount of wall time                        = 282.203859
+  0: The maximum resident set size (KB)                   = 967324
 
-Test 086 rap_flake_debug PASS
+Test 086 rap_flake_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_progcld_thompson_debug
 Checking test 087 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.382957
-  0: The maximum resident set size (KB)                   = 967248
+  0: The total amount of wall time                        = 283.616323
+  0: The maximum resident set size (KB)                   = 967076
 
 Test 087 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_noah_debug
 Checking test 088 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.469404
-  0: The maximum resident set size (KB)                   = 967100
+  0: The total amount of wall time                        = 279.575806
+  0: The maximum resident set size (KB)                   = 966612
 
 Test 088 rap_noah_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_rrtmgp_debug
 Checking test 089 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 477.540421
-  0: The maximum resident set size (KB)                   = 1088032
+  0: The total amount of wall time                        = 479.137704
+  0: The maximum resident set size (KB)                   = 1087812
 
 Test 089 rap_rrtmgp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.226495
-  0: The maximum resident set size (KB)                   = 966960
+  0: The total amount of wall time                        = 284.309273
+  0: The maximum resident set size (KB)                   = 966756
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 091 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 466.503803
-  0: The maximum resident set size (KB)                   = 965380
+  0: The total amount of wall time                        = 468.598460
+  0: The maximum resident set size (KB)                   = 965656
 
 Test 091 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/rrfs_v1beta_debug
 Checking test 092 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.980583
-  0: The maximum resident set size (KB)                   = 964320
+  0: The total amount of wall time                        = 285.670547
+  0: The maximum resident set size (KB)                   = 964152
 
-Test 092 rrfs_v1beta_debug PASS
+Test 092 rrfs_v1beta_debug PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_wam_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_wam_debug
 Checking test 093 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 290.046787
-  0: The maximum resident set size (KB)                   = 214348
+  0: The total amount of wall time                        = 297.570456
+  0: The maximum resident set size (KB)                   = 214476
 
 Test 093 control_wam_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_atm
 Checking test 094 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 306.405720
-  0: The maximum resident set size (KB)                   = 660392
+  0: The total amount of wall time                        = 335.204579
+  0: The maximum resident set size (KB)                   = 660608
 
 Test 094 hafs_regional_atm PASS
 
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_atm_thompson_gfdlsf
-Checking test 095 hafs_regional_atm_thompson_gfdlsf results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
-
-  0: The total amount of wall time                        = 379.902393
-  0: The maximum resident set size (KB)                   = 1025668
-
-Test 095 hafs_regional_atm_thompson_gfdlsf PASS
+Test 095 hafs_regional_atm_thompson_gfdlsf FAIL
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_atm_ocn
 Checking test 096 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2734,28 +2773,28 @@ Checking test 096 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 469.829735
-  0: The maximum resident set size (KB)                   = 690104
+  0: The total amount of wall time                        = 412.119298
+  0: The maximum resident set size (KB)                   = 689928
 
 Test 096 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_atm_wav
 Checking test 097 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 899.384629
-  0: The maximum resident set size (KB)                   = 682088
+  0: The total amount of wall time                        = 888.360952
+  0: The maximum resident set size (KB)                   = 682108
 
 Test 097 hafs_regional_atm_wav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_atm_ocn_wav
 Checking test 098 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2764,58 +2803,58 @@ Checking test 098 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 974.948769
-  0: The maximum resident set size (KB)                   = 699752
+  0: The total amount of wall time                        = 981.493793
+  0: The maximum resident set size (KB)                   = 699716
 
-Test 098 hafs_regional_atm_ocn_wav PASS
+Test 098 hafs_regional_atm_ocn_wav PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_1nest_atm
 Checking test 099 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 634.256318
-  0: The maximum resident set size (KB)                   = 259968
+  0: The total amount of wall time                        = 562.817826
+  0: The maximum resident set size (KB)                   = 263076
 
 Test 099 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_telescopic_2nests_atm
 Checking test 100 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
  Comparing atm.nest03.f006.nc .........OK
- Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 638.469932
-  0: The maximum resident set size (KB)                   = 265484
+  0: The total amount of wall time                        = 585.540760
+  0: The maximum resident set size (KB)                   = 267440
 
-Test 100 hafs_regional_telescopic_2nests_atm PASS
+Test 100 hafs_regional_telescopic_2nests_atm PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_global_1nest_atm
 Checking test 101 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 309.721931
-  0: The maximum resident set size (KB)                   = 164976
+  0: The total amount of wall time                        = 269.870250
+  0: The maximum resident set size (KB)                   = 165096
 
 Test 101 hafs_global_1nest_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_global_multiple_4nests_atm
 Checking test 102 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2828,42 +2867,42 @@ Checking test 102 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 1339.876150
-  0: The maximum resident set size (KB)                   = 230996
+  0: The total amount of wall time                        = 736.415556
+  0: The maximum resident set size (KB)                   = 218608
 
-Test 102 hafs_global_multiple_4nests_atm PASS
+Test 102 hafs_global_multiple_4nests_atm PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_specified_moving_1nest_atm
 Checking test 103 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 390.039168
-  0: The maximum resident set size (KB)                   = 273476
+  0: The total amount of wall time                        = 327.804298
+  0: The maximum resident set size (KB)                   = 266456
 
-Test 103 hafs_regional_specified_moving_1nest_atm PASS
+Test 103 hafs_regional_specified_moving_1nest_atm PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_storm_following_1nest_atm
 Checking test 104 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 387.633172
-  0: The maximum resident set size (KB)                   = 271896
+  0: The total amount of wall time                        = 320.761004
+  0: The maximum resident set size (KB)                   = 267968
 
 Test 104 hafs_regional_storm_following_1nest_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 105 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2872,14 +2911,14 @@ Checking test 105 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 387.691035
-  0: The maximum resident set size (KB)                   = 296372
+  0: The total amount of wall time                        = 329.192643
+  0: The maximum resident set size (KB)                   = 296728
 
 Test 105 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2890,28 +2929,28 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 886.280219
-  0: The maximum resident set size (KB)                   = 314500
+  0: The total amount of wall time                        = 859.308801
+  0: The maximum resident set size (KB)                   = 314844
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_global_storm_following_1nest_atm
 Checking test 107 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 146.433726
-  0: The maximum resident set size (KB)                   = 184692
+  0: The total amount of wall time                        = 94.523882
+  0: The maximum resident set size (KB)                   = 185360
 
 Test 107 hafs_global_storm_following_1nest_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_docn
 Checking test 108 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2919,14 +2958,14 @@ Checking test 108 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 437.824273
-  0: The maximum resident set size (KB)                   = 696676
+  0: The total amount of wall time                        = 372.367060
+  0: The maximum resident set size (KB)                   = 696096
 
 Test 108 hafs_regional_docn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_docn_oisst
 Checking test 109 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2934,118 +2973,118 @@ Checking test 109 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 567.661318
+  0: The total amount of wall time                        = 395.147276
   0: The maximum resident set size (KB)                   = 684236
 
 Test 109 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/hafs_regional_datm_cdeps
 Checking test 110 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1087.925944
-  0: The maximum resident set size (KB)                   = 806740
+  0: The total amount of wall time                        = 1048.319368
+  0: The maximum resident set size (KB)                   = 806788
 
 Test 110 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_control_cfsr
 Checking test 111 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.260221
- 0: The maximum resident set size (KB)                   = 679524
+ 0: The total amount of wall time                        = 151.964256
+ 0: The maximum resident set size (KB)                   = 686812
 
 Test 111 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_restart_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_restart_cfsr
 Checking test 112 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 91.176190
- 0: The maximum resident set size (KB)                   = 687028
+ 0: The total amount of wall time                        = 90.577600
+ 0: The maximum resident set size (KB)                   = 687100
 
 Test 112 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_control_gefs
 Checking test 113 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.177800
- 0: The maximum resident set size (KB)                   = 570972
+ 0: The total amount of wall time                        = 147.243182
+ 0: The maximum resident set size (KB)                   = 570928
 
 Test 113 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_iau_gefs
 Checking test 114 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.452072
- 0: The maximum resident set size (KB)                   = 566716
+ 0: The total amount of wall time                        = 154.183091
+ 0: The maximum resident set size (KB)                   = 568992
 
 Test 114 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_stochy_gefs
 Checking test 115 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.825560
- 0: The maximum resident set size (KB)                   = 569020
+ 0: The total amount of wall time                        = 148.200318
+ 0: The maximum resident set size (KB)                   = 566804
 
 Test 115 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_bulk_cfsr
 Checking test 116 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.643865
- 0: The maximum resident set size (KB)                   = 686952
+ 0: The total amount of wall time                        = 154.252701
+ 0: The maximum resident set size (KB)                   = 686940
 
 Test 116 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_bulk_gefs
 Checking test 117 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.002029
- 0: The maximum resident set size (KB)                   = 568952
+ 0: The total amount of wall time                        = 146.095462
+ 0: The maximum resident set size (KB)                   = 570984
 
 Test 117 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_mx025_cfsr
 Checking test 118 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3054,14 +3093,14 @@ Checking test 118 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 359.847130
-  0: The maximum resident set size (KB)                   = 482144
+  0: The total amount of wall time                        = 358.716640
+  0: The maximum resident set size (KB)                   = 482140
 
-Test 118 datm_cdeps_mx025_cfsr PASS
+Test 118 datm_cdeps_mx025_cfsr PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_mx025_gefs
 Checking test 119 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3070,64 +3109,64 @@ Checking test 119 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 354.388289
-  0: The maximum resident set size (KB)                   = 450212
+  0: The total amount of wall time                        = 356.583008
+  0: The maximum resident set size (KB)                   = 456192
 
-Test 119 datm_cdeps_mx025_gefs PASS
+Test 119 datm_cdeps_mx025_gefs PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_multiple_files_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_multiple_files_cfsr
 Checking test 120 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.956181
- 0: The maximum resident set size (KB)                   = 686948
+ 0: The total amount of wall time                        = 154.300023
+ 0: The maximum resident set size (KB)                   = 687052
 
 Test 120 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_3072x1536_cfsr
 Checking test 121 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.454932
- 0: The maximum resident set size (KB)                   = 1842888
+ 0: The total amount of wall time                        = 203.924820
+ 0: The maximum resident set size (KB)                   = 1842868
 
 Test 121 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_gfs
 Checking test 122 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 203.795938
- 0: The maximum resident set size (KB)                   = 1842876
+ 0: The total amount of wall time                        = 211.067326
+ 0: The maximum resident set size (KB)                   = 1842756
 
 Test 122 datm_cdeps_gfs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/datm_cdeps_debug_cfsr
 Checking test 123 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 367.661124
- 0: The maximum resident set size (KB)                   = 684744
+ 0: The total amount of wall time                        = 365.993703
+ 0: The maximum resident set size (KB)                   = 673252
 
 Test 123 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_atmwav
 Checking test 124 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3171,14 +3210,14 @@ Checking test 124 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 91.390744
-  0: The maximum resident set size (KB)                   = 447016
+  0: The total amount of wall time                        = 91.491140
+  0: The maximum resident set size (KB)                   = 446988
 
-Test 124 control_atmwav PASS
+Test 124 control_atmwav PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_c384gdas_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_c384gdas_wav
 Checking test 125 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3224,14 +3263,14 @@ Checking test 125 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 918.706805
-  0: The maximum resident set size (KB)                   = 936124
+  0: The total amount of wall time                        = 938.207160
+  0: The maximum resident set size (KB)                   = 934284
 
 Test 125 control_c384gdas_wav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atm_aerosols
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_13864/control_atm_aerosols
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_30036/control_atm_aerosols
 Checking test 126 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3275,127 +3314,34 @@ Checking test 126 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 372.788588
-  0: The maximum resident set size (KB)                   = 1037764
+  0: The total amount of wall time                        = 372.281581
+  0: The maximum resident set size (KB)                   = 1037948
 
 Test 126 control_atm_aerosols PASS
 
 FAILED TESTS: 
-Test cpld_restart_c384_p8 011 failed in run_test failed 
+Test hafs_regional_atm_thompson_gfdlsf 095 failed in run_test failed 
 
 REGRESSION TEST FAILED
-Fri May 20 23:03:18 EDT 2022
-Elapsed time: 16h:15m:26s. Have a nice day!
-
-
-
-Sat May 21 11:26:49 EDT 2022
+Wed May 25 04:23:43 EDT 2022
+Elapsed time: 07h:04m:19s. Have a nice day!
+Wed May 25 09:13:10 EDT 2022
 Start Regression test
 
-Compile 001 elapsed time 703 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 648 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/Minsuk.Ji/FV3_RT/rt_42986/cpld_control_c384_p8
-Checking test 001 cpld_control_c384_p8 results ....
- Comparing sfcf006.nc .........OK
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_4410/hafs_regional_atm_thompson_gfdlsf
+Checking test 001 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
- Comparing gocart.inst_aod.20210322_1200z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2021-03-22-43200.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
-
-  0: The total amount of wall time                        = 1622.691221
-  0: The maximum resident set size (KB)                   = 2874000
-
-Test 001 cpld_control_c384_p8 PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/Minsuk.Ji/FV3_RT/rt_42986/cpld_restart_c384_p8
-Checking test 002 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing gocart.inst_aod.20210322_1200z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2021-03-22-43200.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 998.998756
-  0: The maximum resident set size (KB)                   = 2909740
+  0: The total amount of wall time                        = 382.229500
+  0: The maximum resident set size (KB)                   = 1025984
 
-Test 002 cpld_restart_c384_p8 PASS
+Test 001 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat May 21 13:37:32 EDT 2022
-Elapsed time: 02h:10m:44s. Have a nice day!
+Wed May 25 10:08:16 EDT 2022
+Elapsed time: 00h:55m:07s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,16 +1,16 @@
-Fri May 20 19:17:49 UTC 2022
+Wed May 25 01:32:49 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 184 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 288 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 94 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 292 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 98 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 005 elapsed time 216 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 118 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 007 elapsed time 108 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 120 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 007 elapsed time 111 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -57,14 +57,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 797.752131
-  0: The maximum resident set size (KB)                   = 482844
+  0: The total amount of wall time                        = 807.405276
+  0: The maximum resident set size (KB)                   = 482220
 
 Test 001 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,14 +103,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 387.070382
-  0: The maximum resident set size (KB)                   = 182620
+  0: The total amount of wall time                        = 388.812848
+  0: The maximum resident set size (KB)                   = 184108
 
 Test 002 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -149,14 +149,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 673.806083
-0: The maximum resident set size (KB)                   = 697808
+0: The total amount of wall time                        = 672.688003
+0: The maximum resident set size (KB)                   = 698144
 
 Test 003 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -167,14 +167,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 621.218266
-  0: The maximum resident set size (KB)                   = 480880
+  0: The total amount of wall time                        = 637.236522
+  0: The maximum resident set size (KB)                   = 486196
 
 Test 004 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -185,14 +185,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1357.739502
-  0: The maximum resident set size (KB)                   = 524676
+  0: The total amount of wall time                        = 1386.715171
+  0: The maximum resident set size (KB)                   = 527144
 
 Test 005 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -203,14 +203,14 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 984.206537
-  0: The maximum resident set size (KB)                   = 840656
+  0: The total amount of wall time                        = 998.080253
+  0: The maximum resident set size (KB)                   = 845852
 
 Test 006 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -221,14 +221,14 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 980.387051
-  0: The maximum resident set size (KB)                   = 834264
+  0: The total amount of wall time                        = 968.848326
+  0: The maximum resident set size (KB)                   = 833068
 
 Test 007 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_ras
 Checking test 008 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -239,14 +239,14 @@ Checking test 008 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 803.203088
-  0: The maximum resident set size (KB)                   = 492964
+  0: The total amount of wall time                        = 804.587505
+  0: The maximum resident set size (KB)                   = 493688
 
 Test 008 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_p8
 Checking test 009 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -293,14 +293,14 @@ Checking test 009 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 868.554776
-  0: The maximum resident set size (KB)                   = 837168
+  0: The total amount of wall time                        = 886.502903
+  0: The maximum resident set size (KB)                   = 835448
 
 Test 009 control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_control
 Checking test 010 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -347,14 +347,14 @@ Checking test 010 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1406.631751
-  0: The maximum resident set size (KB)                   = 833016
+  0: The total amount of wall time                        = 1446.069836
+  0: The maximum resident set size (KB)                   = 839260
 
 Test 010 rap_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_2threads
 Checking test 011 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -401,14 +401,14 @@ Checking test 011 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1454.748620
- 0: The maximum resident set size (KB)                   = 896532
+ 0: The total amount of wall time                        = 1470.663354
+ 0: The maximum resident set size (KB)                   = 895608
 
 Test 011 rap_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_restart
 Checking test 012 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -447,14 +447,14 @@ Checking test 012 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 674.888212
-  0: The maximum resident set size (KB)                   = 542704
+  0: The total amount of wall time                        = 687.859735
+  0: The maximum resident set size (KB)                   = 541552
 
 Test 012 rap_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_sfcdiff
 Checking test 013 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -501,14 +501,14 @@ Checking test 013 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1363.558438
-  0: The maximum resident set size (KB)                   = 836148
+  0: The total amount of wall time                        = 1376.569494
+  0: The maximum resident set size (KB)                   = 839400
 
 Test 013 rap_sfcdiff PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_sfcdiff_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_sfcdiff_restart
 Checking test 014 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -547,14 +547,14 @@ Checking test 014 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 668.941717
-  0: The maximum resident set size (KB)                   = 543752
+  0: The total amount of wall time                        = 691.817405
+  0: The maximum resident set size (KB)                   = 542120
 
 Test 014 rap_sfcdiff_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/hrrr_control
 Checking test 015 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -601,14 +601,14 @@ Checking test 015 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1372.293073
-  0: The maximum resident set size (KB)                   = 832260
+  0: The total amount of wall time                        = 1418.021193
+  0: The maximum resident set size (KB)                   = 830480
 
 Test 015 hrrr_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -655,14 +655,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1398.398784
-  0: The maximum resident set size (KB)                   = 830812
+  0: The total amount of wall time                        = 1441.133049
+  0: The maximum resident set size (KB)                   = 834332
 
 Test 016 rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rrfs_conus13km_hrrr_warm
 Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -671,14 +671,14 @@ Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1552.785766
-  0: The maximum resident set size (KB)                   = 640632
+  0: The total amount of wall time                        = 1578.588164
+  0: The maximum resident set size (KB)                   = 639188
 
 Test 017 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rrfs_conus13km_radar_tten_warm
 Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -687,14 +687,14 @@ Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1489.502022
-  0: The maximum resident set size (KB)                   = 640608
+  0: The total amount of wall time                        = 1671.499898
+  0: The maximum resident set size (KB)                   = 642300
 
 Test 018 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rrfs_smoke_conus13km_hrrr_warm
 Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -703,236 +703,236 @@ Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1632.240110
-  0: The maximum resident set size (KB)                   = 650364
+  0: The total amount of wall time                        = 1600.458837
+  0: The maximum resident set size (KB)                   = 649996
 
 Test 019 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 98.212883
-  0: The maximum resident set size (KB)                   = 476368
+  0: The total amount of wall time                        = 97.931184
+  0: The maximum resident set size (KB)                   = 479168
 
 Test 020 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 121.876146
-  0: The maximum resident set size (KB)                   = 531904
+  0: The total amount of wall time                        = 123.545441
+  0: The maximum resident set size (KB)                   = 535580
 
 Test 021 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 123.855678
- 0: The maximum resident set size (KB)                   = 551276
+ 0: The total amount of wall time                        = 125.365450
+ 0: The maximum resident set size (KB)                   = 552224
 
 Test 022 regional_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.362057
-  0: The maximum resident set size (KB)                   = 844396
+  0: The total amount of wall time                        = 164.660103
+  0: The maximum resident set size (KB)                   = 848712
 
 Test 023 rap_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 202.091218
-  0: The maximum resident set size (KB)                   = 930252
+  0: The total amount of wall time                        = 207.756186
+  0: The maximum resident set size (KB)                   = 930384
 
 Test 024 rap_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.265264
-  0: The maximum resident set size (KB)                   = 844776
+  0: The total amount of wall time                        = 263.967974
+  0: The maximum resident set size (KB)                   = 844804
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.797471
-  0: The maximum resident set size (KB)                   = 851248
+  0: The total amount of wall time                        = 169.920528
+  0: The maximum resident set size (KB)                   = 845584
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.943180
-  0: The maximum resident set size (KB)                   = 845276
+  0: The total amount of wall time                        = 168.801781
+  0: The maximum resident set size (KB)                   = 841760
 
 Test 027 rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 112.085522
-  0: The maximum resident set size (KB)                   = 837280
+  0: The total amount of wall time                        = 112.889039
+  0: The maximum resident set size (KB)                   = 840552
 
 Test 028 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 108.145079
-  0: The maximum resident set size (KB)                   = 835644
+  0: The total amount of wall time                        = 112.013312
+  0: The maximum resident set size (KB)                   = 835268
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 129.247814
-  0: The maximum resident set size (KB)                   = 867764
+  0: The total amount of wall time                        = 132.709584
+  0: The maximum resident set size (KB)                   = 868448
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 113.297755
-  0: The maximum resident set size (KB)                   = 839040
+  0: The total amount of wall time                        = 113.538110
+  0: The maximum resident set size (KB)                   = 837968
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_ras_debug
 Checking test 032 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 100.602816
-  0: The maximum resident set size (KB)                   = 488572
+  0: The total amount of wall time                        = 99.690248
+  0: The maximum resident set size (KB)                   = 491324
 
 Test 032 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_stochy_debug
 Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 112.106230
-  0: The maximum resident set size (KB)                   = 481908
+  0: The total amount of wall time                        = 115.600656
+  0: The maximum resident set size (KB)                   = 476524
 
 Test 033 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_debug_p8
 Checking test 034 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 113.155497
-  0: The maximum resident set size (KB)                   = 832860
+  0: The total amount of wall time                        = 111.848624
+  0: The maximum resident set size (KB)                   = 832720
 
 Test 034 control_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/control_wam_debug
 Checking test 035 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 178.475663
-  0: The maximum resident set size (KB)                   = 190148
+  0: The total amount of wall time                        = 178.996099
+  0: The maximum resident set size (KB)                   = 190468
 
 Test 035 control_wam_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/cpld_control_c96_noaero_p8
 Checking test 036 cpld_control_c96_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -994,14 +994,14 @@ Checking test 036 cpld_control_c96_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1136.806575
-  0: The maximum resident set size (KB)                   = 859484
+  0: The total amount of wall time                        = 1188.230111
+  0: The maximum resident set size (KB)                   = 863152
 
 Test 036 cpld_control_c96_noaero_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/cpld_debug_noaero_p8
 Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1051,25 +1051,25 @@ Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 575.156192
-  0: The maximum resident set size (KB)                   = 876820
+  0: The total amount of wall time                        = 587.537887
+  0: The maximum resident set size (KB)                   = 875680
 
 Test 037 cpld_debug_noaero_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30541/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9743/datm_cdeps_control_cfsr
 Checking test 038 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 162.332929
- 0: The maximum resident set size (KB)                   = 625464
+ 0: The total amount of wall time                        = 166.746537
+ 0: The maximum resident set size (KB)                   = 630228
 
 Test 038 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 20:05:16 UTC 2022
-Elapsed time: 00h:47m:28s. Have a nice day!
+Wed May 25 03:13:24 UTC 2022
+Elapsed time: 01h:40m:35s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,25 +1,25 @@
-Fri May 20 14:03:20 UTC 2022
+Wed May 25 01:17:26 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 579 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 194 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 590 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 206 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 Compile 003 elapsed time 334 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 348 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 340 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 309 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 175 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 156 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 167 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 155 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 536 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 545 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 171 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 96 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 504 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 347 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 353 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 341 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 316 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 177 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 162 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 162 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 150 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 541 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 539 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 175 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 104 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 514 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 362 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 395.809204
-  0: The maximum resident set size (KB)                   = 4985636
+  0: The total amount of wall time                        = 401.062947
+  0: The maximum resident set size (KB)                   = 4994544
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_2threads_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -146,14 +146,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 499.587480
-  0: The maximum resident set size (KB)                   = 5478952
+  0: The total amount of wall time                        = 499.800900
+  0: The maximum resident set size (KB)                   = 5477608
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_decomp_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -207,14 +207,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 395.147660
-  0: The maximum resident set size (KB)                   = 5161580
+  0: The total amount of wall time                        = 398.417955
+  0: The maximum resident set size (KB)                   = 5163568
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_mpi_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -268,14 +268,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 323.989348
-  0: The maximum resident set size (KB)                   = 4725300
+  0: The total amount of wall time                        = 329.708976
+  0: The maximum resident set size (KB)                   = 4727860
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_bmark_p8
 Checking test 005 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -321,14 +321,14 @@ Checking test 005 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1244.265870
-  0: The maximum resident set size (KB)                   = 6106644
+  0: The total amount of wall time                        = 1254.137151
+  0: The maximum resident set size (KB)                   = 6207768
 
 Test 005 cpld_bmark_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_control_c96_p8
 Checking test 006 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 382.096687
-  0: The maximum resident set size (KB)                   = 4991184
+  0: The total amount of wall time                        = 385.695562
+  0: The maximum resident set size (KB)                   = 4983220
 
 Test 006 cpld_control_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_restart_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_restart_c96_p8
 Checking test 007 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -449,14 +449,14 @@ Checking test 007 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 235.573435
-  0: The maximum resident set size (KB)                   = 4938668
+  0: The total amount of wall time                        = 234.704105
+  0: The maximum resident set size (KB)                   = 4942504
 
 Test 007 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -507,14 +507,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1571.321606
-  0: The maximum resident set size (KB)                   = 5212648
+  0: The total amount of wall time                        = 1570.803053
+  0: The maximum resident set size (KB)                   = 5214520
 
 Test 008 cpld_control_c192_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_restart_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -565,14 +565,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1065.440068
-  0: The maximum resident set size (KB)                   = 5163264
+  0: The total amount of wall time                        = 1071.548679
+  0: The maximum resident set size (KB)                   = 5130280
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_control_c384_p8
 Checking test 010 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -616,14 +616,14 @@ Checking test 010 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1359.011150
-  0: The maximum resident set size (KB)                   = 6064476
+  0: The total amount of wall time                        = 1367.442298
+  0: The maximum resident set size (KB)                   = 6059636
 
-Test 010 cpld_control_c384_p8 PASS
+Test 010 cpld_control_c384_p8 PASS Tries: 2
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_restart_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_restart_c384_p8
 Checking test 011 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -667,14 +667,14 @@ Checking test 011 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 828.579319
-  0: The maximum resident set size (KB)                   = 6020664
+  0: The total amount of wall time                        = 847.560582
+  0: The maximum resident set size (KB)                   = 6015244
 
-Test 011 cpld_restart_c384_p8 PASS
+Test 011 cpld_restart_c384_p8 PASS Tries: 2
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -725,14 +725,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1119.394096
-  0: The maximum resident set size (KB)                   = 5040624
+  0: The total amount of wall time                        = 1112.015274
+  0: The maximum resident set size (KB)                   = 5050936
 
 Test 012 cpld_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control
 Checking test 013 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -779,14 +779,14 @@ Checking test 013 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.617805
-  0: The maximum resident set size (KB)                   = 644292
+  0: The total amount of wall time                        = 126.236513
+  0: The maximum resident set size (KB)                   = 647652
 
 Test 013 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_decomp
 Checking test 014 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -829,28 +829,28 @@ Checking test 014 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 131.017668
-  0: The maximum resident set size (KB)                   = 628716
+  0: The total amount of wall time                        = 132.348009
+  0: The maximum resident set size (KB)                   = 633804
 
 Test 014 control_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_2dwrtdecomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_2dwrtdecomp
 Checking test 015 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 118.750494
-  0: The maximum resident set size (KB)                   = 641840
+  0: The total amount of wall time                        = 120.141083
+  0: The maximum resident set size (KB)                   = 638432
 
 Test 015 control_2dwrtdecomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -893,14 +893,14 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 155.771842
- 0: The maximum resident set size (KB)                   = 698568
+ 0: The total amount of wall time                        = 155.922568
+ 0: The maximum resident set size (KB)                   = 699612
 
 Test 016 control_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -939,14 +939,14 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 65.522163
-  0: The maximum resident set size (KB)                   = 469260
+  0: The total amount of wall time                        = 66.092707
+  0: The maximum resident set size (KB)                   = 470656
 
 Test 017 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_fhzero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -989,14 +989,14 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 117.517362
-  0: The maximum resident set size (KB)                   = 638688
+  0: The total amount of wall time                        = 118.875747
+  0: The maximum resident set size (KB)                   = 646208
 
 Test 018 control_fhzero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1023,14 +1023,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.986572
-  0: The maximum resident set size (KB)                   = 641736
+  0: The total amount of wall time                        = 121.261054
+  0: The maximum resident set size (KB)                   = 648176
 
 Test 019 control_CubedSphereGrid PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1041,14 +1041,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.860039
-  0: The maximum resident set size (KB)                   = 639500
+  0: The total amount of wall time                        = 123.193600
+  0: The maximum resident set size (KB)                   = 643780
 
 Test 020 control_latlon PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1059,14 +1059,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 125.585288
-  0: The maximum resident set size (KB)                   = 641008
+  0: The total amount of wall time                        = 126.088640
+  0: The maximum resident set size (KB)                   = 642176
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1105,14 +1105,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 333.444372
-0: The maximum resident set size (KB)                   = 817504
+0: The total amount of wall time                        = 329.819604
+0: The maximum resident set size (KB)                   = 821856
 
 Test 022 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1123,14 +1123,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 481.022062
-  0: The maximum resident set size (KB)                   = 806588
+  0: The total amount of wall time                        = 483.362844
+  0: The maximum resident set size (KB)                   = 801452
 
 Test 023 control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1141,14 +1141,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 658.150424
-  0: The maximum resident set size (KB)                   = 1083860
+  0: The total amount of wall time                        = 653.485736
+  0: The maximum resident set size (KB)                   = 1089120
 
 Test 024 control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 591.190780
-  0: The maximum resident set size (KB)                   = 1243856
+  0: The total amount of wall time                        = 593.875692
+  0: The maximum resident set size (KB)                   = 1245172
 
 Test 025 control_c384gdas PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1209,28 +1209,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 83.186289
-  0: The maximum resident set size (KB)                   = 651324
+  0: The total amount of wall time                        = 84.755453
+  0: The maximum resident set size (KB)                   = 654248
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_stochy_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 43.489519
-  0: The maximum resident set size (KB)                   = 475368
+  0: The total amount of wall time                        = 43.812014
+  0: The maximum resident set size (KB)                   = 489672
 
 Test 027 control_stochy_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1241,14 +1241,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.162779
-  0: The maximum resident set size (KB)                   = 646892
+  0: The total amount of wall time                        = 74.535778
+  0: The maximum resident set size (KB)                   = 644184
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1263,14 +1263,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 124.758449
-  0: The maximum resident set size (KB)                   = 645032
+  0: The total amount of wall time                        = 125.199936
+  0: The maximum resident set size (KB)                   = 644328
 
 Test 029 control_iovr4 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1285,14 +1285,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 124.776649
-  0: The maximum resident set size (KB)                   = 647648
+  0: The total amount of wall time                        = 127.181805
+  0: The maximum resident set size (KB)                   = 640344
 
 Test 030 control_iovr5 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1339,14 +1339,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.061132
-  0: The maximum resident set size (KB)                   = 1040468
+  0: The total amount of wall time                        = 168.398999
+  0: The maximum resident set size (KB)                   = 1040372
 
 Test 031 control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1365,14 +1365,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 317.251437
-  0: The maximum resident set size (KB)                   = 1044872
+  0: The total amount of wall time                        = 322.313512
+  0: The maximum resident set size (KB)                   = 1038292
 
 Test 032 control_p8_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_restart_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1411,14 +1411,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.640354
-  0: The maximum resident set size (KB)                   = 861744
+  0: The total amount of wall time                        = 89.240903
+  0: The maximum resident set size (KB)                   = 863788
 
 Test 033 control_restart_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_decomp_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1461,14 +1461,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.603234
-  0: The maximum resident set size (KB)                   = 1024484
+  0: The total amount of wall time                        = 173.228635
+  0: The maximum resident set size (KB)                   = 1019656
 
 Test 034 control_decomp_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_2threads_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1511,14 +1511,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 201.530725
- 0: The maximum resident set size (KB)                   = 1107596
+ 0: The total amount of wall time                        = 204.119905
+ 0: The maximum resident set size (KB)                   = 1118980
 
 Test 035 control_2threads_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1565,14 +1565,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 194.805350
-  0: The maximum resident set size (KB)                   = 1161296
+  0: The total amount of wall time                        = 196.064623
+  0: The maximum resident set size (KB)                   = 1163052
 
 Test 036 control_p8_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,42 +1583,42 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 330.575246
- 0: The maximum resident set size (KB)                   = 832096
+ 0: The total amount of wall time                        = 331.215310
+ 0: The maximum resident set size (KB)                   = 819440
 
 Test 037 regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 182.214368
- 0: The maximum resident set size (KB)                   = 824800
+ 0: The total amount of wall time                        = 180.726258
+ 0: The maximum resident set size (KB)                   = 827288
 
 Test 038 regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_control_2dwrtdecomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 328.885515
- 0: The maximum resident set size (KB)                   = 828888
+ 0: The total amount of wall time                        = 330.249250
+ 0: The maximum resident set size (KB)                   = 835236
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1626,14 +1626,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 339.172363
- 0: The maximum resident set size (KB)                   = 802716
+ 0: The total amount of wall time                        = 342.890104
+ 0: The maximum resident set size (KB)                   = 809256
 
 Test 040 regional_noquilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1644,28 +1644,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 231.988195
- 0: The maximum resident set size (KB)                   = 826892
+ 0: The total amount of wall time                        = 234.014840
+ 0: The maximum resident set size (KB)                   = 826164
 
 Test 041 regional_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 326.136878
- 0: The maximum resident set size (KB)                   = 810444
+ 0: The total amount of wall time                        = 327.491876
+ 0: The maximum resident set size (KB)                   = 824356
 
 Test 042 regional_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_3km
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 254.244434
-  0: The maximum resident set size (KB)                   = 887880
+  0: The total amount of wall time                        = 255.849161
+  0: The maximum resident set size (KB)                   = 885836
 
 Test 043 regional_3km PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1730,14 +1730,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 431.686915
-  0: The maximum resident set size (KB)                   = 1037064
+  0: The total amount of wall time                        = 433.687199
+  0: The maximum resident set size (KB)                   = 1037900
 
 Test 044 rap_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1784,14 +1784,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 461.679006
-  0: The maximum resident set size (KB)                   = 1184680
+  0: The total amount of wall time                        = 463.557102
+  0: The maximum resident set size (KB)                   = 1186600
 
 Test 045 rap_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1802,14 +1802,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 296.700590
-  0: The maximum resident set size (KB)                   = 1202836
+  0: The total amount of wall time                        = 294.011636
+  0: The maximum resident set size (KB)                   = 1201264
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1856,14 +1856,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 518.182784
- 0: The maximum resident set size (KB)                   = 1094388
+ 0: The total amount of wall time                        = 512.363659
+ 0: The maximum resident set size (KB)                   = 1098256
 
 Test 047 rap_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1902,14 +1902,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 219.704160
-  0: The maximum resident set size (KB)                   = 921552
+  0: The total amount of wall time                        = 220.390341
+  0: The maximum resident set size (KB)                   = 952996
 
 Test 048 rap_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1956,14 +1956,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 434.833842
-  0: The maximum resident set size (KB)                   = 1044448
+  0: The total amount of wall time                        = 434.243891
+  0: The maximum resident set size (KB)                   = 1032384
 
 Test 049 rap_sfcdiff PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_sfcdiff_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2002,14 +2002,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 220.930847
-  0: The maximum resident set size (KB)                   = 953500
+  0: The total amount of wall time                        = 220.662862
+  0: The maximum resident set size (KB)                   = 947824
 
 Test 050 rap_sfcdiff_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2056,14 +2056,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 416.273764
-  0: The maximum resident set size (KB)                   = 1026340
+  0: The total amount of wall time                        = 415.545075
+  0: The maximum resident set size (KB)                   = 1031864
 
 Test 051 hrrr_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2110,14 +2110,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 425.211289
-  0: The maximum resident set size (KB)                   = 1036772
+  0: The total amount of wall time                        = 425.619555
+  0: The maximum resident set size (KB)                   = 1031412
 
 Test 052 rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2132,14 +2132,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 500.509631
-  0: The maximum resident set size (KB)                   = 702332
+  0: The total amount of wall time                        = 503.339263
+  0: The maximum resident set size (KB)                   = 701428
 
 Test 053 rrfs_v1nssl PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2154,14 +2154,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 489.880930
-  0: The maximum resident set size (KB)                   = 731104
+  0: The total amount of wall time                        = 488.623151
+  0: The maximum resident set size (KB)                   = 733664
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2170,14 +2170,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 176.030695
-  0: The maximum resident set size (KB)                   = 921144
+  0: The total amount of wall time                        = 179.146648
+  0: The maximum resident set size (KB)                   = 920928
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2186,14 +2186,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 180.932536
-  0: The maximum resident set size (KB)                   = 926056
+  0: The total amount of wall time                        = 178.651014
+  0: The maximum resident set size (KB)                   = 925124
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2202,14 +2202,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 196.626538
-  0: The maximum resident set size (KB)                   = 951180
+  0: The total amount of wall time                        = 196.977960
+  0: The maximum resident set size (KB)                   = 958484
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2220,14 +2220,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 323.811228
-  0: The maximum resident set size (KB)                   = 756320
+  0: The total amount of wall time                        = 327.265171
+  0: The maximum resident set size (KB)                   = 750628
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2238,14 +2238,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 323.565452
-  0: The maximum resident set size (KB)                   = 756116
+  0: The total amount of wall time                        = 321.692680
+  0: The maximum resident set size (KB)                   = 760120
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2256,14 +2256,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 210.212719
-  0: The maximum resident set size (KB)                   = 755900
+  0: The total amount of wall time                        = 209.309337
+  0: The maximum resident set size (KB)                   = 755152
 
 Test 060 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2274,14 +2274,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 167.263879
-  0: The maximum resident set size (KB)                   = 716108
+  0: The total amount of wall time                        = 168.123169
+  0: The maximum resident set size (KB)                   = 713964
 
 Test 061 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 231.960966
-  0: The maximum resident set size (KB)                   = 1078516
+  0: The total amount of wall time                        = 232.577899
+  0: The maximum resident set size (KB)                   = 1077992
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2310,54 +2310,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 218.138207
-  0: The maximum resident set size (KB)                   = 1060612
+  0: The total amount of wall time                        = 218.526724
+  0: The maximum resident set size (KB)                   = 1056748
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 100.918818
-  0: The maximum resident set size (KB)                   = 616868
+  0: The total amount of wall time                        = 101.168623
+  0: The maximum resident set size (KB)                   = 617036
 
 Test 064 control_wam PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.033739
-  0: The maximum resident set size (KB)                   = 802512
+  0: The total amount of wall time                        = 146.009925
+  0: The maximum resident set size (KB)                   = 804000
 
 Test 065 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_2threads_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 212.321617
- 0: The maximum resident set size (KB)                   = 857908
+ 0: The total amount of wall time                        = 212.384594
+ 0: The maximum resident set size (KB)                   = 859204
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2384,415 +2384,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.455009
-  0: The maximum resident set size (KB)                   = 809140
+  0: The total amount of wall time                        = 160.780816
+  0: The maximum resident set size (KB)                   = 803544
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.265716
-  0: The maximum resident set size (KB)                   = 803124
+  0: The total amount of wall time                        = 146.576339
+  0: The maximum resident set size (KB)                   = 803560
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.008242
-  0: The maximum resident set size (KB)                   = 807752
+  0: The total amount of wall time                        = 167.466311
+  0: The maximum resident set size (KB)                   = 811544
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.782860
-  0: The maximum resident set size (KB)                   = 806632
+  0: The total amount of wall time                        = 146.551645
+  0: The maximum resident set size (KB)                   = 813816
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 229.082773
-  0: The maximum resident set size (KB)                   = 853808
+  0: The total amount of wall time                        = 226.849202
+  0: The maximum resident set size (KB)                   = 854232
 
 Test 071 control_csawmg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 224.871686
-  0: The maximum resident set size (KB)                   = 851040
+  0: The total amount of wall time                        = 224.397417
+  0: The maximum resident set size (KB)                   = 853248
 
 Test 072 control_csawmgt_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.723901
-  0: The maximum resident set size (KB)                   = 816752
+  0: The total amount of wall time                        = 154.304586
+  0: The maximum resident set size (KB)                   = 813824
 
 Test 073 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.697055
-  0: The maximum resident set size (KB)                   = 860440
+  0: The total amount of wall time                        = 159.186776
+  0: The maximum resident set size (KB)                   = 865804
 
 Test 074 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.287537
-  0: The maximum resident set size (KB)                   = 1197600
+  0: The total amount of wall time                        = 162.231326
+  0: The maximum resident set size (KB)                   = 1197608
 
 Test 075 control_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.335228
-  0: The maximum resident set size (KB)                   = 1171064
+  0: The total amount of wall time                        = 170.005663
+  0: The maximum resident set size (KB)                   = 1177200
 
 Test 076 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.164368
-  0: The maximum resident set size (KB)                   = 1166404
+  0: The total amount of wall time                        = 169.341549
+  0: The maximum resident set size (KB)                   = 1164000
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.918259
-  0: The maximum resident set size (KB)                   = 1207988
+  0: The total amount of wall time                        = 183.858107
+  0: The maximum resident set size (KB)                   = 1209316
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.788402
-  0: The maximum resident set size (KB)                   = 1181984
+  0: The total amount of wall time                        = 174.264786
+  0: The maximum resident set size (KB)                   = 1175736
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 233.955408
- 0: The maximum resident set size (KB)                   = 834136
+ 0: The total amount of wall time                        = 237.784399
+ 0: The maximum resident set size (KB)                   = 842292
 
 Test 080 regional_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.310827
-  0: The maximum resident set size (KB)                   = 1179548
+  0: The total amount of wall time                        = 268.200702
+  0: The maximum resident set size (KB)                   = 1179808
 
 Test 081 rap_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_unified_drag_suite_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.048873
-  0: The maximum resident set size (KB)                   = 1182680
+  0: The total amount of wall time                        = 270.105786
+  0: The maximum resident set size (KB)                   = 1184084
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.117019
-  0: The maximum resident set size (KB)                   = 1264944
+  0: The total amount of wall time                        = 281.987309
+  0: The maximum resident set size (KB)                   = 1268032
 
 Test 083 rap_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.847814
-  0: The maximum resident set size (KB)                   = 1185660
+  0: The total amount of wall time                        = 270.449700
+  0: The maximum resident set size (KB)                   = 1178276
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_unified_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.444785
-  0: The maximum resident set size (KB)                   = 1181284
+  0: The total amount of wall time                        = 266.452877
+  0: The maximum resident set size (KB)                   = 1180260
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.798186
-  0: The maximum resident set size (KB)                   = 1182992
+  0: The total amount of wall time                        = 267.794707
+  0: The maximum resident set size (KB)                   = 1184740
 
 Test 086 rap_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.405187
-  0: The maximum resident set size (KB)                   = 1184028
+  0: The total amount of wall time                        = 261.175729
+  0: The maximum resident set size (KB)                   = 1183680
 
 Test 087 rap_flake_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.516836
-  0: The maximum resident set size (KB)                   = 1180016
+  0: The total amount of wall time                        = 267.757462
+  0: The maximum resident set size (KB)                   = 1183320
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.149980
-  0: The maximum resident set size (KB)                   = 1191192
+  0: The total amount of wall time                        = 266.754690
+  0: The maximum resident set size (KB)                   = 1183664
 
 Test 089 rap_noah_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 444.385203
-  0: The maximum resident set size (KB)                   = 1316004
+  0: The total amount of wall time                        = 444.646133
+  0: The maximum resident set size (KB)                   = 1315764
 
 Test 090 rap_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.943596
-  0: The maximum resident set size (KB)                   = 1183360
+  0: The total amount of wall time                        = 270.674403
+  0: The maximum resident set size (KB)                   = 1188544
 
 Test 091 rap_sfcdiff_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 437.979959
-  0: The maximum resident set size (KB)                   = 1185368
+  0: The total amount of wall time                        = 433.968321
+  0: The maximum resident set size (KB)                   = 1184584
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 257.468774
-  0: The maximum resident set size (KB)                   = 1175812
+  0: The total amount of wall time                        = 259.037018
+  0: The maximum resident set size (KB)                   = 1187296
 
 Test 093 rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 279.424950
-  0: The maximum resident set size (KB)                   = 504160
+  0: The total amount of wall time                        = 273.967169
+  0: The maximum resident set size (KB)                   = 516400
 
 Test 094 control_wam_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 288.741420
-  0: The maximum resident set size (KB)                   = 979580
+  0: The total amount of wall time                        = 288.126615
+  0: The maximum resident set size (KB)                   = 977452
 
 Test 095 hafs_regional_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 346.917126
-  0: The maximum resident set size (KB)                   = 1352724
+  0: The total amount of wall time                        = 352.747908
+  0: The maximum resident set size (KB)                   = 1348080
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2801,28 +2801,28 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 364.898341
-  0: The maximum resident set size (KB)                   = 1199052
+  0: The total amount of wall time                        = 367.035175
+  0: The maximum resident set size (KB)                   = 1202276
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 718.547658
-  0: The maximum resident set size (KB)                   = 1195036
+  0: The total amount of wall time                        = 722.506089
+  0: The maximum resident set size (KB)                   = 1196660
 
 Test 098 hafs_regional_atm_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2831,28 +2831,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 811.471752
-  0: The maximum resident set size (KB)                   = 1171012
+  0: The total amount of wall time                        = 817.157442
+  0: The maximum resident set size (KB)                   = 1173900
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 446.689539
-  0: The maximum resident set size (KB)                   = 532740
+  0: The total amount of wall time                        = 446.232843
+  0: The maximum resident set size (KB)                   = 538988
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2861,28 +2861,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 469.936606
-  0: The maximum resident set size (KB)                   = 594608
+  0: The total amount of wall time                        = 465.435267
+  0: The maximum resident set size (KB)                   = 586820
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 205.878339
-  0: The maximum resident set size (KB)                   = 381456
+  0: The total amount of wall time                        = 205.828648
+  0: The maximum resident set size (KB)                   = 385008
 
 Test 102 hafs_global_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2893,30 +2893,30 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing sfc.nest04.f006.nc .........OK
  Comparing sfc.nest04.f006.nc .........OK
  Comparing atm.nest05.f006.nc .........OK
- Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 555.449937
-  0: The maximum resident set size (KB)                   = 386672
+  0: The total amount of wall time                        = 557.669820
+  0: The maximum resident set size (KB)                   = 391628
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
- Comparing sfc.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 264.592470
-  0: The maximum resident set size (KB)                   = 541860
+  0: The total amount of wall time                        = 267.041542
+  0: The maximum resident set size (KB)                   = 546272
 
-Test 104 hafs_regional_specified_moving_1nest_atm PASS
+Test 104 hafs_regional_specified_moving_1nest_atm PASS Tries: 2
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 105 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2925,14 +2925,14 @@ Checking test 105 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 263.349300
-  0: The maximum resident set size (KB)                   = 625308
+  0: The total amount of wall time                        = 264.013498
+  0: The maximum resident set size (KB)                   = 629504
 
 Test 105 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2943,28 +2943,28 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 604.641227
-  0: The maximum resident set size (KB)                   = 524036
+  0: The total amount of wall time                        = 594.653871
+  0: The maximum resident set size (KB)                   = 520516
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_global_storm_following_1nest_atm
 Checking test 107 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 76.488518
-  0: The maximum resident set size (KB)                   = 398400
+  0: The total amount of wall time                        = 77.930795
+  0: The maximum resident set size (KB)                   = 396920
 
 Test 107 hafs_global_storm_following_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_docn
 Checking test 108 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2972,14 +2972,14 @@ Checking test 108 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 352.894252
-  0: The maximum resident set size (KB)                   = 1210032
+  0: The total amount of wall time                        = 361.664031
+  0: The maximum resident set size (KB)                   = 1210012
 
 Test 108 hafs_regional_docn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_docn_oisst
 Checking test 109 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2987,118 +2987,118 @@ Checking test 109 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 355.942249
-  0: The maximum resident set size (KB)                   = 1201756
+  0: The total amount of wall time                        = 363.638602
+  0: The maximum resident set size (KB)                   = 1199568
 
 Test 109 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/hafs_regional_datm_cdeps
 Checking test 110 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 943.772613
-  0: The maximum resident set size (KB)                   = 1012720
+  0: The total amount of wall time                        = 940.521530
+  0: The maximum resident set size (KB)                   = 1019812
 
 Test 110 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_control_cfsr
 Checking test 111 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.941847
- 0: The maximum resident set size (KB)                   = 1016436
+ 0: The total amount of wall time                        = 150.857017
+ 0: The maximum resident set size (KB)                   = 1011100
 
 Test 111 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_restart_cfsr
 Checking test 112 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 86.792656
- 0: The maximum resident set size (KB)                   = 1012996
+ 0: The total amount of wall time                        = 90.124003
+ 0: The maximum resident set size (KB)                   = 980844
 
 Test 112 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_control_gefs
 Checking test 113 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.829462
- 0: The maximum resident set size (KB)                   = 935752
+ 0: The total amount of wall time                        = 145.792303
+ 0: The maximum resident set size (KB)                   = 935604
 
 Test 113 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_iau_gefs
 Checking test 114 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.902612
- 0: The maximum resident set size (KB)                   = 937100
+ 0: The total amount of wall time                        = 148.277718
+ 0: The maximum resident set size (KB)                   = 938860
 
 Test 114 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_stochy_gefs
 Checking test 115 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.517128
- 0: The maximum resident set size (KB)                   = 928052
+ 0: The total amount of wall time                        = 150.796595
+ 0: The maximum resident set size (KB)                   = 935436
 
 Test 115 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_bulk_cfsr
 Checking test 116 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.073845
- 0: The maximum resident set size (KB)                   = 1026672
+ 0: The total amount of wall time                        = 147.248905
+ 0: The maximum resident set size (KB)                   = 1027532
 
 Test 116 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_bulk_gefs
 Checking test 117 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.030787
- 0: The maximum resident set size (KB)                   = 926632
+ 0: The total amount of wall time                        = 141.815664
+ 0: The maximum resident set size (KB)                   = 940616
 
 Test 117 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_mx025_cfsr
 Checking test 118 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3107,14 +3107,14 @@ Checking test 118 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 304.091985
-  0: The maximum resident set size (KB)                   = 841088
+  0: The total amount of wall time                        = 309.952923
+  0: The maximum resident set size (KB)                   = 847208
 
 Test 118 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_mx025_gefs
 Checking test 119 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3123,64 +3123,64 @@ Checking test 119 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 308.340291
-  0: The maximum resident set size (KB)                   = 858184
+  0: The total amount of wall time                        = 308.780508
+  0: The maximum resident set size (KB)                   = 862048
 
 Test 119 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_multiple_files_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_multiple_files_cfsr
 Checking test 120 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.577296
- 0: The maximum resident set size (KB)                   = 1013332
+ 0: The total amount of wall time                        = 151.740001
+ 0: The maximum resident set size (KB)                   = 1035808
 
 Test 120 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_3072x1536_cfsr
 Checking test 121 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.823877
- 0: The maximum resident set size (KB)                   = 2192360
+ 0: The total amount of wall time                        = 200.042346
+ 0: The maximum resident set size (KB)                   = 2186584
 
 Test 121 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_gfs
 Checking test 122 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 202.472377
- 0: The maximum resident set size (KB)                   = 2245292
+ 0: The total amount of wall time                        = 204.673665
+ 0: The maximum resident set size (KB)                   = 2248832
 
 Test 122 datm_cdeps_gfs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/datm_cdeps_debug_cfsr
 Checking test 123 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 433.832572
- 0: The maximum resident set size (KB)                   = 975872
+ 0: The total amount of wall time                        = 442.680059
+ 0: The maximum resident set size (KB)                   = 971048
 
 Test 123 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_atmwav
 Checking test 124 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3224,15 +3224,78 @@ Checking test 124 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 79.667263
-  0: The maximum resident set size (KB)                   = 672312
+  0: The total amount of wall time                        = 80.465092
+  0: The maximum resident set size (KB)                   = 673872
 
 Test 124 control_atmwav PASS
 
+Test 125 control_c384gdas_wav FAIL
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_28134/control_atm_aerosols
+Checking test 126 control_atm_aerosols results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 342.615455
+  0: The maximum resident set size (KB)                   = 4798096
+
+Test 126 control_atm_aerosols PASS
+
+FAILED TESTS: 
+Test control_c384gdas_wav 125 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Wed May 25 04:46:56 UTC 2022
+Elapsed time: 03h:29m:31s. Have a nice day!
+Wed May 25 12:02:33 UTC 2022
+Start Regression test
+
+Compile 001 elapsed time 539 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_c384gdas_wav
-Checking test 125 control_c384gdas_wav results ....
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_133883/control_c384gdas_wav
+Checking test 001 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3277,63 +3340,12 @@ Checking test 125 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 720.619931
-  0: The maximum resident set size (KB)                   = 1283040
+  0: The total amount of wall time                        = 715.978012
+  0: The maximum resident set size (KB)                   = 1322064
 
-Test 125 control_c384gdas_wav PASS Tries: 2
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13965/control_atm_aerosols
-Checking test 126 control_atm_aerosols results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 344.815743
-  0: The maximum resident set size (KB)                   = 4796920
-
-Test 126 control_atm_aerosols PASS
+Test 001 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 15:24:43 UTC 2022
-Elapsed time: 01h:21m:24s. Have a nice day!
+Wed May 25 12:43:55 UTC 2022
+Elapsed time: 00h:41m:23s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,25 +1,25 @@
-Fri May 20 05:24:27 GMT 2022
+Wed May 25 11:48:29 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1743 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 260 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 004 elapsed time 1441 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 1426 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 1228 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 007 elapsed time 257 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 248 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 246 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 230 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 1605 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 1626 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 013 elapsed time 281 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 014 elapsed time 146 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 1544 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 016 elapsed time 1319 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 1906 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 492 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1593 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 1456 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 1456 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 1940 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 007 elapsed time 320 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 280 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 871 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 589 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 2118 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 2281 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 548 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 014 elapsed time 486 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 1678 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 016 elapsed time 1392 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 537.355623
-  0: The maximum resident set size (KB)                   = 1996516
+  0: The total amount of wall time                        = 901.860149
+  0: The maximum resident set size (KB)                   = 2002388
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/cpld_2threads_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -146,14 +146,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 1016.225149
-  0: The maximum resident set size (KB)                   = 2588088
+  0: The total amount of wall time                        = 1531.083817
+  0: The maximum resident set size (KB)                   = 2599016
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/cpld_mpi_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/cpld_mpi_p8
 Checking test 003 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -207,14 +207,14 @@ Checking test 003 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 432.040366
-  0: The maximum resident set size (KB)                   = 1864804
+  0: The total amount of wall time                        = 822.217200
+  0: The maximum resident set size (KB)                   = 1863944
 
 Test 003 cpld_mpi_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/cpld_control_c96_p8
 Checking test 004 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -277,14 +277,14 @@ Checking test 004 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 424.862438
-  0: The maximum resident set size (KB)                   = 1859068
+  0: The total amount of wall time                        = 582.847000
+  0: The maximum resident set size (KB)                   = 1851780
 
 Test 004 cpld_control_c96_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/cpld_restart_c96_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/cpld_restart_c96_p8
 Checking test 005 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -335,14 +335,14 @@ Checking test 005 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 275.378051
-  0: The maximum resident set size (KB)                   = 1815464
+  0: The total amount of wall time                        = 536.419357
+  0: The maximum resident set size (KB)                   = 1808696
 
 Test 005 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/cpld_debug_p8
 Checking test 006 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 006 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1185.926689
-  0: The maximum resident set size (KB)                   = 1892040
+  0: The total amount of wall time                        = 1522.155371
+  0: The maximum resident set size (KB)                   = 1925856
 
-Test 006 cpld_debug_p8 PASS
+Test 006 cpld_debug_p8 PASS Tries: 2
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control
 Checking test 007 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -447,14 +447,14 @@ Checking test 007 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.125578
-  0: The maximum resident set size (KB)                   = 581660
+  0: The total amount of wall time                        = 692.383546
+  0: The maximum resident set size (KB)                   = 581416
 
 Test 007 control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_decomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_decomp
 Checking test 008 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -497,28 +497,28 @@ Checking test 008 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.242572
-  0: The maximum resident set size (KB)                   = 577992
+  0: The total amount of wall time                        = 775.237923
+  0: The maximum resident set size (KB)                   = 574468
 
 Test 008 control_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_2dwrtdecomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_2dwrtdecomp
 Checking test 009 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 163.101127
-  0: The maximum resident set size (KB)                   = 580384
+  0: The total amount of wall time                        = 699.859221
+  0: The maximum resident set size (KB)                   = 580768
 
 Test 009 control_2dwrtdecomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_2threads
 Checking test 010 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -561,14 +561,14 @@ Checking test 010 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 400.237455
- 0: The maximum resident set size (KB)                   = 647212
+ 0: The total amount of wall time                        = 1179.265865
+ 0: The maximum resident set size (KB)                   = 646444
 
 Test 010 control_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_restart
 Checking test 011 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -607,14 +607,14 @@ Checking test 011 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.287857
-  0: The maximum resident set size (KB)                   = 371484
+  0: The total amount of wall time                        = 278.840605
+  0: The maximum resident set size (KB)                   = 368612
 
 Test 011 control_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_fhzero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_fhzero
 Checking test 012 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -657,14 +657,14 @@ Checking test 012 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.317398
-  0: The maximum resident set size (KB)                   = 579444
+  0: The total amount of wall time                        = 692.368177
+  0: The maximum resident set size (KB)                   = 583680
 
 Test 012 control_fhzero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_CubedSphereGrid
 Checking test 013 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -691,14 +691,14 @@ Checking test 013 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 162.706803
-  0: The maximum resident set size (KB)                   = 581228
+  0: The total amount of wall time                        = 750.954237
+  0: The maximum resident set size (KB)                   = 582092
 
 Test 013 control_CubedSphereGrid PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_latlon
 Checking test 014 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -709,14 +709,14 @@ Checking test 014 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.800790
-  0: The maximum resident set size (KB)                   = 584088
+  0: The total amount of wall time                        = 703.486335
+  0: The maximum resident set size (KB)                   = 579528
 
 Test 014 control_latlon PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_wrtGauss_netcdf_parallel
 Checking test 015 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -727,14 +727,14 @@ Checking test 015 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 170.068649
-  0: The maximum resident set size (KB)                   = 581316
+  0: The total amount of wall time                        = 706.736908
+  0: The maximum resident set size (KB)                   = 582380
 
 Test 015 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_c48
 Checking test 016 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -773,14 +773,14 @@ Checking test 016 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 566.267067
-0: The maximum resident set size (KB)                   = 788056
+0: The total amount of wall time                        = 1321.978028
+0: The maximum resident set size (KB)                   = 786456
 
 Test 016 control_c48 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_c192
 Checking test 017 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -791,82 +791,18 @@ Checking test 017 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 668.920787
-  0: The maximum resident set size (KB)                   = 731852
+  0: The total amount of wall time                        = 1643.955815
+  0: The maximum resident set size (KB)                   = 731532
 
 Test 017 control_c192 PASS
 
+Test 018 control_c384 FAIL
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_c384
-Checking test 018 control_c384 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 906.879435
-  0: The maximum resident set size (KB)                   = 1065772
-
-Test 018 control_c384 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_c384gdas
-Checking test 019 control_c384gdas results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF06 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF06 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 799.092223
-  0: The maximum resident set size (KB)                   = 1153416
-
-Test 019 control_c384gdas PASS
+Test 019 control_c384gdas FAIL
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_stochy
 Checking test 020 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -877,28 +813,28 @@ Checking test 020 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 112.500202
-  0: The maximum resident set size (KB)                   = 583580
+  0: The total amount of wall time                        = 294.399319
+  0: The maximum resident set size (KB)                   = 589704
 
 Test 020 control_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_stochy_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_stochy_restart
 Checking test 021 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 61.136344
-  0: The maximum resident set size (KB)                   = 388588
+  0: The total amount of wall time                        = 64.311001
+  0: The maximum resident set size (KB)                   = 394280
 
 Test 021 control_stochy_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_lndp
 Checking test 022 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -909,14 +845,14 @@ Checking test 022 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 99.671227
-  0: The maximum resident set size (KB)                   = 584708
+  0: The total amount of wall time                        = 277.373535
+  0: The maximum resident set size (KB)                   = 584112
 
 Test 022 control_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_iovr4
 Checking test 023 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -931,14 +867,14 @@ Checking test 023 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 172.108745
-  0: The maximum resident set size (KB)                   = 583080
+  0: The total amount of wall time                        = 356.558820
+  0: The maximum resident set size (KB)                   = 581508
 
 Test 023 control_iovr4 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_iovr5
 Checking test 024 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -953,14 +889,14 @@ Checking test 024 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 173.139560
-  0: The maximum resident set size (KB)                   = 581592
+  0: The total amount of wall time                        = 360.475692
+  0: The maximum resident set size (KB)                   = 582100
 
 Test 024 control_iovr5 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_p8
 Checking test 025 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1007,14 +943,14 @@ Checking test 025 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 225.662702
-  0: The maximum resident set size (KB)                   = 979172
+  0: The total amount of wall time                        = 409.782607
+  0: The maximum resident set size (KB)                   = 972972
 
 Test 025 control_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_p8_lndp
 Checking test 026 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1033,14 +969,14 @@ Checking test 026 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 426.570634
-  0: The maximum resident set size (KB)                   = 975856
+  0: The total amount of wall time                        = 619.379161
+  0: The maximum resident set size (KB)                   = 980632
 
 Test 026 control_p8_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_restart_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_restart_p8
 Checking test 027 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1079,14 +1015,14 @@ Checking test 027 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.780519
-  0: The maximum resident set size (KB)                   = 757988
+  0: The total amount of wall time                        = 125.429295
+  0: The maximum resident set size (KB)                   = 763592
 
 Test 027 control_restart_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_decomp_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_decomp_p8
 Checking test 028 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1129,14 +1065,14 @@ Checking test 028 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.701886
-  0: The maximum resident set size (KB)                   = 964196
+  0: The total amount of wall time                        = 419.955496
+  0: The maximum resident set size (KB)                   = 962716
 
 Test 028 control_decomp_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_2threads_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_2threads_p8
 Checking test 029 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1179,14 +1115,14 @@ Checking test 029 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 532.121721
- 0: The maximum resident set size (KB)                   = 1053724
+ 0: The total amount of wall time                        = 726.936143
+ 0: The maximum resident set size (KB)                   = 1048112
 
 Test 029 control_2threads_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_p8_rrtmgp
 Checking test 030 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1233,14 +1169,14 @@ Checking test 030 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 260.048336
-  0: The maximum resident set size (KB)                   = 1096992
+  0: The total amount of wall time                        = 271.897047
+  0: The maximum resident set size (KB)                   = 1100124
 
 Test 030 control_p8_rrtmgp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_control
 Checking test 031 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1251,42 +1187,42 @@ Checking test 031 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 446.064604
- 0: The maximum resident set size (KB)                   = 754528
+ 0: The total amount of wall time                        = 457.351604
+ 0: The maximum resident set size (KB)                   = 741552
 
 Test 031 regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_restart
 Checking test 032 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 262.050244
- 0: The maximum resident set size (KB)                   = 730000
+ 0: The total amount of wall time                        = 487.391443
+ 0: The maximum resident set size (KB)                   = 728204
 
 Test 032 regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_control_2dwrtdecomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_control_2dwrtdecomp
 Checking test 033 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 451.402794
- 0: The maximum resident set size (KB)                   = 741912
+ 0: The total amount of wall time                        = 448.223560
+ 0: The maximum resident set size (KB)                   = 741972
 
 Test 033 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_noquilt
 Checking test 034 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1294,28 +1230,28 @@ Checking test 034 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 477.410094
- 0: The maximum resident set size (KB)                   = 716124
+ 0: The total amount of wall time                        = 485.691920
+ 0: The maximum resident set size (KB)                   = 712628
 
 Test 034 regional_noquilt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_netcdf_parallel
 Checking test 035 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 442.312305
- 0: The maximum resident set size (KB)                   = 734368
+ 0: The total amount of wall time                        = 446.814910
+ 0: The maximum resident set size (KB)                   = 736516
 
 Test 035 regional_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_3km
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_3km
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_3km
 Checking test 036 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1326,16 +1262,68 @@ Checking test 036 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 345.736346
-  0: The maximum resident set size (KB)                   = 776716
+  0: The total amount of wall time                        = 348.769577
+  0: The maximum resident set size (KB)                   = 777980
 
 Test 036 regional_3km PASS
 
-Test 037 rap_control FAIL
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_control
+Checking test 037 rap_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 1522.055443
+  0: The maximum resident set size (KB)                   = 967728
+
+Test 037 rap_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_rrtmgp
 Checking test 038 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1382,9 +1370,14 @@ Checking test 038 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
+  0: The total amount of wall time                        = 1626.109410
+  0: The maximum resident set size (KB)                   = 1097736
+
+Test 038 rap_rrtmgp PASS
+
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_spp_sppt_shum_skeb
 Checking test 039 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1395,14 +1388,60 @@ Checking test 039 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 832.563564
-  0: The maximum resident set size (KB)                   = 1097220
+  0: The total amount of wall time                        = 1203.866866
+  0: The maximum resident set size (KB)                   = 1097416
 
-Test 039 regional_spp_sppt_shum_skeb PASS
+Test 039 regional_spp_sppt_shum_skeb PASS Tries: 2
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_restart
+Checking test 040 rap_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 295.327221
+  0: The maximum resident set size (KB)                   = 817136
+
+Test 040 rap_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_sfcdiff
 Checking test 041 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1449,14 +1488,14 @@ Checking test 041 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 571.418660
-  0: The maximum resident set size (KB)                   = 970204
+  0: The total amount of wall time                        = 1607.278605
+  0: The maximum resident set size (KB)                   = 968296
 
 Test 041 rap_sfcdiff PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_sfcdiff_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_sfcdiff_restart
 Checking test 042 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1495,14 +1534,14 @@ Checking test 042 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 301.448669
-  0: The maximum resident set size (KB)                   = 821604
+  0: The total amount of wall time                        = 296.089385
+  0: The maximum resident set size (KB)                   = 817068
 
 Test 042 rap_sfcdiff_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/hrrr_control
 Checking test 043 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1549,14 +1588,14 @@ Checking test 043 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 543.412085
-  0: The maximum resident set size (KB)                   = 960880
+  0: The total amount of wall time                        = 1588.702943
+  0: The maximum resident set size (KB)                   = 962808
 
 Test 043 hrrr_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_v1beta
 Checking test 044 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1603,14 +1642,14 @@ Checking test 044 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 563.753669
-  0: The maximum resident set size (KB)                   = 963396
+  0: The total amount of wall time                        = 1598.932464
+  0: The maximum resident set size (KB)                   = 964596
 
 Test 044 rrfs_v1beta PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_v1nssl
 Checking test 045 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1625,14 +1664,14 @@ Checking test 045 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 664.571992
-  0: The maximum resident set size (KB)                   = 645512
+  0: The total amount of wall time                        = 1678.199753
+  0: The maximum resident set size (KB)                   = 642052
 
 Test 045 rrfs_v1nssl PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_v1nssl_nohailnoccn
 Checking test 046 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1647,14 +1686,14 @@ Checking test 046 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 661.022437
-  0: The maximum resident set size (KB)                   = 643412
+  0: The total amount of wall time                        = 1679.640496
+  0: The maximum resident set size (KB)                   = 644280
 
 Test 046 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_conus13km_hrrr_warm
 Checking test 047 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1663,14 +1702,14 @@ Checking test 047 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 236.350984
-  0: The maximum resident set size (KB)                   = 845452
+  0: The total amount of wall time                        = 767.103354
+  0: The maximum resident set size (KB)                   = 849848
 
 Test 047 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_conus13km_radar_tten_warm
 Checking test 048 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1679,14 +1718,14 @@ Checking test 048 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 240.699150
-  0: The maximum resident set size (KB)                   = 841944
+  0: The total amount of wall time                        = 781.126327
+  0: The maximum resident set size (KB)                   = 852988
 
 Test 048 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_smoke_conus13km_hrrr_warm
 Checking test 049 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1695,14 +1734,14 @@ Checking test 049 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 266.167083
-  0: The maximum resident set size (KB)                   = 880072
+  0: The total amount of wall time                        = 921.884947
+  0: The maximum resident set size (KB)                   = 880468
 
 Test 049 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_csawmg
 Checking test 050 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1713,14 +1752,14 @@ Checking test 050 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 436.219636
-  0: The maximum resident set size (KB)                   = 689456
+  0: The total amount of wall time                        = 1277.014894
+  0: The maximum resident set size (KB)                   = 687340
 
 Test 050 control_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_csawmgt
 Checking test 051 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1731,14 +1770,14 @@ Checking test 051 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 430.430326
-  0: The maximum resident set size (KB)                   = 691932
+  0: The total amount of wall time                        = 1319.817193
+  0: The maximum resident set size (KB)                   = 688148
 
 Test 051 control_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_flake
 Checking test 052 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1749,14 +1788,14 @@ Checking test 052 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 274.639748
-  0: The maximum resident set size (KB)                   = 691012
+  0: The total amount of wall time                        = 936.575902
+  0: The maximum resident set size (KB)                   = 692864
 
 Test 052 control_flake PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_ras
 Checking test 053 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1767,14 +1806,14 @@ Checking test 053 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 229.312611
-  0: The maximum resident set size (KB)                   = 651808
+  0: The total amount of wall time                        = 819.902229
+  0: The maximum resident set size (KB)                   = 658172
 
 Test 053 control_ras PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_thompson
 Checking test 054 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1785,14 +1824,14 @@ Checking test 054 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 320.703353
-  0: The maximum resident set size (KB)                   = 1010240
+  0: The total amount of wall time                        = 992.253054
+  0: The maximum resident set size (KB)                   = 996852
 
 Test 054 control_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_thompson_no_aero
 Checking test 055 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1803,54 +1842,54 @@ Checking test 055 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 295.774150
-  0: The maximum resident set size (KB)                   = 989904
+  0: The total amount of wall time                        = 874.913066
+  0: The maximum resident set size (KB)                   = 992868
 
 Test 055 control_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_wam
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_wam
 Checking test 056 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 135.789159
-  0: The maximum resident set size (KB)                   = 457820
+  0: The total amount of wall time                        = 138.319354
+  0: The maximum resident set size (KB)                   = 462412
 
 Test 056 control_wam PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_debug
 Checking test 057 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.638774
-  0: The maximum resident set size (KB)                   = 746820
+  0: The total amount of wall time                        = 195.505083
+  0: The maximum resident set size (KB)                   = 742096
 
 Test 057 control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_2threads_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_2threads_debug
 Checking test 058 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 336.869087
- 0: The maximum resident set size (KB)                   = 804044
+ 0: The total amount of wall time                        = 338.838868
+ 0: The maximum resident set size (KB)                   = 807684
 
 Test 058 control_2threads_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_CubedSphereGrid_debug
 Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1877,415 +1916,405 @@ Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.831934
-  0: The maximum resident set size (KB)                   = 741260
+  0: The total amount of wall time                        = 208.115026
+  0: The maximum resident set size (KB)                   = 747196
 
 Test 059 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_wrtGauss_netcdf_parallel_debug
 Checking test 060 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 199.306883
-  0: The maximum resident set size (KB)                   = 742112
+  0: The total amount of wall time                        = 197.675913
+  0: The maximum resident set size (KB)                   = 740988
 
 Test 060 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_stochy_debug
 Checking test 061 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.082220
-  0: The maximum resident set size (KB)                   = 748704
+  0: The total amount of wall time                        = 218.327249
+  0: The maximum resident set size (KB)                   = 749260
 
 Test 061 control_stochy_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_lndp_debug
 Checking test 062 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.413743
-  0: The maximum resident set size (KB)                   = 750504
+  0: The total amount of wall time                        = 198.005097
+  0: The maximum resident set size (KB)                   = 747900
 
 Test 062 control_lndp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_csawmg_debug
 Checking test 063 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 302.722077
-  0: The maximum resident set size (KB)                   = 796000
+  0: The total amount of wall time                        = 305.092131
+  0: The maximum resident set size (KB)                   = 797356
 
 Test 063 control_csawmg_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_csawmgt_debug
 Checking test 064 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 305.881827
-  0: The maximum resident set size (KB)                   = 793940
+  0: The total amount of wall time                        = 300.791222
+  0: The maximum resident set size (KB)                   = 794008
 
 Test 064 control_csawmgt_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_ras_debug
 Checking test 065 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.087854
-  0: The maximum resident set size (KB)                   = 755896
+  0: The total amount of wall time                        = 206.023745
+  0: The maximum resident set size (KB)                   = 757648
 
 Test 065 control_ras_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_diag_debug
 Checking test 066 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 202.966937
-  0: The maximum resident set size (KB)                   = 803456
+  0: The total amount of wall time                        = 206.089522
+  0: The maximum resident set size (KB)                   = 805764
 
 Test 066 control_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_debug_p8
 Checking test 067 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.864744
-  0: The maximum resident set size (KB)                   = 1129496
+  0: The total amount of wall time                        = 375.829291
+  0: The maximum resident set size (KB)                   = 1133828
 
 Test 067 control_debug_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_thompson_debug
 Checking test 068 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.617118
-  0: The maximum resident set size (KB)                   = 1113132
+  0: The total amount of wall time                        = 224.886856
+  0: The maximum resident set size (KB)                   = 1116652
 
 Test 068 control_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_thompson_no_aero_debug
 Checking test 069 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.761431
-  0: The maximum resident set size (KB)                   = 1100988
+  0: The total amount of wall time                        = 224.807554
+  0: The maximum resident set size (KB)                   = 1106468
 
 Test 069 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_thompson_extdiag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_thompson_extdiag_debug
 Checking test 070 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 236.515136
-  0: The maximum resident set size (KB)                   = 1142092
+  0: The total amount of wall time                        = 414.861354
+  0: The maximum resident set size (KB)                   = 1144924
 
 Test 070 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_thompson_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_thompson_progcld_thompson_debug
 Checking test 071 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 225.216296
-  0: The maximum resident set size (KB)                   = 1113396
+  0: The total amount of wall time                        = 231.006498
+  0: The maximum resident set size (KB)                   = 1117408
 
 Test 071 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/regional_debug
 Checking test 072 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 323.718888
- 0: The maximum resident set size (KB)                   = 752840
+ 0: The total amount of wall time                        = 536.761317
+ 0: The maximum resident set size (KB)                   = 755612
 
 Test 072 regional_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_control_debug
 Checking test 073 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.030516
-  0: The maximum resident set size (KB)                   = 1123292
+  0: The total amount of wall time                        = 481.836349
+  0: The maximum resident set size (KB)                   = 1126328
 
 Test 073 rap_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_unified_drag_suite_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_unified_drag_suite_debug
 Checking test 074 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.849768
-  0: The maximum resident set size (KB)                   = 1119840
+  0: The total amount of wall time                        = 525.595919
+  0: The maximum resident set size (KB)                   = 1129228
 
 Test 074 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_diag_debug
 Checking test 075 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 367.666038
-  0: The maximum resident set size (KB)                   = 1200632
+  0: The total amount of wall time                        = 558.182256
+  0: The maximum resident set size (KB)                   = 1200552
 
 Test 075 rap_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_cires_ugwp_debug
 Checking test 076 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 355.772953
-  0: The maximum resident set size (KB)                   = 1121632
+  0: The total amount of wall time                        = 527.716769
+  0: The maximum resident set size (KB)                   = 1121624
 
 Test 076 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_unified_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_unified_ugwp_debug
 Checking test 077 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.982481
-  0: The maximum resident set size (KB)                   = 1121048
+  0: The total amount of wall time                        = 571.503805
+  0: The maximum resident set size (KB)                   = 1125596
 
 Test 077 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_lndp_debug
 Checking test 078 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 352.383990
-  0: The maximum resident set size (KB)                   = 1124164
+  0: The total amount of wall time                        = 565.756711
+  0: The maximum resident set size (KB)                   = 1129748
 
 Test 078 rap_lndp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_flake_debug
 Checking test 079 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.074178
-  0: The maximum resident set size (KB)                   = 1123528
+  0: The total amount of wall time                        = 559.612465
+  0: The maximum resident set size (KB)                   = 1124372
 
 Test 079 rap_flake_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_progcld_thompson_debug
 Checking test 080 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.872302
-  0: The maximum resident set size (KB)                   = 1128660
+  0: The total amount of wall time                        = 550.256160
+  0: The maximum resident set size (KB)                   = 1126080
 
 Test 080 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_noah_debug
 Checking test 081 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.849326
-  0: The maximum resident set size (KB)                   = 1118752
+  0: The total amount of wall time                        = 540.373236
+  0: The maximum resident set size (KB)                   = 1125820
 
 Test 081 rap_noah_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_rrtmgp_debug
 Checking test 082 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 598.942537
-  0: The maximum resident set size (KB)                   = 1244216
+  0: The total amount of wall time                        = 930.269078
+  0: The maximum resident set size (KB)                   = 1250312
 
 Test 082 rap_rrtmgp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_sfcdiff_debug
 Checking test 083 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 354.851825
-  0: The maximum resident set size (KB)                   = 1128928
+  0: The total amount of wall time                        = 574.840396
+  0: The maximum resident set size (KB)                   = 1124108
 
 Test 083 rap_sfcdiff_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 084 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 573.608245
-  0: The maximum resident set size (KB)                   = 1117020
+  0: The total amount of wall time                        = 899.600404
+  0: The maximum resident set size (KB)                   = 1121804
 
 Test 084 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/rrfs_v1beta_debug
 Checking test 085 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.451983
-  0: The maximum resident set size (KB)                   = 1123280
+  0: The total amount of wall time                        = 504.698798
+  0: The maximum resident set size (KB)                   = 1122492
 
 Test 085 rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_wam_debug
 Checking test 086 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 362.830902
-  0: The maximum resident set size (KB)                   = 427480
+  0: The total amount of wall time                        = 462.806543
+  0: The maximum resident set size (KB)                   = 426536
 
 Test 086 control_wam_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/hafs_regional_atm
 Checking test 087 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 663.041811
-  0: The maximum resident set size (KB)                   = 1150376
+  0: The total amount of wall time                        = 1588.877587
+  0: The maximum resident set size (KB)                   = 1173960
 
 Test 087 hafs_regional_atm PASS
 
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_atm_thompson_gfdlsf
-Checking test 088 hafs_regional_atm_thompson_gfdlsf results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
-
-  0: The total amount of wall time                        = 787.173668
-  0: The maximum resident set size (KB)                   = 1535720
-
-Test 088 hafs_regional_atm_thompson_gfdlsf PASS
+Test 088 hafs_regional_atm_thompson_gfdlsf FAIL
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/hafs_regional_atm_ocn
 Checking test 089 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2294,44 +2323,30 @@ Checking test 089 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 476.973437
-  0: The maximum resident set size (KB)                   = 1273960
+  0: The total amount of wall time                        = 643.193784
+  0: The maximum resident set size (KB)                   = 1279424
 
 Test 089 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/hafs_regional_atm_wav
 Checking test 090 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 856.912070
-  0: The maximum resident set size (KB)                   = 1274032
+  0: The total amount of wall time                        = 1449.475223
+  0: The maximum resident set size (KB)                   = 1265892
 
-Test 090 hafs_regional_atm_wav PASS
+Test 090 hafs_regional_atm_wav PASS Tries: 2
 
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_atm_ocn_wav
-Checking test 091 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing archv.2019_241_06.a .........OK
- Comparing archs.2019_241_06.a .........OK
- Comparing out_grd.ww3 .........OK
- Comparing out_pnt.ww3 .........OK
-
-  0: The total amount of wall time                        = 975.069035
-  0: The maximum resident set size (KB)                   = 1284264
-
-Test 091 hafs_regional_atm_ocn_wav PASS
+Test 091 hafs_regional_atm_ocn_wav FAIL
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/hafs_regional_docn
 Checking test 092 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2339,14 +2354,14 @@ Checking test 092 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 478.402969
-  0: The maximum resident set size (KB)                   = 1278416
+  0: The total amount of wall time                        = 1350.387962
+  0: The maximum resident set size (KB)                   = 1281296
 
 Test 092 hafs_regional_docn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/hafs_regional_docn_oisst
 Checking test 093 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2354,118 +2369,107 @@ Checking test 093 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 463.266773
-  0: The maximum resident set size (KB)                   = 1271640
+  0: The total amount of wall time                        = 1351.466381
+  0: The maximum resident set size (KB)                   = 1287296
 
 Test 093 hafs_regional_docn_oisst PASS
 
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/hafs_regional_datm_cdeps
-Checking test 094 hafs_regional_datm_cdeps results ....
- Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
- Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
- Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
-
-  0: The total amount of wall time                        = 1219.954068
-  0: The maximum resident set size (KB)                   = 949532
-
-Test 094 hafs_regional_datm_cdeps PASS
+Test 094 hafs_regional_datm_cdeps FAIL
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_control_cfsr
 Checking test 095 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.194519
- 0: The maximum resident set size (KB)                   = 913548
+ 0: The total amount of wall time                        = 263.378949
+ 0: The maximum resident set size (KB)                   = 908544
 
 Test 095 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_restart_cfsr
 Checking test 096 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 115.107922
- 0: The maximum resident set size (KB)                   = 915820
+ 0: The total amount of wall time                        = 198.926309
+ 0: The maximum resident set size (KB)                   = 896472
 
 Test 096 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_control_gefs
 Checking test 097 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 187.813066
- 0: The maximum resident set size (KB)                   = 808580
+ 0: The total amount of wall time                        = 261.234571
+ 0: The maximum resident set size (KB)                   = 809376
 
 Test 097 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_iau_gefs
 Checking test 098 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 191.264357
- 0: The maximum resident set size (KB)                   = 806700
+ 0: The total amount of wall time                        = 259.903517
+ 0: The maximum resident set size (KB)                   = 812188
 
 Test 098 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_stochy_gefs
 Checking test 099 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 191.608844
- 0: The maximum resident set size (KB)                   = 806772
+ 0: The total amount of wall time                        = 276.308237
+ 0: The maximum resident set size (KB)                   = 808556
 
 Test 099 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_bulk_cfsr
 Checking test 100 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.769294
- 0: The maximum resident set size (KB)                   = 909412
+ 0: The total amount of wall time                        = 267.985665
+ 0: The maximum resident set size (KB)                   = 907432
 
 Test 100 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_bulk_gefs
 Checking test 101 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 188.896498
- 0: The maximum resident set size (KB)                   = 811220
+ 0: The total amount of wall time                        = 281.300484
+ 0: The maximum resident set size (KB)                   = 821780
 
 Test 101 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_mx025_cfsr
 Checking test 102 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2474,14 +2478,14 @@ Checking test 102 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 434.236232
-  0: The maximum resident set size (KB)                   = 756576
+  0: The total amount of wall time                        = 1077.037435
+  0: The maximum resident set size (KB)                   = 757316
 
 Test 102 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_mx025_gefs
 Checking test 103 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2490,64 +2494,64 @@ Checking test 103 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 409.896505
-  0: The maximum resident set size (KB)                   = 703764
+  0: The total amount of wall time                        = 1234.086678
+  0: The maximum resident set size (KB)                   = 715968
 
 Test 103 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_multiple_files_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_multiple_files_cfsr
 Checking test 104 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.330610
- 0: The maximum resident set size (KB)                   = 911228
+ 0: The total amount of wall time                        = 1067.559137
+ 0: The maximum resident set size (KB)                   = 907028
 
 Test 104 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_3072x1536_cfsr
 Checking test 105 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 290.644519
- 0: The maximum resident set size (KB)                   = 2047848
+ 0: The total amount of wall time                        = 263.972741
+ 0: The maximum resident set size (KB)                   = 2112632
 
-Test 105 datm_cdeps_3072x1536_cfsr PASS
+Test 105 datm_cdeps_3072x1536_cfsr PASS Tries: 2
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_gfs
 Checking test 106 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 263.687027
- 0: The maximum resident set size (KB)                   = 2057488
+ 0: The total amount of wall time                        = 1097.147368
+ 0: The maximum resident set size (KB)                   = 2123276
 
 Test 106 datm_cdeps_gfs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/datm_cdeps_debug_cfsr
 Checking test 107 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 567.267704
- 0: The maximum resident set size (KB)                   = 892744
+ 0: The total amount of wall time                        = 1238.586940
+ 0: The maximum resident set size (KB)                   = 891728
 
 Test 107 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_atmwav
 Checking test 108 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2591,14 +2595,14 @@ Checking test 108 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 108.254941
-  0: The maximum resident set size (KB)                   = 598712
+  0: The total amount of wall time                        = 708.947543
+  0: The maximum resident set size (KB)                   = 605404
 
 Test 108 control_atmwav PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atm_aerosols
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_185229/control_atm_aerosols
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_203467/control_atm_aerosols
 Checking test 109 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2642,38 +2646,57 @@ Checking test 109 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 448.949388
-  0: The maximum resident set size (KB)                   = 1418268
+  0: The total amount of wall time                        = 1331.226109
+  0: The maximum resident set size (KB)                   = 1422656
 
 Test 109 control_atm_aerosols PASS
 
 FAILED TESTS: 
-Test rap_control 037 failed in run_test failed 
-Test rap_rrtmgp 038 failed in run_test failed 
+Test control_c384 018 failed in run_test failed 
+Test control_c384gdas 019 failed in run_test failed 
+Test hafs_regional_atm_thompson_gfdlsf 088 failed in run_test failed 
+Test hafs_regional_atm_ocn_wav 091 failed in run_test failed 
+Test hafs_regional_datm_cdeps 094 failed in run_test failed 
 
 REGRESSION TEST FAILED
-Fri May 20 07:06:06 GMT 2022
-Elapsed time: 01h:41m:40s. Have a nice day!
-Fri May 20 11:56:15 GMT 2022
+Wed May 25 14:09:51 GMT 2022
+Elapsed time: 02h:21m:23s. Have a nice day!
+Wed May 25 15:06:00 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1443 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 1470 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 002 elapsed time 1811 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 003 elapsed time 1812 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_47111/rap_control
-Checking test 001 rap_control results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_156011/control_c384
+Checking test 001 control_c384 results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 1198.256382
+  0: The maximum resident set size (KB)                   = 1078188
+
+Test 001 control_c384 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_156011/control_c384gdas
+Checking test 002 control_c384gdas results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF06 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF06 .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -2707,66 +2730,53 @@ Checking test 001 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 571.702795
-  0: The maximum resident set size (KB)                   = 969672
+  0: The total amount of wall time                        = 821.829322
+  0: The maximum resident set size (KB)                   = 1162132
 
-Test 001 rap_control PASS
+Test 002 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_47111/rap_rrtmgp
-Checking test 002 rap_rrtmgp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_156011/hafs_regional_atm_thompson_gfdlsf
+Checking test 003 hafs_regional_atm_thompson_gfdlsf results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 604.100899
-  0: The maximum resident set size (KB)                   = 1098656
+  0: The total amount of wall time                        = 1072.255131
+  0: The maximum resident set size (KB)                   = 1545816
 
-Test 002 rap_rrtmgp PASS
+Test 003 hafs_regional_atm_thompson_gfdlsf PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_156011/hafs_regional_atm_ocn_wav
+Checking test 004 hafs_regional_atm_ocn_wav results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing archv.2019_241_06.a .........OK
+ Comparing archs.2019_241_06.a .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+
+  0: The total amount of wall time                        = 1256.879327
+  0: The maximum resident set size (KB)                   = 1269288
+
+Test 004 hafs_regional_atm_ocn_wav PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_156011/hafs_regional_datm_cdeps
+Checking test 005 hafs_regional_datm_cdeps results ....
+ Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
+ Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
+
+  0: The total amount of wall time                        = 1490.761716
+  0: The maximum resident set size (KB)                   = 949056
+
+Test 005 hafs_regional_datm_cdeps PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 12:47:27 GMT 2022
-Elapsed time: 00h:51m:13s. Have a nice day!
+Wed May 25 16:09:53 GMT 2022
+Elapsed time: 01h:03m:54s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,28 +1,25 @@
-Thu May 19 23:36:54 CDT 2022
+Tue May 24 20:17:01 CDT 2022
 Start Regression test
 
-Test 007 compile FAIL
-
-Test 007 compile FAIL
-
-Compile 001 elapsed time 620 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 607 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 002 elapsed time 207 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 361 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 401 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 367 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 358 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 173 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 174 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 945 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 585 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 201 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 115 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 550 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 428 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 391 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 387 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 366 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 207 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 186 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 190 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 171 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 597 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 614 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 188 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 110 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 566 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 363 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -88,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 410.456421
-  0: The maximum resident set size (KB)                   = 5030768
+  0: The total amount of wall time                        = 418.666602
+  0: The maximum resident set size (KB)                   = 5023164
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_2threads_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -149,14 +146,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 507.418497
-  0: The maximum resident set size (KB)                   = 5514276
+  0: The total amount of wall time                        = 569.362200
+  0: The maximum resident set size (KB)                   = 5513004
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_decomp_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -210,14 +207,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 406.617393
-  0: The maximum resident set size (KB)                   = 5196676
+  0: The total amount of wall time                        = 423.969600
+  0: The maximum resident set size (KB)                   = 5202396
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_mpi_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -271,14 +268,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 345.472908
-  0: The maximum resident set size (KB)                   = 4763372
+  0: The total amount of wall time                        = 407.971904
+  0: The maximum resident set size (KB)                   = 4766120
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_bmark_p8
 Checking test 005 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -324,14 +321,14 @@ Checking test 005 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1349.186985
-  0: The maximum resident set size (KB)                   = 6114032
+  0: The total amount of wall time                        = 1412.442060
+  0: The maximum resident set size (KB)                   = 6109940
 
 Test 005 cpld_bmark_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_control_c96_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_control_c96_p8
 Checking test 006 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -394,14 +391,14 @@ Checking test 006 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 398.780119
-  0: The maximum resident set size (KB)                   = 4979680
+  0: The total amount of wall time                        = 400.646890
+  0: The maximum resident set size (KB)                   = 4976612
 
-Test 006 cpld_control_c96_p8 PASS
+Test 006 cpld_control_c96_p8 PASS Tries: 2
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_restart_c96_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_restart_c96_p8
 Checking test 007 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -452,14 +449,14 @@ Checking test 007 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 243.648307
-  0: The maximum resident set size (KB)                   = 4940896
+  0: The total amount of wall time                        = 242.911059
+  0: The maximum resident set size (KB)                   = 4948292
 
 Test 007 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -510,14 +507,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1235.712241
-  0: The maximum resident set size (KB)                   = 4881124
+  0: The total amount of wall time                        = 1230.580136
+  0: The maximum resident set size (KB)                   = 4866440
 
 Test 008 cpld_control_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_restart_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -568,14 +565,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 934.274540
-  0: The maximum resident set size (KB)                   = 4935396
+  0: The total amount of wall time                        = 983.876410
+  0: The maximum resident set size (KB)                   = 4941736
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_control_c384_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_control_c384_p8
 Checking test 010 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -619,14 +616,14 @@ Checking test 010 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1574.788265
-  0: The maximum resident set size (KB)                   = 6066812
+  0: The total amount of wall time                        = 1693.055200
+  0: The maximum resident set size (KB)                   = 6068580
 
 Test 010 cpld_control_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_restart_c384_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_restart_c384_p8
 Checking test 011 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -670,14 +667,14 @@ Checking test 011 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 875.636499
-  0: The maximum resident set size (KB)                   = 6108016
+  0: The total amount of wall time                        = 910.803800
+  0: The maximum resident set size (KB)                   = 6019752
 
 Test 011 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -728,14 +725,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1170.647865
-  0: The maximum resident set size (KB)                   = 5045128
+  0: The total amount of wall time                        = 1183.147392
+  0: The maximum resident set size (KB)                   = 5038248
 
 Test 012 cpld_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control
 Checking test 013 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -782,14 +779,14 @@ Checking test 013 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.186459
-  0: The maximum resident set size (KB)                   = 641944
+  0: The total amount of wall time                        = 139.550288
+  0: The maximum resident set size (KB)                   = 638172
 
 Test 013 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_decomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_decomp
 Checking test 014 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -832,28 +829,28 @@ Checking test 014 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 137.532819
-  0: The maximum resident set size (KB)                   = 580104
+  0: The total amount of wall time                        = 140.479741
+  0: The maximum resident set size (KB)                   = 631804
 
 Test 014 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_2dwrtdecomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_2dwrtdecomp
 Checking test 015 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 125.759620
-  0: The maximum resident set size (KB)                   = 641712
+  0: The total amount of wall time                        = 137.469297
+  0: The maximum resident set size (KB)                   = 638360
 
 Test 015 control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -896,14 +893,14 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 157.535700
- 0: The maximum resident set size (KB)                   = 695668
+ 0: The total amount of wall time                        = 154.960353
+ 0: The maximum resident set size (KB)                   = 698052
 
 Test 016 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -942,14 +939,14 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 68.992064
-  0: The maximum resident set size (KB)                   = 471528
+  0: The total amount of wall time                        = 70.392775
+  0: The maximum resident set size (KB)                   = 470076
 
 Test 017 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_fhzero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -992,14 +989,14 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 123.630380
-  0: The maximum resident set size (KB)                   = 642260
+  0: The total amount of wall time                        = 139.347063
+  0: The maximum resident set size (KB)                   = 640852
 
 Test 018 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1026,14 +1023,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 124.914239
-  0: The maximum resident set size (KB)                   = 638676
+  0: The total amount of wall time                        = 127.222209
+  0: The maximum resident set size (KB)                   = 638364
 
 Test 019 control_CubedSphereGrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1044,14 +1041,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.093897
-  0: The maximum resident set size (KB)                   = 642984
+  0: The total amount of wall time                        = 127.040543
+  0: The maximum resident set size (KB)                   = 639712
 
 Test 020 control_latlon PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1062,14 +1059,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.767856
-  0: The maximum resident set size (KB)                   = 646920
+  0: The total amount of wall time                        = 131.879556
+  0: The maximum resident set size (KB)                   = 638588
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1108,14 +1105,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 330.710995
-0: The maximum resident set size (KB)                   = 814312
+0: The total amount of wall time                        = 332.577078
+0: The maximum resident set size (KB)                   = 823024
 
 Test 022 control_c48 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1126,14 +1123,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 487.253826
-  0: The maximum resident set size (KB)                   = 800072
+  0: The total amount of wall time                        = 495.124858
+  0: The maximum resident set size (KB)                   = 801160
 
 Test 023 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1144,14 +1141,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 678.957954
-  0: The maximum resident set size (KB)                   = 1084860
+  0: The total amount of wall time                        = 795.944158
+  0: The maximum resident set size (KB)                   = 1082388
 
 Test 024 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1194,14 +1191,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 685.183592
-  0: The maximum resident set size (KB)                   = 1244452
+  0: The total amount of wall time                        = 610.062723
+  0: The maximum resident set size (KB)                   = 1236224
 
 Test 025 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1212,28 +1209,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 85.466423
-  0: The maximum resident set size (KB)                   = 654308
+  0: The total amount of wall time                        = 84.770964
+  0: The maximum resident set size (KB)                   = 646352
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_stochy_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.468105
-  0: The maximum resident set size (KB)                   = 485772
+  0: The total amount of wall time                        = 46.623907
+  0: The maximum resident set size (KB)                   = 484488
 
 Test 027 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1244,14 +1241,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 77.000238
-  0: The maximum resident set size (KB)                   = 619980
+  0: The total amount of wall time                        = 78.206593
+  0: The maximum resident set size (KB)                   = 638868
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1266,14 +1263,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.489173
-  0: The maximum resident set size (KB)                   = 643328
+  0: The total amount of wall time                        = 173.439780
+  0: The maximum resident set size (KB)                   = 646684
 
 Test 029 control_iovr4 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1288,14 +1285,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.262345
-  0: The maximum resident set size (KB)                   = 646528
+  0: The total amount of wall time                        = 134.220420
+  0: The maximum resident set size (KB)                   = 643440
 
 Test 030 control_iovr5 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1339,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.276615
-  0: The maximum resident set size (KB)                   = 1035816
+  0: The total amount of wall time                        = 175.925755
+  0: The maximum resident set size (KB)                   = 1032588
 
 Test 031 control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_p8_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1368,14 +1365,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 319.543450
-  0: The maximum resident set size (KB)                   = 1032324
+  0: The total amount of wall time                        = 320.144980
+  0: The maximum resident set size (KB)                   = 1039556
 
 Test 032 control_p8_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_restart_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1414,14 +1411,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 91.559205
-  0: The maximum resident set size (KB)                   = 869672
+  0: The total amount of wall time                        = 99.824740
+  0: The maximum resident set size (KB)                   = 862180
 
 Test 033 control_restart_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_decomp_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1464,14 +1461,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.620129
-  0: The maximum resident set size (KB)                   = 1019888
+  0: The total amount of wall time                        = 178.551442
+  0: The maximum resident set size (KB)                   = 1020776
 
 Test 034 control_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_2threads_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1514,14 +1511,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 197.182717
- 0: The maximum resident set size (KB)                   = 1101032
+ 0: The total amount of wall time                        = 199.855446
+ 0: The maximum resident set size (KB)                   = 1104944
 
 Test 035 control_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_p8_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1568,14 +1565,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.940672
-  0: The maximum resident set size (KB)                   = 1160720
+  0: The total amount of wall time                        = 197.575176
+  0: The maximum resident set size (KB)                   = 1160160
 
 Test 036 control_p8_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1586,42 +1583,42 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 336.180094
- 0: The maximum resident set size (KB)                   = 829908
+ 0: The total amount of wall time                        = 345.139799
+ 0: The maximum resident set size (KB)                   = 830544
 
 Test 037 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 204.856623
- 0: The maximum resident set size (KB)                   = 823860
+ 0: The total amount of wall time                        = 190.484009
+ 0: The maximum resident set size (KB)                   = 823900
 
 Test 038 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_control_2dwrtdecomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 334.125202
- 0: The maximum resident set size (KB)                   = 823120
+ 0: The total amount of wall time                        = 337.455470
+ 0: The maximum resident set size (KB)                   = 830840
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1629,14 +1626,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 338.478781
- 0: The maximum resident set size (KB)                   = 791136
+ 0: The total amount of wall time                        = 336.761739
+ 0: The maximum resident set size (KB)                   = 802100
 
 Test 040 regional_noquilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1647,28 +1644,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 230.402268
- 0: The maximum resident set size (KB)                   = 821200
+ 0: The total amount of wall time                        = 230.080251
+ 0: The maximum resident set size (KB)                   = 825944
 
 Test 041 regional_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 333.068304
- 0: The maximum resident set size (KB)                   = 821128
+ 0: The total amount of wall time                        = 334.139164
+ 0: The maximum resident set size (KB)                   = 819572
 
 Test 042 regional_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_3km
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_3km
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1679,14 +1676,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 256.357747
-  0: The maximum resident set size (KB)                   = 886020
+  0: The total amount of wall time                        = 258.723982
+  0: The maximum resident set size (KB)                   = 884380
 
 Test 043 regional_3km PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1733,14 +1730,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 435.682754
-  0: The maximum resident set size (KB)                   = 1040904
+  0: The total amount of wall time                        = 438.857014
+  0: The maximum resident set size (KB)                   = 1031208
 
 Test 044 rap_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1787,14 +1784,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.636916
-  0: The maximum resident set size (KB)                   = 1183248
+  0: The total amount of wall time                        = 474.573063
+  0: The maximum resident set size (KB)                   = 1191296
 
 Test 045 rap_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1805,14 +1802,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 292.913360
-  0: The maximum resident set size (KB)                   = 1190508
+  0: The total amount of wall time                        = 310.789291
+  0: The maximum resident set size (KB)                   = 1198952
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1859,14 +1856,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 500.580897
- 0: The maximum resident set size (KB)                   = 1091868
+ 0: The total amount of wall time                        = 503.722153
+ 0: The maximum resident set size (KB)                   = 1091588
 
 Test 047 rap_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1905,14 +1902,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.092249
-  0: The maximum resident set size (KB)                   = 930500
+  0: The total amount of wall time                        = 228.921523
+  0: The maximum resident set size (KB)                   = 952464
 
 Test 048 rap_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1959,14 +1956,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 621.215689
-  0: The maximum resident set size (KB)                   = 1045148
+  0: The total amount of wall time                        = 438.559601
+  0: The maximum resident set size (KB)                   = 1039924
 
 Test 049 rap_sfcdiff PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_sfcdiff_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2005,14 +2002,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 224.007252
-  0: The maximum resident set size (KB)                   = 947760
+  0: The total amount of wall time                        = 223.965890
+  0: The maximum resident set size (KB)                   = 938032
 
 Test 050 rap_sfcdiff_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2059,14 +2056,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 418.559418
-  0: The maximum resident set size (KB)                   = 1040888
+  0: The total amount of wall time                        = 421.092760
+  0: The maximum resident set size (KB)                   = 1032332
 
 Test 051 hrrr_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2110,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 430.896082
-  0: The maximum resident set size (KB)                   = 1036328
+  0: The total amount of wall time                        = 430.074537
+  0: The maximum resident set size (KB)                   = 1025568
 
 Test 052 rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_v1nssl
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2132,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 502.929100
-  0: The maximum resident set size (KB)                   = 702412
+  0: The total amount of wall time                        = 509.207425
+  0: The maximum resident set size (KB)                   = 707900
 
 Test 053 rrfs_v1nssl PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2157,14 +2154,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 492.239404
-  0: The maximum resident set size (KB)                   = 739200
+  0: The total amount of wall time                        = 493.169601
+  0: The maximum resident set size (KB)                   = 725936
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2173,14 +2170,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 187.971428
-  0: The maximum resident set size (KB)                   = 921752
+  0: The total amount of wall time                        = 216.579760
+  0: The maximum resident set size (KB)                   = 918960
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2189,14 +2186,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 210.874361
-  0: The maximum resident set size (KB)                   = 922700
+  0: The total amount of wall time                        = 306.312820
+  0: The maximum resident set size (KB)                   = 928584
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2205,14 +2202,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 238.487674
-  0: The maximum resident set size (KB)                   = 953588
+  0: The total amount of wall time                        = 218.227510
+  0: The maximum resident set size (KB)                   = 954400
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2223,14 +2220,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 332.691976
-  0: The maximum resident set size (KB)                   = 757280
+  0: The total amount of wall time                        = 331.285885
+  0: The maximum resident set size (KB)                   = 750352
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2241,14 +2238,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 330.510196
-  0: The maximum resident set size (KB)                   = 757428
+  0: The total amount of wall time                        = 328.880736
+  0: The maximum resident set size (KB)                   = 750588
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2259,14 +2256,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 211.102818
-  0: The maximum resident set size (KB)                   = 754916
+  0: The total amount of wall time                        = 215.569902
+  0: The maximum resident set size (KB)                   = 756168
 
 Test 060 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2277,14 +2274,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 171.220696
-  0: The maximum resident set size (KB)                   = 717892
+  0: The total amount of wall time                        = 171.338538
+  0: The maximum resident set size (KB)                   = 714992
 
 Test 061 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2295,14 +2292,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 237.520061
-  0: The maximum resident set size (KB)                   = 1076612
+  0: The total amount of wall time                        = 234.663615
+  0: The maximum resident set size (KB)                   = 1075608
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2313,245 +2310,489 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 220.862481
-  0: The maximum resident set size (KB)                   = 1050980
+  0: The total amount of wall time                        = 221.889313
+  0: The maximum resident set size (KB)                   = 1057020
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_wam
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 104.917300
-  0: The maximum resident set size (KB)                   = 612924
+  0: The total amount of wall time                        = 104.482896
+  0: The maximum resident set size (KB)                   = 613904
 
 Test 064 control_wam PASS
 
 
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_debug
+Checking test 065 control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 155.584728
+  0: The maximum resident set size (KB)                   = 798732
+
+Test 065 control_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_2threads_debug
+Checking test 066 control_2threads_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+ 0: The total amount of wall time                        = 232.851272
+ 0: The maximum resident set size (KB)                   = 864812
+
+Test 066 control_2threads_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_CubedSphereGrid_debug
+Checking test 067 control_CubedSphereGrid_debug results ....
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf001.tile1.nc .........OK
+ Comparing sfcf001.tile2.nc .........OK
+ Comparing sfcf001.tile3.nc .........OK
+ Comparing sfcf001.tile4.nc .........OK
+ Comparing sfcf001.tile5.nc .........OK
+ Comparing sfcf001.tile6.nc .........OK
+ Comparing atmf000.tile1.nc .........OK
+ Comparing atmf000.tile2.nc .........OK
+ Comparing atmf000.tile3.nc .........OK
+ Comparing atmf000.tile4.nc .........OK
+ Comparing atmf000.tile5.nc .........OK
+ Comparing atmf000.tile6.nc .........OK
+ Comparing atmf001.tile1.nc .........OK
+ Comparing atmf001.tile2.nc .........OK
+ Comparing atmf001.tile3.nc .........OK
+ Comparing atmf001.tile4.nc .........OK
+ Comparing atmf001.tile5.nc .........OK
+ Comparing atmf001.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 168.303856
+  0: The maximum resident set size (KB)                   = 810924
+
+Test 067 control_CubedSphereGrid_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_wrtGauss_netcdf_parallel_debug
+Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 155.144407
+  0: The maximum resident set size (KB)                   = 803996
+
+Test 068 control_wrtGauss_netcdf_parallel_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_stochy_debug
+Checking test 069 control_stochy_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 179.089231
+  0: The maximum resident set size (KB)                   = 811064
+
+Test 069 control_stochy_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_lndp_debug
+Checking test 070 control_lndp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 159.627405
+  0: The maximum resident set size (KB)                   = 807072
+
+Test 070 control_lndp_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_csawmg_debug
+Checking test 071 control_csawmg_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 241.421931
+  0: The maximum resident set size (KB)                   = 854960
+
+Test 071 control_csawmg_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_csawmgt_debug
+Checking test 072 control_csawmgt_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 234.564014
+  0: The maximum resident set size (KB)                   = 850232
+
+Test 072 control_csawmgt_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_ras_debug
+Checking test 073 control_ras_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 161.693341
+  0: The maximum resident set size (KB)                   = 816108
+
+Test 073 control_ras_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_diag_debug
+Checking test 074 control_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 168.570686
+  0: The maximum resident set size (KB)                   = 861088
+
+Test 074 control_diag_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_debug_p8
+Checking test 075 control_debug_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 173.504063
+  0: The maximum resident set size (KB)                   = 1194468
+
+Test 075 control_debug_p8 PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_thompson_debug
+Checking test 076 control_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 180.256766
+  0: The maximum resident set size (KB)                   = 1171088
+
+Test 076 control_thompson_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_thompson_no_aero_debug
+Checking test 077 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 177.329871
+  0: The maximum resident set size (KB)                   = 1168072
+
+Test 077 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug_extdiag
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_thompson_extdiag_debug
+Checking test 078 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 189.189436
+  0: The maximum resident set size (KB)                   = 1200784
+
+Test 078 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_thompson_progcld_thompson_debug
+Checking test 079 control_thompson_progcld_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 178.638072
+  0: The maximum resident set size (KB)                   = 1177032
+
+Test 079 control_thompson_progcld_thompson_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/regional_debug
+Checking test 080 regional_debug results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+
+ 0: The total amount of wall time                        = 247.794237
+ 0: The maximum resident set size (KB)                   = 848344
+
+Test 080 regional_debug PASS
+
+
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.472679
-  0: The maximum resident set size (KB)                   = 1181080
+  0: The total amount of wall time                        = 273.353917
+  0: The maximum resident set size (KB)                   = 1181140
 
 Test 081 rap_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_unified_drag_suite_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.406436
-  0: The maximum resident set size (KB)                   = 1176452
+  0: The total amount of wall time                        = 272.995136
+  0: The maximum resident set size (KB)                   = 1187896
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 294.355149
-  0: The maximum resident set size (KB)                   = 1267664
+  0: The total amount of wall time                        = 297.779111
+  0: The maximum resident set size (KB)                   = 1268700
 
 Test 083 rap_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.841170
-  0: The maximum resident set size (KB)                   = 1177492
+  0: The total amount of wall time                        = 273.765671
+  0: The maximum resident set size (KB)                   = 1181828
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_unified_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.690431
-  0: The maximum resident set size (KB)                   = 1185432
+  0: The total amount of wall time                        = 279.220773
+  0: The maximum resident set size (KB)                   = 1185924
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.794072
-  0: The maximum resident set size (KB)                   = 1184916
+  0: The total amount of wall time                        = 283.494530
+  0: The maximum resident set size (KB)                   = 1140992
 
 Test 086 rap_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.705565
-  0: The maximum resident set size (KB)                   = 1185048
+  0: The total amount of wall time                        = 273.742473
+  0: The maximum resident set size (KB)                   = 1177716
 
 Test 087 rap_flake_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.012807
-  0: The maximum resident set size (KB)                   = 1183288
+  0: The total amount of wall time                        = 275.546293
+  0: The maximum resident set size (KB)                   = 1181184
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.914062
-  0: The maximum resident set size (KB)                   = 1182072
+  0: The total amount of wall time                        = 267.660810
+  0: The maximum resident set size (KB)                   = 1179880
 
 Test 089 rap_noah_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 468.264410
-  0: The maximum resident set size (KB)                   = 1319116
+  0: The total amount of wall time                        = 458.777970
+  0: The maximum resident set size (KB)                   = 1311668
 
 Test 090 rap_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.048967
-  0: The maximum resident set size (KB)                   = 1187112
+  0: The total amount of wall time                        = 273.678592
+  0: The maximum resident set size (KB)                   = 1183464
 
 Test 091 rap_sfcdiff_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 450.839005
-  0: The maximum resident set size (KB)                   = 1183932
+  0: The total amount of wall time                        = 450.316287
+  0: The maximum resident set size (KB)                   = 1179968
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.039634
-  0: The maximum resident set size (KB)                   = 1178092
+  0: The total amount of wall time                        = 278.207916
+  0: The maximum resident set size (KB)                   = 1183748
 
 Test 093 rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 292.995398
-  0: The maximum resident set size (KB)                   = 526316
+  0: The total amount of wall time                        = 293.518175
+  0: The maximum resident set size (KB)                   = 516336
 
 Test 094 control_wam_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 266.916820
-  0: The maximum resident set size (KB)                   = 981444
+  0: The total amount of wall time                        = 288.258308
+  0: The maximum resident set size (KB)                   = 973992
 
 Test 095 hafs_regional_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 369.554133
-  0: The maximum resident set size (KB)                   = 1350088
+  0: The total amount of wall time                        = 366.012149
+  0: The maximum resident set size (KB)                   = 1358144
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2560,58 +2801,58 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 353.618172
-  0: The maximum resident set size (KB)                   = 1203968
+  0: The total amount of wall time                        = 370.951447
+  0: The maximum resident set size (KB)                   = 1208548
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 701.681020
-  0: The maximum resident set size (KB)                   = 1200984
+  0: The total amount of wall time                        = 695.259668
+  0: The maximum resident set size (KB)                   = 1194888
 
 Test 098 hafs_regional_atm_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 797.052259
-  0: The maximum resident set size (KB)                   = 1161784
+  0: The total amount of wall time                        = 813.440002
+  0: The maximum resident set size (KB)                   = 1169472
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 439.554317
-  0: The maximum resident set size (KB)                   = 570792
+  0: The total amount of wall time                        = 439.911452
+  0: The maximum resident set size (KB)                   = 562948
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2620,28 +2861,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 462.274095
-  0: The maximum resident set size (KB)                   = 583692
+  0: The total amount of wall time                        = 463.828781
+  0: The maximum resident set size (KB)                   = 608712
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 205.182015
-  0: The maximum resident set size (KB)                   = 382964
+  0: The total amount of wall time                        = 206.235298
+  0: The maximum resident set size (KB)                   = 383072
 
 Test 102 hafs_global_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2654,42 +2895,42 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 556.081446
-  0: The maximum resident set size (KB)                   = 413980
+  0: The total amount of wall time                        = 555.040901
+  0: The maximum resident set size (KB)                   = 392440
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 261.816106
-  0: The maximum resident set size (KB)                   = 583532
+  0: The total amount of wall time                        = 272.568452
+  0: The maximum resident set size (KB)                   = 582256
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 250.269027
-  0: The maximum resident set size (KB)                   = 579668
+  0: The total amount of wall time                        = 259.077031
+  0: The maximum resident set size (KB)                   = 574292
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2698,14 +2939,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 260.185070
-  0: The maximum resident set size (KB)                   = 630984
+  0: The total amount of wall time                        = 270.239080
+  0: The maximum resident set size (KB)                   = 626764
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2716,28 +2957,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 583.000756
-  0: The maximum resident set size (KB)                   = 556528
+  0: The total amount of wall time                        = 718.920882
+  0: The maximum resident set size (KB)                   = 556884
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 78.403058
-  0: The maximum resident set size (KB)                   = 397968
+  0: The total amount of wall time                        = 78.702808
+  0: The maximum resident set size (KB)                   = 402280
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2745,14 +2986,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 346.641811
-  0: The maximum resident set size (KB)                   = 1217220
+  0: The total amount of wall time                        = 354.571374
+  0: The maximum resident set size (KB)                   = 1207444
 
 Test 109 hafs_regional_docn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2760,118 +3001,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 465.833834
-  0: The maximum resident set size (KB)                   = 1197772
+  0: The total amount of wall time                        = 354.184778
+  0: The maximum resident set size (KB)                   = 1201864
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 935.528450
-  0: The maximum resident set size (KB)                   = 1015508
+  0: The total amount of wall time                        = 924.808570
+  0: The maximum resident set size (KB)                   = 1009548
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.535954
- 0: The maximum resident set size (KB)                   = 1018960
+ 0: The total amount of wall time                        = 141.999351
+ 0: The maximum resident set size (KB)                   = 1014808
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 98.257782
- 0: The maximum resident set size (KB)                   = 979596
+ 0: The total amount of wall time                        = 102.524004
+ 0: The maximum resident set size (KB)                   = 982216
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.499671
- 0: The maximum resident set size (KB)                   = 932148
+ 0: The total amount of wall time                        = 140.981570
+ 0: The maximum resident set size (KB)                   = 935612
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.613219
- 0: The maximum resident set size (KB)                   = 933596
+ 0: The total amount of wall time                        = 140.702730
+ 0: The maximum resident set size (KB)                   = 932952
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.830389
- 0: The maximum resident set size (KB)                   = 940188
+ 0: The total amount of wall time                        = 211.547283
+ 0: The maximum resident set size (KB)                   = 933508
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.526290
- 0: The maximum resident set size (KB)                   = 1037088
+ 0: The total amount of wall time                        = 146.413002
+ 0: The maximum resident set size (KB)                   = 1026088
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.771915
- 0: The maximum resident set size (KB)                   = 930544
+ 0: The total amount of wall time                        = 140.547819
+ 0: The maximum resident set size (KB)                   = 932364
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2880,14 +3121,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 297.559157
-  0: The maximum resident set size (KB)                   = 849968
+  0: The total amount of wall time                        = 296.569056
+  0: The maximum resident set size (KB)                   = 848768
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2896,64 +3137,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 292.176758
-  0: The maximum resident set size (KB)                   = 845428
+  0: The total amount of wall time                        = 290.644041
+  0: The maximum resident set size (KB)                   = 853460
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.790644
- 0: The maximum resident set size (KB)                   = 1025600
+ 0: The total amount of wall time                        = 140.484100
+ 0: The maximum resident set size (KB)                   = 1032952
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.007114
- 0: The maximum resident set size (KB)                   = 2243824
+ 0: The total amount of wall time                        = 192.268800
+ 0: The maximum resident set size (KB)                   = 2242740
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_gfs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 191.064790
- 0: The maximum resident set size (KB)                   = 2236984
+ 0: The total amount of wall time                        = 194.376176
+ 0: The maximum resident set size (KB)                   = 2237932
 
 Test 123 datm_cdeps_gfs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 436.742642
- 0: The maximum resident set size (KB)                   = 977044
+ 0: The total amount of wall time                        = 435.451447
+ 0: The maximum resident set size (KB)                   = 973756
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2997,14 +3238,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 82.298522
-  0: The maximum resident set size (KB)                   = 620324
+  0: The total amount of wall time                        = 80.921631
+  0: The maximum resident set size (KB)                   = 669760
 
 Test 125 control_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_c384gdas_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_c384gdas_wav
 Checking test 126 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3050,14 +3291,14 @@ Checking test 126 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 699.255393
-  0: The maximum resident set size (KB)                   = 1319056
+  0: The total amount of wall time                        = 699.972092
+  0: The maximum resident set size (KB)                   = 1319248
 
 Test 126 control_c384gdas_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_atm_aerosols
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_402331/control_atm_aerosols
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_383163/control_atm_aerosols
 Checking test 127 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3101,266 +3342,12 @@ Checking test 127 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.450742
-  0: The maximum resident set size (KB)                   = 4797952
+  0: The total amount of wall time                        = 342.223462
+  0: The maximum resident set size (KB)                   = 4804476
 
 Test 127 control_atm_aerosols PASS
 
-FAILED TESTS: 
-Test compile_007 failed in run_compile failed 
-
-REGRESSION TEST FAILED
-Fri May 20 00:43:54 CDT 2022
-Elapsed time: 01h:07m:01s. Have a nice day!
-Fri May 20 06:58:10 CDT 2022
-Start Regression test
-
-Compile 001 elapsed time 181 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_debug
-Checking test 001 control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 154.165260
-  0: The maximum resident set size (KB)                   = 803012
-
-Test 001 control_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_2threads_debug
-Checking test 002 control_2threads_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
- 0: The total amount of wall time                        = 229.774054
- 0: The maximum resident set size (KB)                   = 860800
-
-Test 002 control_2threads_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_CubedSphereGrid_debug
-Checking test 003 control_CubedSphereGrid_debug results ....
- Comparing sfcf000.tile1.nc .........OK
- Comparing sfcf000.tile2.nc .........OK
- Comparing sfcf000.tile3.nc .........OK
- Comparing sfcf000.tile4.nc .........OK
- Comparing sfcf000.tile5.nc .........OK
- Comparing sfcf000.tile6.nc .........OK
- Comparing sfcf001.tile1.nc .........OK
- Comparing sfcf001.tile2.nc .........OK
- Comparing sfcf001.tile3.nc .........OK
- Comparing sfcf001.tile4.nc .........OK
- Comparing sfcf001.tile5.nc .........OK
- Comparing sfcf001.tile6.nc .........OK
- Comparing atmf000.tile1.nc .........OK
- Comparing atmf000.tile2.nc .........OK
- Comparing atmf000.tile3.nc .........OK
- Comparing atmf000.tile4.nc .........OK
- Comparing atmf000.tile5.nc .........OK
- Comparing atmf000.tile6.nc .........OK
- Comparing atmf001.tile1.nc .........OK
- Comparing atmf001.tile2.nc .........OK
- Comparing atmf001.tile3.nc .........OK
- Comparing atmf001.tile4.nc .........OK
- Comparing atmf001.tile5.nc .........OK
- Comparing atmf001.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 178.640205
-  0: The maximum resident set size (KB)                   = 805580
-
-Test 003 control_CubedSphereGrid_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_wrtGauss_netcdf_parallel_debug
-Checking test 004 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 151.074194
-  0: The maximum resident set size (KB)                   = 802364
-
-Test 004 control_wrtGauss_netcdf_parallel_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_stochy_debug
-Checking test 005 control_stochy_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 176.028844
-  0: The maximum resident set size (KB)                   = 814124
-
-Test 005 control_stochy_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_lndp_debug
-Checking test 006 control_lndp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 155.078035
-  0: The maximum resident set size (KB)                   = 810236
-
-Test 006 control_lndp_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_csawmg_debug
-Checking test 007 control_csawmg_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 234.029846
-  0: The maximum resident set size (KB)                   = 862324
-
-Test 007 control_csawmg_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_csawmgt_debug
-Checking test 008 control_csawmgt_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 230.390091
-  0: The maximum resident set size (KB)                   = 850692
-
-Test 008 control_csawmgt_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_ras_debug
-Checking test 009 control_ras_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 157.919142
-  0: The maximum resident set size (KB)                   = 816548
-
-Test 009 control_ras_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_diag_debug
-Checking test 010 control_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 162.589308
-  0: The maximum resident set size (KB)                   = 866672
-
-Test 010 control_diag_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_debug_p8
-Checking test 011 control_debug_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 170.419070
-  0: The maximum resident set size (KB)                   = 1196404
-
-Test 011 control_debug_p8 PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_thompson_debug
-Checking test 012 control_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 180.448667
-  0: The maximum resident set size (KB)                   = 1177944
-
-Test 012 control_thompson_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_thompson_no_aero_debug
-Checking test 013 control_thompson_no_aero_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 175.897823
-  0: The maximum resident set size (KB)                   = 1161212
-
-Test 013 control_thompson_no_aero_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_thompson_extdiag_debug
-Checking test 014 control_thompson_extdiag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 191.379041
-  0: The maximum resident set size (KB)                   = 1209708
-
-Test 014 control_thompson_extdiag_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/control_thompson_progcld_thompson_debug
-Checking test 015 control_thompson_progcld_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 177.253253
-  0: The maximum resident set size (KB)                   = 1178296
-
-Test 015 control_thompson_progcld_thompson_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_54576/regional_debug
-Checking test 016 regional_debug results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
-
- 0: The total amount of wall time                        = 249.023935
- 0: The maximum resident set size (KB)                   = 844044
-
-Test 016 regional_debug PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 08:24:41 CDT 2022
-Elapsed time: 01h:26m:32s. Have a nice day!
+Tue May 24 22:09:28 CDT 2022
+Elapsed time: 01h:52m:28s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,18 +1,18 @@
-Fri May 20 03:10:33 UTC 2022
+Wed May 25 02:11:38 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 723 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 754 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 730 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 685 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 532 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 496 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 513 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 491 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 1009 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 731 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 800 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 736 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 706 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 538 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 511 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 528 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 510 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 927 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -59,14 +59,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 145.445272
-The maximum resident set size (KB)                   = 420612
+The total amount of wall time                        = 145.610181
+The maximum resident set size (KB)                   = 421780
 
 Test 001 control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_decomp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -109,28 +109,28 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 146.526672
-The maximum resident set size (KB)                   = 419544
+The total amount of wall time                        = 149.249099
+The maximum resident set size (KB)                   = 419780
 
 Test 002 control_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_2dwrtdecomp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_2dwrtdecomp
 Checking test 003 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 138.419275
-The maximum resident set size (KB)                   = 421632
+The total amount of wall time                        = 139.260253
+The maximum resident set size (KB)                   = 421788
 
 Test 003 control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_restart
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_restart
 Checking test 004 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -169,14 +169,14 @@ Checking test 004 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 77.926014
-The maximum resident set size (KB)                   = 158172
+The total amount of wall time                        = 81.534508
+The maximum resident set size (KB)                   = 158120
 
 Test 004 control_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_fhzero
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_fhzero
 Checking test 005 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -219,14 +219,14 @@ Checking test 005 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 135.144983
-The maximum resident set size (KB)                   = 420644
+The total amount of wall time                        = 144.817489
+The maximum resident set size (KB)                   = 420540
 
 Test 005 control_fhzero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_CubedSphereGrid
 Checking test 006 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -253,14 +253,14 @@ Checking test 006 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 136.178286
-The maximum resident set size (KB)                   = 420688
+The total amount of wall time                        = 149.825309
+The maximum resident set size (KB)                   = 420592
 
 Test 006 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_latlon
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_latlon
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_latlon
 Checking test 007 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -271,14 +271,14 @@ Checking test 007 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 141.048664
-The maximum resident set size (KB)                   = 420756
+The total amount of wall time                        = 144.575796
+The maximum resident set size (KB)                   = 420672
 
 Test 007 control_latlon PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_wrtGauss_netcdf_parallel
 Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -289,14 +289,14 @@ Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 142.764408
-The maximum resident set size (KB)                   = 420548
+The total amount of wall time                        = 148.884128
+The maximum resident set size (KB)                   = 421676
 
 Test 008 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c48
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_c48
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_c48
 Checking test 009 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -335,14 +335,14 @@ Checking test 009 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 449.074995
-The maximum resident set size (KB)                   = 628208
+The total amount of wall time                        = 450.230183
+The maximum resident set size (KB)                   = 628212
 
 Test 009 control_c48 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c192
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_c192
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_c192
 Checking test 010 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -353,14 +353,14 @@ Checking test 010 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 547.987340
-The maximum resident set size (KB)                   = 521988
+The total amount of wall time                        = 560.279900
+The maximum resident set size (KB)                   = 522108
 
 Test 010 control_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_stochy
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_stochy
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_stochy
 Checking test 011 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -371,28 +371,28 @@ Checking test 011 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 96.143339
-The maximum resident set size (KB)                   = 426984
+The total amount of wall time                        = 97.839166
+The maximum resident set size (KB)                   = 427012
 
 Test 011 control_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_stochy
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_stochy_restart
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_stochy_restart
 Checking test 012 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 54.669521
-The maximum resident set size (KB)                   = 175408
+The total amount of wall time                        = 63.756791
+The maximum resident set size (KB)                   = 175328
 
 Test 012 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_lndp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_lndp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_lndp
 Checking test 013 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -403,14 +403,14 @@ Checking test 013 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 86.945068
-The maximum resident set size (KB)                   = 424656
+The total amount of wall time                        = 90.688168
+The maximum resident set size (KB)                   = 424660
 
 Test 013 control_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_iovr4
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_iovr4
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_iovr4
 Checking test 014 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -425,14 +425,14 @@ Checking test 014 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 144.882566
-The maximum resident set size (KB)                   = 420508
+The total amount of wall time                        = 152.522704
+The maximum resident set size (KB)                   = 420612
 
 Test 014 control_iovr4 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_iovr5
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_iovr5
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_iovr5
 Checking test 015 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -447,14 +447,14 @@ Checking test 015 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 144.056167
-The maximum resident set size (KB)                   = 420568
+The total amount of wall time                        = 153.610872
+The maximum resident set size (KB)                   = 421664
 
 Test 015 control_iovr5 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_p8
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_p8
 Checking test 016 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -501,14 +501,14 @@ Checking test 016 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 188.740238
-The maximum resident set size (KB)                   = 808728
+The total amount of wall time                        = 192.922884
+The maximum resident set size (KB)                   = 808744
 
 Test 016 control_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8_lndp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_p8_lndp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_p8_lndp
 Checking test 017 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -527,14 +527,14 @@ Checking test 017 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 350.196482
-The maximum resident set size (KB)                   = 812132
+The total amount of wall time                        = 358.330788
+The maximum resident set size (KB)                   = 812160
 
 Test 017 control_p8_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_restart_p8
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_restart_p8
 Checking test 018 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -573,14 +573,14 @@ Checking test 018 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 106.389880
-The maximum resident set size (KB)                   = 545780
+The total amount of wall time                        = 118.791520
+The maximum resident set size (KB)                   = 545736
 
 Test 018 control_restart_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_decomp_p8
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_decomp_p8
 Checking test 019 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -623,14 +623,14 @@ Checking test 019 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 195.835520
-The maximum resident set size (KB)                   = 803744
+The total amount of wall time                        = 202.536955
+The maximum resident set size (KB)                   = 803832
 
 Test 019 control_decomp_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8_rrtmgp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_p8_rrtmgp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_p8_rrtmgp
 Checking test 020 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -677,14 +677,14 @@ Checking test 020 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 231.294705
-The maximum resident set size (KB)                   = 926564
+The total amount of wall time                        = 240.735548
+The maximum resident set size (KB)                   = 926420
 
 Test 020 control_p8_rrtmgp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_control
 Checking test 021 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -695,42 +695,42 @@ Checking test 021 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 366.233674
-The maximum resident set size (KB)                   = 534012
+The total amount of wall time                        = 376.981849
+The maximum resident set size (KB)                   = 533868
 
 Test 021 regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_restart
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_restart
 Checking test 022 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 219.067845
-The maximum resident set size (KB)                   = 530268
+The total amount of wall time                        = 224.621422
+The maximum resident set size (KB)                   = 530248
 
 Test 022 regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_control_2dwrtdecomp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_control_2dwrtdecomp
 Checking test 023 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 367.912106
-The maximum resident set size (KB)                   = 533884
+The total amount of wall time                        = 370.274666
+The maximum resident set size (KB)                   = 534052
 
 Test 023 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_noquilt
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_noquilt
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_noquilt
 Checking test 024 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -738,28 +738,28 @@ Checking test 024 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 395.738803
-The maximum resident set size (KB)                   = 536596
+The total amount of wall time                        = 402.571620
+The maximum resident set size (KB)                   = 536672
 
 Test 024 regional_noquilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_netcdf_parallel
 Checking test 025 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 359.589523
-The maximum resident set size (KB)                   = 527664
+The total amount of wall time                        = 362.697717
+The maximum resident set size (KB)                   = 527768
 
 Test 025 regional_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_3km
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_3km
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_3km
 Checking test 026 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -770,14 +770,14 @@ Checking test 026 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 299.976230
-The maximum resident set size (KB)                   = 559984
+The total amount of wall time                        = 310.884795
+The maximum resident set size (KB)                   = 559908
 
 Test 026 regional_3km PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_control
 Checking test 027 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -824,14 +824,14 @@ Checking test 027 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 458.699970
-The maximum resident set size (KB)                   = 788416
+The total amount of wall time                        = 462.909735
+The maximum resident set size (KB)                   = 788364
 
 Test 027 rap_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_rrtmgp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_rrtmgp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_rrtmgp
 Checking test 028 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -878,14 +878,14 @@ Checking test 028 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 492.718747
-The maximum resident set size (KB)                   = 908256
+The total amount of wall time                        = 499.989370
+The maximum resident set size (KB)                   = 908292
 
 Test 028 rap_rrtmgp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/regional_spp_sppt_shum_skeb
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_spp_sppt_shum_skeb
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_spp_sppt_shum_skeb
 Checking test 029 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -896,14 +896,14 @@ Checking test 029 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 338.887611
+The total amount of wall time                        = 353.165321
 The maximum resident set size (KB)                   = 861268
 
 Test 029 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_restart
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_restart
 Checking test 030 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -942,14 +942,14 @@ Checking test 030 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 237.665772
-The maximum resident set size (KB)                   = 532788
+The total amount of wall time                        = 240.874994
+The maximum resident set size (KB)                   = 532608
 
 Test 030 rap_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_sfcdiff
 Checking test 031 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -996,14 +996,14 @@ Checking test 031 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 460.403577
-The maximum resident set size (KB)                   = 788136
+The total amount of wall time                        = 463.720006
+The maximum resident set size (KB)                   = 788128
 
 Test 031 rap_sfcdiff PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_sfcdiff_restart
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_sfcdiff_restart
 Checking test 032 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1042,14 +1042,14 @@ Checking test 032 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 239.519701
-The maximum resident set size (KB)                   = 532428
+The total amount of wall time                        = 241.504464
+The maximum resident set size (KB)                   = 532468
 
 Test 032 rap_sfcdiff_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hrrr_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hrrr_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hrrr_control
 Checking test 033 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1096,14 +1096,14 @@ Checking test 033 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 438.870307
-The maximum resident set size (KB)                   = 785192
+The total amount of wall time                        = 450.675988
+The maximum resident set size (KB)                   = 785308
 
 Test 033 hrrr_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_v1beta
 Checking test 034 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 034 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 445.321437
-The maximum resident set size (KB)                   = 785068
+The total amount of wall time                        = 449.278292
+The maximum resident set size (KB)                   = 785092
 
 Test 034 rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1nssl
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_v1nssl
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_v1nssl
 Checking test 035 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1172,14 +1172,14 @@ Checking test 035 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 502.435818
-The maximum resident set size (KB)                   = 475108
+The total amount of wall time                        = 503.537583
+The maximum resident set size (KB)                   = 474968
 
 Test 035 rrfs_v1nssl PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1nssl_nohailnoccn
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_v1nssl_nohailnoccn
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_v1nssl_nohailnoccn
 Checking test 036 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 036 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 488.394561
-The maximum resident set size (KB)                   = 470392
+The total amount of wall time                        = 489.105377
+The maximum resident set size (KB)                   = 470428
 
 Test 036 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_conus13km_hrrr_warm
 Checking test 037 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1210,14 +1210,14 @@ Checking test 037 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 259.003571
-The maximum resident set size (KB)                   = 602092
+The total amount of wall time                        = 266.088139
+The maximum resident set size (KB)                   = 601500
 
 Test 037 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_conus13km_radar_tten_warm
 Checking test 038 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1226,14 +1226,14 @@ Checking test 038 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 270.453214
-The maximum resident set size (KB)                   = 603688
+The total amount of wall time                        = 287.098738
+The maximum resident set size (KB)                   = 603820
 
 Test 038 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_smoke_conus13km_hrrr_warm
 Checking test 039 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1242,14 +1242,14 @@ Checking test 039 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 284.634687
-The maximum resident set size (KB)                   = 615816
+The total amount of wall time                        = 297.838501
+The maximum resident set size (KB)                   = 615872
 
 Test 039 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmg
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_csawmg
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_csawmg
 Checking test 040 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1260,14 +1260,14 @@ Checking test 040 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 361.051243
-The maximum resident set size (KB)                   = 488184
+The total amount of wall time                        = 363.413531
+The maximum resident set size (KB)                   = 488284
 
 Test 040 control_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_csawmgt
 Checking test 041 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1278,14 +1278,14 @@ Checking test 041 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 358.478333
-The maximum resident set size (KB)                   = 488172
+The total amount of wall time                        = 368.880827
+The maximum resident set size (KB)                   = 488308
 
 Test 041 control_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_flake
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_flake
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_flake
 Checking test 042 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1296,14 +1296,14 @@ Checking test 042 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 236.603086
-The maximum resident set size (KB)                   = 492808
+The total amount of wall time                        = 235.557966
+The maximum resident set size (KB)                   = 492760
 
 Test 042 control_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_ras
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_ras
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_ras
 Checking test 043 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1314,40 +1314,40 @@ Checking test 043 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 193.997094
-The maximum resident set size (KB)                   = 456744
+The total amount of wall time                        = 194.821611
+The maximum resident set size (KB)                   = 456592
 
 Test 043 control_ras PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wam
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_wam
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_wam
 Checking test 044 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 113.098498
-The maximum resident set size (KB)                   = 169272
+The total amount of wall time                        = 114.647637
+The maximum resident set size (KB)                   = 169276
 
 Test 044 control_wam PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_debug
 Checking test 045 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.394510
-The maximum resident set size (KB)                   = 588384
+The total amount of wall time                        = 155.355318
+The maximum resident set size (KB)                   = 588428
 
 Test 045 control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_CubedSphereGrid_debug
 Checking test 046 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1374,415 +1374,415 @@ Checking test 046 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 153.307732
-The maximum resident set size (KB)                   = 586752
+The total amount of wall time                        = 154.732542
+The maximum resident set size (KB)                   = 586756
 
 Test 046 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_wrtGauss_netcdf_parallel_debug
 Checking test 047 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 146.273738
-The maximum resident set size (KB)                   = 588240
+The total amount of wall time                        = 147.685827
+The maximum resident set size (KB)                   = 588324
 
 Test 047 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_stochy_debug
 Checking test 048 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.582406
-The maximum resident set size (KB)                   = 591636
+The total amount of wall time                        = 165.822686
+The maximum resident set size (KB)                   = 591824
 
 Test 048 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_lndp_debug
 Checking test 049 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 148.656290
-The maximum resident set size (KB)                   = 588984
+The total amount of wall time                        = 150.731981
+The maximum resident set size (KB)                   = 589008
 
 Test 049 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_csawmg_debug
 Checking test 050 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 234.057765
-The maximum resident set size (KB)                   = 628032
+The total amount of wall time                        = 235.657526
+The maximum resident set size (KB)                   = 628040
 
 Test 050 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_csawmgt_debug
 Checking test 051 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 232.543489
-The maximum resident set size (KB)                   = 627832
+The total amount of wall time                        = 231.633872
+The maximum resident set size (KB)                   = 627920
 
 Test 051 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_ras_debug
 Checking test 052 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 148.903843
-The maximum resident set size (KB)                   = 598880
+The total amount of wall time                        = 150.182188
+The maximum resident set size (KB)                   = 598928
 
 Test 052 control_ras_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_diag_debug
 Checking test 053 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 153.739521
-The maximum resident set size (KB)                   = 643988
+The total amount of wall time                        = 155.056721
+The maximum resident set size (KB)                   = 643912
 
 Test 053 control_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_debug_p8
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_debug_p8
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_debug_p8
 Checking test 054 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.463769
-The maximum resident set size (KB)                   = 973244
+The total amount of wall time                        = 176.604161
+The maximum resident set size (KB)                   = 973268
 
 Test 054 control_debug_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_thompson_debug
 Checking test 055 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 177.360286
-The maximum resident set size (KB)                   = 946148
+The total amount of wall time                        = 177.370101
+The maximum resident set size (KB)                   = 946164
 
 Test 055 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_thompson_no_aero_debug
 Checking test 056 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.098907
-The maximum resident set size (KB)                   = 941196
+The total amount of wall time                        = 173.147286
+The maximum resident set size (KB)                   = 941224
 
 Test 056 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_thompson_extdiag_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_thompson_extdiag_debug
 Checking test 057 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 183.477209
-The maximum resident set size (KB)                   = 973808
+The total amount of wall time                        = 186.149736
+The maximum resident set size (KB)                   = 973984
 
 Test 057 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_thompson_progcld_thompson_debug
 Checking test 058 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 176.621999
-The maximum resident set size (KB)                   = 946116
+The total amount of wall time                        = 175.314974
+The maximum resident set size (KB)                   = 946128
 
 Test 058 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/regional_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/regional_debug
 Checking test 059 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 249.732860
-The maximum resident set size (KB)                   = 554152
+The total amount of wall time                        = 251.179797
+The maximum resident set size (KB)                   = 554268
 
 Test 059 regional_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_control_debug
 Checking test 060 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 273.686028
-The maximum resident set size (KB)                   = 951820
+The total amount of wall time                        = 278.244667
+The maximum resident set size (KB)                   = 951944
 
 Test 060 rap_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_unified_drag_suite_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_unified_drag_suite_debug
 Checking test 061 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 274.039303
-The maximum resident set size (KB)                   = 951920
+The total amount of wall time                        = 272.298966
+The maximum resident set size (KB)                   = 951928
 
 Test 061 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_diag_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_diag_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_diag_debug
 Checking test 062 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.646330
-The maximum resident set size (KB)                   = 1035488
+The total amount of wall time                        = 290.473689
+The maximum resident set size (KB)                   = 1035292
 
 Test 062 rap_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_cires_ugwp_debug
 Checking test 063 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 277.129039
-The maximum resident set size (KB)                   = 956464
+The total amount of wall time                        = 290.566477
+The maximum resident set size (KB)                   = 956412
 
 Test 063 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_unified_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_unified_ugwp_debug
 Checking test 064 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 277.596315
-The maximum resident set size (KB)                   = 952024
+The total amount of wall time                        = 287.918303
+The maximum resident set size (KB)                   = 951876
 
 Test 064 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_lndp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_lndp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_lndp_debug
 Checking test 065 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 275.612365
-The maximum resident set size (KB)                   = 955536
+The total amount of wall time                        = 276.474795
+The maximum resident set size (KB)                   = 955436
 
 Test 065 rap_lndp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_flake_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_flake_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_flake_debug
 Checking test 066 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 273.967573
-The maximum resident set size (KB)                   = 951952
+The total amount of wall time                        = 272.990485
+The maximum resident set size (KB)                   = 951804
 
 Test 066 rap_flake_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_progcld_thompson_debug
 Checking test 067 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 274.306104
-The maximum resident set size (KB)                   = 951784
+The total amount of wall time                        = 274.461644
+The maximum resident set size (KB)                   = 951808
 
 Test 067 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_noah_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_noah_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_noah_debug
 Checking test 068 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 266.081215
-The maximum resident set size (KB)                   = 950296
+The total amount of wall time                        = 267.714606
+The maximum resident set size (KB)                   = 950252
 
 Test 068 rap_noah_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_rrtmgp_debug
 Checking test 069 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 452.567067
-The maximum resident set size (KB)                   = 1074656
+The total amount of wall time                        = 454.141161
+The maximum resident set size (KB)                   = 1074616
 
 Test 069 rap_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_sfcdiff_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_sfcdiff_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_sfcdiff_debug
 Checking test 070 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 273.735490
-The maximum resident set size (KB)                   = 953896
+The total amount of wall time                        = 274.774357
+The maximum resident set size (KB)                   = 953864
 
 Test 070 rap_sfcdiff_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 071 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 440.702760
-The maximum resident set size (KB)                   = 953512
+The total amount of wall time                        = 441.195957
+The maximum resident set size (KB)                   = 953580
 
 Test 071 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/rrfs_v1beta_debug
 Checking test 072 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 269.886059
-The maximum resident set size (KB)                   = 950136
+The total amount of wall time                        = 269.681109
+The maximum resident set size (KB)                   = 950192
 
 Test 072 rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wam_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/control_wam_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/control_wam_debug
 Checking test 073 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 273.075931
-The maximum resident set size (KB)                   = 199308
+The total amount of wall time                        = 274.410780
+The maximum resident set size (KB)                   = 199172
 
 Test 073 control_wam_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_atm
 Checking test 074 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 350.238124
-The maximum resident set size (KB)                   = 647152
+The total amount of wall time                        = 409.174796
+The maximum resident set size (KB)                   = 646924
 
 Test 074 hafs_regional_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_atm_thompson_gfdlsf
 Checking test 075 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 394.468240
-The maximum resident set size (KB)                   = 1004796
+The total amount of wall time                        = 416.942608
+The maximum resident set size (KB)                   = 1003256
 
 Test 075 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_ocn
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_atm_ocn
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_atm_ocn
 Checking test 076 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1791,28 +1791,28 @@ Checking test 076 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 540.469459
-The maximum resident set size (KB)                   = 667528
+The total amount of wall time                        = 571.655947
+The maximum resident set size (KB)                   = 667444
 
 Test 076 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_wav
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_atm_wav
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_atm_wav
 Checking test 077 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 950.160980
-The maximum resident set size (KB)                   = 664028
+The total amount of wall time                        = 975.307579
+The maximum resident set size (KB)                   = 664188
 
 Test 077 hafs_regional_atm_wav PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_atm_ocn_wav
 Checking test 078 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1821,28 +1821,28 @@ Checking test 078 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 1014.454222
-The maximum resident set size (KB)                   = 680776
+The total amount of wall time                        = 1169.309900
+The maximum resident set size (KB)                   = 680916
 
 Test 078 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_1nest_atm
 Checking test 079 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 382.817989
-The maximum resident set size (KB)                   = 244744
+The total amount of wall time                        = 388.401246
+The maximum resident set size (KB)                   = 245056
 
 Test 079 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_telescopic_2nests_atm
 Checking test 080 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1851,56 +1851,56 @@ Checking test 080 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 399.967171
-The maximum resident set size (KB)                   = 247028
+The total amount of wall time                        = 411.237758
+The maximum resident set size (KB)                   = 247160
 
 Test 080 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_global_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_global_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_global_1nest_atm
 Checking test 081 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 172.194871
-The maximum resident set size (KB)                   = 147528
+The total amount of wall time                        = 174.172309
+The maximum resident set size (KB)                   = 147380
 
 Test 081 hafs_global_1nest_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_specified_moving_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_specified_moving_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_specified_moving_1nest_atm
 Checking test 082 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 239.345859
-The maximum resident set size (KB)                   = 251824
+The total amount of wall time                        = 244.266917
+The maximum resident set size (KB)                   = 252160
 
 Test 082 hafs_regional_specified_moving_1nest_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_storm_following_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_storm_following_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_storm_following_1nest_atm
 Checking test 083 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 226.513099
-The maximum resident set size (KB)                   = 252612
+The total amount of wall time                        = 231.438097
+The maximum resident set size (KB)                   = 251808
 
 Test 083 hafs_regional_storm_following_1nest_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 084 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1909,14 +1909,14 @@ Checking test 084 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 265.764948
-The maximum resident set size (KB)                   = 279036
+The total amount of wall time                        = 275.087385
+The maximum resident set size (KB)                   = 278836
 
 Test 084 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 085 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1927,26 +1927,26 @@ Checking test 085 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 556.141327
-The maximum resident set size (KB)                   = 294560
+The total amount of wall time                        = 567.439629
+The maximum resident set size (KB)                   = 294824
 
 Test 085 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_global_storm_following_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_13122/hafs_global_storm_following_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_41021/hafs_global_storm_following_1nest_atm
 Checking test 086 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 68.182620
-The maximum resident set size (KB)                   = 165944
+The total amount of wall time                        = 69.948751
+The maximum resident set size (KB)                   = 165872
 
 Test 086 hafs_global_storm_following_1nest_atm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 03:50:23 UTC 2022
-Elapsed time: 00h:39m:51s. Have a nice day!
+Wed May 25 03:17:11 UTC 2022
+Elapsed time: 01h:05m:34s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,25 +1,25 @@
-Fri May 20 14:04:07 UTC 2022
+Wed May 25 02:11:21 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 2385 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 575 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1120 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 2368 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 587 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1111 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 004 elapsed time 1301 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1209 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 887 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 447 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 336 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 357 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 259 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 1814 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 1773 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 811 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 314 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 1481 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 1035 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1007 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 881 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 469 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 340 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 358 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 287 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 1795 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 1755 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 787 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 315 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 1480 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 1028 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 443.489384
-[0] The maximum resident set size (KB)                   = 1463072
+[0] The total amount of wall time                        = 443.280173
+[0] The maximum resident set size (KB)                   = 1461836
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_2threads_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -146,14 +146,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 489.098827
-[0] The maximum resident set size (KB)                   = 2191012
+[0] The total amount of wall time                        = 489.396386
+[0] The maximum resident set size (KB)                   = 2200252
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_decomp_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -207,14 +207,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 438.581731
-[0] The maximum resident set size (KB)                   = 1625724
+[0] The total amount of wall time                        = 440.836393
+[0] The maximum resident set size (KB)                   = 1627328
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_mpi_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -268,14 +268,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 370.530077
-[0] The maximum resident set size (KB)                   = 1267816
+[0] The total amount of wall time                        = 370.783893
+[0] The maximum resident set size (KB)                   = 1264172
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_bmark_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_bmark_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_bmark_p8
 Checking test 005 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -321,14 +321,14 @@ Checking test 005 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1313.887101
-[0] The maximum resident set size (KB)                   = 2972516
+[0] The total amount of wall time                        = 1346.714829
+[0] The maximum resident set size (KB)                   = 2970944
 
 Test 005 cpld_bmark_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_c96_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_control_c96_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_control_c96_p8
 Checking test 006 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 430.121181
-[0] The maximum resident set size (KB)                   = 1457324
+[0] The total amount of wall time                        = 436.883425
+[0] The maximum resident set size (KB)                   = 1460232
 
 Test 006 cpld_control_c96_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_c96_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_restart_c96_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_restart_c96_p8
 Checking test 007 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -449,14 +449,14 @@ Checking test 007 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 258.038045
-[0] The maximum resident set size (KB)                   = 1425344
+[0] The total amount of wall time                        = 258.520744
+[0] The maximum resident set size (KB)                   = 1420004
 
 Test 007 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_control_c192_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -507,14 +507,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-[0] The total amount of wall time                        = 1321.212812
-[0] The maximum resident set size (KB)                   = 1437216
+[0] The total amount of wall time                        = 1325.623456
+[0] The maximum resident set size (KB)                   = 1438496
 
 Test 008 cpld_control_c192_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_restart_c192_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -565,14 +565,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-[0] The total amount of wall time                        = 876.982128
-[0] The maximum resident set size (KB)                   = 1647500
+[0] The total amount of wall time                        = 883.002024
+[0] The maximum resident set size (KB)                   = 1645440
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_c384_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_control_c384_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_control_c384_p8
 Checking test 010 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -616,14 +616,14 @@ Checking test 010 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 1427.399612
-[0] The maximum resident set size (KB)                   = 2966796
+[0] The total amount of wall time                        = 1421.897168
+[0] The maximum resident set size (KB)                   = 2966868
 
 Test 010 cpld_control_c384_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_control_c384_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_restart_c384_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_restart_c384_p8
 Checking test 011 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -667,14 +667,14 @@ Checking test 011 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 885.062377
-[0] The maximum resident set size (KB)                   = 2937164
+[0] The total amount of wall time                        = 877.930987
+[0] The maximum resident set size (KB)                   = 2946836
 
 Test 011 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/cpld_debug_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/cpld_debug_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -725,14 +725,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 1287.441006
-[0] The maximum resident set size (KB)                   = 1520868
+[0] The total amount of wall time                        = 1290.068554
+[0] The maximum resident set size (KB)                   = 1516044
 
 Test 012 cpld_debug_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control
 Checking test 013 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -779,14 +779,14 @@ Checking test 013 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 148.172847
-[0] The maximum resident set size (KB)                   = 467704
+[0] The total amount of wall time                        = 143.526915
+[0] The maximum resident set size (KB)                   = 466604
 
 Test 013 control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_decomp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_decomp
 Checking test 014 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -829,28 +829,28 @@ Checking test 014 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 155.279421
-[0] The maximum resident set size (KB)                   = 463760
+[0] The total amount of wall time                        = 153.947038
+[0] The maximum resident set size (KB)                   = 458144
 
 Test 014 control_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_2dwrtdecomp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_2dwrtdecomp
 Checking test 015 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-[0] The total amount of wall time                        = 142.793370
-[0] The maximum resident set size (KB)                   = 464216
+[0] The total amount of wall time                        = 138.731669
+[0] The maximum resident set size (KB)                   = 463956
 
 Test 015 control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_2threads
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -893,14 +893,14 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 135.766517
-[0] The maximum resident set size (KB)                   = 518944
+[0] The total amount of wall time                        = 134.587660
+[0] The maximum resident set size (KB)                   = 522580
 
 Test 016 control_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -939,14 +939,14 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 77.680619
-[0] The maximum resident set size (KB)                   = 210040
+[0] The total amount of wall time                        = 77.881953
+[0] The maximum resident set size (KB)                   = 208496
 
 Test 017 control_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_fhzero
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -989,14 +989,14 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 139.211018
-[0] The maximum resident set size (KB)                   = 464112
+[0] The total amount of wall time                        = 141.254122
+[0] The maximum resident set size (KB)                   = 461872
 
 Test 018 control_fhzero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1023,14 +1023,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 139.193307
-[0] The maximum resident set size (KB)                   = 464480
+[0] The total amount of wall time                        = 140.211887
+[0] The maximum resident set size (KB)                   = 464592
 
 Test 019 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_latlon
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_latlon
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1041,17 +1041,17 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 146.372113
-[0] The maximum resident set size (KB)                   = 464388
+[0] The total amount of wall time                        = 145.526869
+[0] The maximum resident set size (KB)                   = 468528
 
 Test 020 control_latlon PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1059,14 +1059,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 150.618465
-[0] The maximum resident set size (KB)                   = 462460
+[0] The total amount of wall time                        = 146.747328
+[0] The maximum resident set size (KB)                   = 464080
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c48
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_c48
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1105,14 +1105,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 408.069881
-[0] The maximum resident set size (KB)                   = 664740
+[0] The total amount of wall time                        = 449.853832
+[0] The maximum resident set size (KB)                   = 664580
 
 Test 022 control_c48 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c192
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_c192
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1123,14 +1123,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 558.961415
-[0] The maximum resident set size (KB)                   = 567984
+[0] The total amount of wall time                        = 570.117844
+[0] The maximum resident set size (KB)                   = 565024
 
 Test 023 control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c384
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_c384
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1141,14 +1141,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 561.068146
-[0] The maximum resident set size (KB)                   = 836868
+[0] The total amount of wall time                        = 560.456732
+[0] The maximum resident set size (KB)                   = 836124
 
 Test 024 control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 554.990030
-[0] The maximum resident set size (KB)                   = 983124
+[0] The total amount of wall time                        = 549.095924
+[0] The maximum resident set size (KB)                   = 985972
 
 Test 025 control_c384gdas PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_stochy
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_stochy
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1209,28 +1209,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 94.975146
-[0] The maximum resident set size (KB)                   = 470532
+[0] The total amount of wall time                        = 94.510339
+[0] The maximum resident set size (KB)                   = 466496
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_stochy
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_stochy_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 50.101328
-[0] The maximum resident set size (KB)                   = 262472
+[0] The total amount of wall time                        = 50.328800
+[0] The maximum resident set size (KB)                   = 267796
 
 Test 027 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_lndp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_lndp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1241,14 +1241,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 86.273293
-[0] The maximum resident set size (KB)                   = 467972
+[0] The total amount of wall time                        = 88.716045
+[0] The maximum resident set size (KB)                   = 467276
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_iovr4
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_iovr4
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1263,14 +1263,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 144.814187
-[0] The maximum resident set size (KB)                   = 467768
+[0] The total amount of wall time                        = 145.562024
+[0] The maximum resident set size (KB)                   = 464472
 
 Test 029 control_iovr4 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_iovr5
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_iovr5
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1285,14 +1285,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 149.123826
-[0] The maximum resident set size (KB)                   = 462296
+[0] The total amount of wall time                        = 145.290592
+[0] The maximum resident set size (KB)                   = 466672
 
 Test 030 control_iovr5 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1339,14 +1339,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 190.799247
-[0] The maximum resident set size (KB)                   = 844360
+[0] The total amount of wall time                        = 191.496288
+[0] The maximum resident set size (KB)                   = 846056
 
 Test 031 control_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8_lndp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_p8_lndp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1365,14 +1365,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-[0] The total amount of wall time                        = 354.154272
-[0] The maximum resident set size (KB)                   = 847196
+[0] The total amount of wall time                        = 355.211478
+[0] The maximum resident set size (KB)                   = 846188
 
 Test 032 control_p8_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_restart_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1411,14 +1411,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 101.785571
-[0] The maximum resident set size (KB)                   = 594956
+[0] The total amount of wall time                        = 101.934208
+[0] The maximum resident set size (KB)                   = 594364
 
 Test 033 control_restart_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_decomp_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1461,14 +1461,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 196.888207
-[0] The maximum resident set size (KB)                   = 839740
+[0] The total amount of wall time                        = 196.973419
+[0] The maximum resident set size (KB)                   = 842272
 
 Test 034 control_decomp_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_2threads_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1511,14 +1511,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 174.728014
-[0] The maximum resident set size (KB)                   = 928052
+[0] The total amount of wall time                        = 175.554117
+[0] The maximum resident set size (KB)                   = 922948
 
 Test 035 control_2threads_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_p8_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_p8_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1565,14 +1565,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 229.435553
-[0] The maximum resident set size (KB)                   = 966380
+[0] The total amount of wall time                        = 230.384893
+[0] The maximum resident set size (KB)                   = 963048
 
 Test 036 control_p8_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,42 +1583,42 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 375.233151
-[0] The maximum resident set size (KB)                   = 577656
+[0] The total amount of wall time                        = 374.014451
+[0] The maximum resident set size (KB)                   = 577816
 
 Test 037 regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 205.656308
-[0] The maximum resident set size (KB)                   = 584728
+[0] The total amount of wall time                        = 208.403222
+[0] The maximum resident set size (KB)                   = 583920
 
 Test 038 regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_control_2dwrtdecomp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 373.089733
-[0] The maximum resident set size (KB)                   = 582248
+[0] The total amount of wall time                        = 372.620572
+[0] The maximum resident set size (KB)                   = 580864
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_noquilt
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_noquilt
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1626,14 +1626,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 398.187709
-[0] The maximum resident set size (KB)                   = 611828
+[0] The total amount of wall time                        = 401.639506
+[0] The maximum resident set size (KB)                   = 613120
 
 Test 040 regional_noquilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_2threads
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1644,28 +1644,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 218.514446
-[0] The maximum resident set size (KB)                   = 583060
+[0] The total amount of wall time                        = 221.481612
+[0] The maximum resident set size (KB)                   = 582880
 
 Test 041 regional_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 374.719643
-[0] The maximum resident set size (KB)                   = 578236
+[0] The total amount of wall time                        = 372.796688
+[0] The maximum resident set size (KB)                   = 574300
 
 Test 042 regional_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_3km
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_3km
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-[0] The total amount of wall time                        = 313.370535
-[0] The maximum resident set size (KB)                   = 612920
+[0] The total amount of wall time                        = 309.005285
+[0] The maximum resident set size (KB)                   = 613452
 
 Test 043 regional_3km PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1730,14 +1730,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 473.200536
-[0] The maximum resident set size (KB)                   = 837996
+[0] The total amount of wall time                        = 477.694411
+[0] The maximum resident set size (KB)                   = 836236
 
 Test 044 rap_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1784,14 +1784,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 519.752806
-[0] The maximum resident set size (KB)                   = 950868
+[0] The total amount of wall time                        = 508.995080
+[0] The maximum resident set size (KB)                   = 948828
 
 Test 045 rap_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/regional_spp_sppt_shum_skeb
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_spp_sppt_shum_skeb
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1802,14 +1802,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-[0] The total amount of wall time                        = 265.064240
-[0] The maximum resident set size (KB)                   = 938820
+[0] The total amount of wall time                        = 263.232333
+[0] The maximum resident set size (KB)                   = 937840
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_2threads
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1856,14 +1856,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 441.983891
-[0] The maximum resident set size (KB)                   = 905140
+[0] The total amount of wall time                        = 445.800855
+[0] The maximum resident set size (KB)                   = 902872
 
 Test 047 rap_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1902,14 +1902,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 241.251902
-[0] The maximum resident set size (KB)                   = 590140
+[0] The total amount of wall time                        = 241.616034
+[0] The maximum resident set size (KB)                   = 591220
 
 Test 048 rap_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1956,14 +1956,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 467.402690
-[0] The maximum resident set size (KB)                   = 837404
+[0] The total amount of wall time                        = 467.937743
+[0] The maximum resident set size (KB)                   = 841800
 
 Test 049 rap_sfcdiff PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_sfcdiff_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2002,14 +2002,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 240.299285
-[0] The maximum resident set size (KB)                   = 593328
+[0] The total amount of wall time                        = 240.589897
+[0] The maximum resident set size (KB)                   = 590344
 
 Test 050 rap_sfcdiff_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hrrr_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hrrr_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2056,14 +2056,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 448.682510
-[0] The maximum resident set size (KB)                   = 840528
+[0] The total amount of wall time                        = 446.754012
+[0] The maximum resident set size (KB)                   = 840036
 
 Test 051 hrrr_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2110,14 +2110,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 459.737789
-[0] The maximum resident set size (KB)                   = 830992
+[0] The total amount of wall time                        = 468.034220
+[0] The maximum resident set size (KB)                   = 835320
 
 Test 052 rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1nssl
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_v1nssl
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2132,14 +2132,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 537.360343
-[0] The maximum resident set size (KB)                   = 526120
+[0] The total amount of wall time                        = 525.454884
+[0] The maximum resident set size (KB)                   = 524884
 
 Test 053 rrfs_v1nssl PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1nssl_nohailnoccn
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_v1nssl_nohailnoccn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2154,14 +2154,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 522.442957
-[0] The maximum resident set size (KB)                   = 513496
+[0] The total amount of wall time                        = 518.324388
+[0] The maximum resident set size (KB)                   = 513536
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2170,14 +2170,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 199.642885
-[0] The maximum resident set size (KB)                   = 667968
+[0] The total amount of wall time                        = 199.134120
+[0] The maximum resident set size (KB)                   = 665436
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2186,14 +2186,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 207.766819
-[0] The maximum resident set size (KB)                   = 670020
+[0] The total amount of wall time                        = 202.397462
+[0] The maximum resident set size (KB)                   = 669296
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2202,14 +2202,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 216.476040
-[0] The maximum resident set size (KB)                   = 682868
+[0] The total amount of wall time                        = 220.475190
+[0] The maximum resident set size (KB)                   = 676928
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2220,14 +2220,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 378.319332
-[0] The maximum resident set size (KB)                   = 524456
+[0] The total amount of wall time                        = 377.731911
+[0] The maximum resident set size (KB)                   = 526364
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2238,14 +2238,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 371.233418
-[0] The maximum resident set size (KB)                   = 524356
+[0] The total amount of wall time                        = 377.729164
+[0] The maximum resident set size (KB)                   = 525860
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_flake
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_flake
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2256,14 +2256,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 259.530115
-[0] The maximum resident set size (KB)                   = 533720
+[0] The total amount of wall time                        = 255.520127
+[0] The maximum resident set size (KB)                   = 531828
 
 Test 060 control_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_ras
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_ras
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2274,14 +2274,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 196.515564
-[0] The maximum resident set size (KB)                   = 498600
+[0] The total amount of wall time                        = 196.896231
+[0] The maximum resident set size (KB)                   = 493208
 
 Test 061 control_ras PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_thompson
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 267.136738
-[0] The maximum resident set size (KB)                   = 850572
+[0] The total amount of wall time                        = 264.935543
+[0] The maximum resident set size (KB)                   = 851204
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2310,54 +2310,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 251.355929
-[0] The maximum resident set size (KB)                   = 842192
+[0] The total amount of wall time                        = 247.375474
+[0] The maximum resident set size (KB)                   = 840712
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wam
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_wam
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-[0] The total amount of wall time                        = 121.563258
-[0] The maximum resident set size (KB)                   = 232280
+[0] The total amount of wall time                        = 128.318143
+[0] The maximum resident set size (KB)                   = 231564
 
 Test 064 control_wam PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 167.697635
-[0] The maximum resident set size (KB)                   = 630364
+[0] The total amount of wall time                        = 167.629149
+[0] The maximum resident set size (KB)                   = 629084
 
 Test 065 control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_2threads_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 156.534392
-[0] The maximum resident set size (KB)                   = 685280
+[0] The total amount of wall time                        = 157.451898
+[0] The maximum resident set size (KB)                   = 683656
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2384,391 +2384,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 181.928617
-[0] The maximum resident set size (KB)                   = 630724
+[0] The total amount of wall time                        = 182.029355
+[0] The maximum resident set size (KB)                   = 631904
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 170.478495
-[0] The maximum resident set size (KB)                   = 632120
+[0] The total amount of wall time                        = 171.297594
+[0] The maximum resident set size (KB)                   = 627844
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.554920
-[0] The maximum resident set size (KB)                   = 635232
+[0] The total amount of wall time                        = 192.153632
+[0] The maximum resident set size (KB)                   = 634444
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 172.467084
-[0] The maximum resident set size (KB)                   = 635096
+[0] The total amount of wall time                        = 173.185166
+[0] The maximum resident set size (KB)                   = 635088
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 270.467645
-[0] The maximum resident set size (KB)                   = 666420
+[0] The total amount of wall time                        = 270.593959
+[0] The maximum resident set size (KB)                   = 668720
 
 Test 071 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 268.027376
-[0] The maximum resident set size (KB)                   = 668540
+[0] The total amount of wall time                        = 266.474370
+[0] The maximum resident set size (KB)                   = 665648
 
 Test 072 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 174.718915
-[0] The maximum resident set size (KB)                   = 641708
+[0] The total amount of wall time                        = 174.856926
+[0] The maximum resident set size (KB)                   = 644376
 
 Test 073 control_ras_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 178.301843
-[0] The maximum resident set size (KB)                   = 687968
+[0] The total amount of wall time                        = 178.689014
+[0] The maximum resident set size (KB)                   = 687412
 
 Test 074 control_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_debug_p8
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_debug_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.977691
-[0] The maximum resident set size (KB)                   = 1010044
+[0] The total amount of wall time                        = 191.993150
+[0] The maximum resident set size (KB)                   = 1012028
 
 Test 075 control_debug_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 199.327866
-[0] The maximum resident set size (KB)                   = 993256
+[0] The total amount of wall time                        = 199.197785
+[0] The maximum resident set size (KB)                   = 992780
 
 Test 076 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.563618
-[0] The maximum resident set size (KB)                   = 984676
+[0] The total amount of wall time                        = 191.566923
+[0] The maximum resident set size (KB)                   = 986484
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_thompson_extdiag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 210.700740
-[0] The maximum resident set size (KB)                   = 1022496
+[0] The total amount of wall time                        = 208.940385
+[0] The maximum resident set size (KB)                   = 1020920
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 199.825815
-[0] The maximum resident set size (KB)                   = 988584
+[0] The total amount of wall time                        = 198.846621
+[0] The maximum resident set size (KB)                   = 991048
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/fv3_regional_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/regional_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-[0] The total amount of wall time                        = 282.891048
-[0] The maximum resident set size (KB)                   = 609440
+[0] The total amount of wall time                        = 283.525082
+[0] The maximum resident set size (KB)                   = 610324
 
 Test 080 regional_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 307.854713
-[0] The maximum resident set size (KB)                   = 998868
+[0] The total amount of wall time                        = 309.126663
+[0] The maximum resident set size (KB)                   = 999300
 
 Test 081 rap_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_unified_drag_suite_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 308.113419
-[0] The maximum resident set size (KB)                   = 998812
+[0] The total amount of wall time                        = 307.483034
+[0] The maximum resident set size (KB)                   = 998260
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_diag_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_diag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 323.910450
-[0] The maximum resident set size (KB)                   = 1081952
+[0] The total amount of wall time                        = 323.744186
+[0] The maximum resident set size (KB)                   = 1081124
 
 Test 083 rap_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 313.775821
-[0] The maximum resident set size (KB)                   = 999332
+[0] The total amount of wall time                        = 314.203824
+[0] The maximum resident set size (KB)                   = 999892
 
 Test 084 rap_cires_ugwp_debug PASS
 
-Test 085 rap_unified_ugwp_debug FAIL
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_unified_ugwp_debug
+Checking test 085 rap_unified_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 315.012803
+[0] The maximum resident set size (KB)                   = 1001904
+
+Test 085 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 309.880364
-[0] The maximum resident set size (KB)                   = 998452
+[0] The total amount of wall time                        = 312.256143
+[0] The maximum resident set size (KB)                   = 999244
 
 Test 086 rap_lndp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_flake_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_flake_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 307.412408
-[0] The maximum resident set size (KB)                   = 1001260
+[0] The total amount of wall time                        = 308.933272
+[0] The maximum resident set size (KB)                   = 994376
 
 Test 087 rap_flake_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 308.238966
-[0] The maximum resident set size (KB)                   = 996872
+[0] The total amount of wall time                        = 309.541339
+[0] The maximum resident set size (KB)                   = 999736
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_noah_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_noah_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 304.094919
-[0] The maximum resident set size (KB)                   = 1001388
+[0] The total amount of wall time                        = 303.912293
+[0] The maximum resident set size (KB)                   = 998712
 
 Test 089 rap_noah_debug PASS
 
-Test 090 rap_rrtmgp_debug FAIL
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_rrtmgp_debug
+Checking test 090 rap_rrtmgp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 523.039905
+[0] The maximum resident set size (KB)                   = 1116024
+
+Test 090 rap_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_sfcdiff_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_sfcdiff_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 308.898664
-[0] The maximum resident set size (KB)                   = 1000848
+[0] The total amount of wall time                        = 309.008844
+[0] The maximum resident set size (KB)                   = 998300
 
 Test 091 rap_sfcdiff_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 512.237083
-[0] The maximum resident set size (KB)                   = 998932
+[0] The total amount of wall time                        = 512.139664
+[0] The maximum resident set size (KB)                   = 1003012
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 306.986077
-[0] The maximum resident set size (KB)                   = 995656
+[0] The total amount of wall time                        = 307.282992
+[0] The maximum resident set size (KB)                   = 998948
 
 Test 093 rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_wam_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_wam_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-[0] The total amount of wall time                        = 322.265710
-[0] The maximum resident set size (KB)                   = 251532
+[0] The total amount of wall time                        = 322.148636
+[0] The maximum resident set size (KB)                   = 254752
 
 Test 094 control_wam_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing HURPRS.GrbF06 .........OK
 
-[0] The total amount of wall time                        = 279.275744
-[0] The maximum resident set size (KB)                   = 720016
+[0] The total amount of wall time                        = 274.933758
+[0] The maximum resident set size (KB)                   = 716692
 
 Test 095 hafs_regional_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-[0] The total amount of wall time                        = 304.144947
-[0] The maximum resident set size (KB)                   = 1071484
+[0] The total amount of wall time                        = 324.092515
+[0] The maximum resident set size (KB)                   = 1077064
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2777,28 +2801,28 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 382.950459
-[0] The maximum resident set size (KB)                   = 749272
+[0] The total amount of wall time                        = 392.866239
+[0] The maximum resident set size (KB)                   = 748212
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_atm_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 920.560979
-[0] The maximum resident set size (KB)                   = 739360
+[0] The total amount of wall time                        = 935.824089
+[0] The maximum resident set size (KB)                   = 745776
 
 Test 098 hafs_regional_atm_wav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2807,28 +2831,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 1043.103647
-[0] The maximum resident set size (KB)                   = 763528
+[0] The total amount of wall time                        = 1038.867266
+[0] The maximum resident set size (KB)                   = 758664
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 405.427152
-[0] The maximum resident set size (KB)                   = 322340
+[0] The total amount of wall time                        = 410.296486
+[0] The maximum resident set size (KB)                   = 322180
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2837,28 +2861,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 419.752828
-[0] The maximum resident set size (KB)                   = 332896
+[0] The total amount of wall time                        = 420.299355
+[0] The maximum resident set size (KB)                   = 330988
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_global_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_global_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 184.722200
-[0] The maximum resident set size (KB)                   = 211308
+[0] The total amount of wall time                        = 190.954916
+[0] The maximum resident set size (KB)                   = 207348
 
 Test 102 hafs_global_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_global_multiple_4nests_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_global_multiple_4nests_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2869,92 +2893,92 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing sfc.nest04.f006.nc .........OK
  Comparing sfc.nest04.f006.nc .........OK
  Comparing atm.nest05.f006.nc .........OK
- Comparing sfc.nest05.f006.nc .........OK
+ Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 559.328751
-[0] The maximum resident set size (KB)                   = 295832
+[0] The total amount of wall time                        = 560.950553
+[0] The maximum resident set size (KB)                   = 263660
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_specified_moving_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_specified_moving_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 245.645719
-[0] The maximum resident set size (KB)                   = 324812
+[0] The total amount of wall time                        = 245.797131
+[0] The maximum resident set size (KB)                   = 324372
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_storm_following_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_storm_following_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 229.755181
-[0] The maximum resident set size (KB)                   = 326092
+[0] The total amount of wall time                        = 232.136262
+[0] The maximum resident set size (KB)                   = 324756
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-[0] The total amount of wall time                        = 267.611443
-[0] The maximum resident set size (KB)                   = 346928
+[0] The total amount of wall time                        = 265.499603
+[0] The maximum resident set size (KB)                   = 347576
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
- Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest02.f006.nc .........OK
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 676.096919
-[0] The maximum resident set size (KB)                   = 370072
+[0] The total amount of wall time                        = 688.959571
+[0] The maximum resident set size (KB)                   = 366228
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_global_storm_following_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_global_storm_following_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
- Comparing sfc.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 77.782248
-[0] The maximum resident set size (KB)                   = 226168
+[0] The total amount of wall time                        = 79.692968
+[0] The maximum resident set size (KB)                   = 226004
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_docn
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_docn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2962,133 +2986,133 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 379.766910
-[0] The maximum resident set size (KB)                   = 767464
+[0] The total amount of wall time                        = 376.783922
+[0] The maximum resident set size (KB)                   = 761220
 
 Test 109 hafs_regional_docn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_docn_oisst
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_docn_oisst
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 381.115277
-[0] The maximum resident set size (KB)                   = 741052
+[0] The total amount of wall time                        = 384.384155
+[0] The maximum resident set size (KB)                   = 742136
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/hafs_regional_datm_cdeps
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/hafs_regional_datm_cdeps
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1096.195619
-[0] The maximum resident set size (KB)                   = 889496
+[0] The total amount of wall time                        = 1094.902872
+[0] The maximum resident set size (KB)                   = 888196
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 178.792400
-[0] The maximum resident set size (KB)                   = 724272
+[0] The total amount of wall time                        = 175.510983
+[0] The maximum resident set size (KB)                   = 724008
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 119.165641
-[0] The maximum resident set size (KB)                   = 744472
+[0] The total amount of wall time                        = 119.471040
+[0] The maximum resident set size (KB)                   = 723452
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.728925
-[0] The maximum resident set size (KB)                   = 625944
+[0] The total amount of wall time                        = 170.957191
+[0] The maximum resident set size (KB)                   = 629132
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_iau_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_iau_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.190883
-[0] The maximum resident set size (KB)                   = 628584
+[0] The total amount of wall time                        = 174.500505
+[0] The maximum resident set size (KB)                   = 625388
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_stochy_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_stochy_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.138286
-[0] The maximum resident set size (KB)                   = 625580
+[0] The total amount of wall time                        = 173.749023
+[0] The maximum resident set size (KB)                   = 625656
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 177.506017
-[0] The maximum resident set size (KB)                   = 724588
+[0] The total amount of wall time                        = 176.553259
+[0] The maximum resident set size (KB)                   = 725676
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.768032
-[0] The maximum resident set size (KB)                   = 625444
+[0] The total amount of wall time                        = 170.839203
+[0] The maximum resident set size (KB)                   = 627516
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3097,14 +3121,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 354.844118
-[0] The maximum resident set size (KB)                   = 561056
+[0] The total amount of wall time                        = 367.581013
+[0] The maximum resident set size (KB)                   = 556040
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3113,64 +3137,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 357.191580
-[0] The maximum resident set size (KB)                   = 524924
+[0] The total amount of wall time                        = 363.043212
+[0] The maximum resident set size (KB)                   = 522360
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_multiple_files_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 176.044310
-[0] The maximum resident set size (KB)                   = 724556
+[0] The total amount of wall time                        = 177.573992
+[0] The maximum resident set size (KB)                   = 725972
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_3072x1536_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_3072x1536_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 253.981213
-[0] The maximum resident set size (KB)                   = 1836828
+[0] The total amount of wall time                        = 253.874182
+[0] The maximum resident set size (KB)                   = 1837748
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_gfs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_gfs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 252.680922
-[0] The maximum resident set size (KB)                   = 1836364
+[0] The total amount of wall time                        = 256.849162
+[0] The maximum resident set size (KB)                   = 1837984
 
 Test 123 datm_cdeps_gfs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 505.056376
-[0] The maximum resident set size (KB)                   = 731460
+[0] The total amount of wall time                        = 508.253031
+[0] The maximum resident set size (KB)                   = 730608
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3214,14 +3238,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 91.488673
-[0] The maximum resident set size (KB)                   = 478544
+[0] The total amount of wall time                        = 93.953981
+[0] The maximum resident set size (KB)                   = 470264
 
 Test 125 control_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_c384gdas_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_c384gdas_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_c384gdas_wav
 Checking test 126 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3267,14 +3291,14 @@ Checking test 126 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-[0] The total amount of wall time                        = 626.659260
-[0] The maximum resident set size (KB)                   = 992788
+[0] The total amount of wall time                        = 632.150625
+[0] The maximum resident set size (KB)                   = 996836
 
 Test 126 control_c384gdas_wav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/control_atm_aerosols
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_16137/control_atm_aerosols
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_15848/control_atm_aerosols
 Checking test 127 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3318,55 +3342,12 @@ Checking test 127 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 391.676793
-[0] The maximum resident set size (KB)                   = 1045160
+[0] The total amount of wall time                        = 386.952424
+[0] The maximum resident set size (KB)                   = 1042828
 
 Test 127 control_atm_aerosols PASS
 
-FAILED TESTS: 
-Test rap_unified_ugwp_debug 085 failed in run_test failed 
-Test rap_rrtmgp_debug 090 failed in run_test failed 
-
-REGRESSION TEST FAILED
-Fri May 20 15:51:28 UTC 2022
-Elapsed time: 01h:47m:23s. Have a nice day!
-
-
-
-Fri May 20 17:22:16 UTC 2022
-Start Regression test
-
-Compile 001 elapsed time 341 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 002 elapsed time 361 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_46116/rap_unified_ugwp_debug
-Checking test 001 rap_unified_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 312.994690
-[0] The maximum resident set size (KB)                   = 999428
-
-Test 001 rap_unified_ugwp_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220519/rap_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_46116/rap_rrtmgp_debug
-Checking test 002 rap_rrtmgp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 519.665778
-[0] The maximum resident set size (KB)                   = 1109288
-
-Test 002 rap_rrtmgp_debug PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May 20 17:39:54 UTC 2022
-Elapsed time: 00h:17m:40s. Have a nice day!
+Wed May 25 04:41:20 UTC 2022
+Elapsed time: 02h:30m:02s. Have a nice day!


### PR DESCRIPTION
# PR Checklist

- [X] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [X] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [X] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Description

This PR only contains minor bugfixes for CCPP-framework and CCPP-physics and should not affect UFS RTs at all (will test to confirm)

### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/issues/927
https://github.com/NCAR/ccpp-framework/issues/450

## Testing

All tests in rt.conf pass with existing baselines.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [x] CI

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/924
https://github.com/NCAR/ccpp-framework/pull/451
https://github.com/NOAA-EMC/fv3atm/pull/541