### PR TITLE
Emergency fix: exponentiation instead of multiplication caused bad 2m temperatures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/SamuelTrahanNOAA/fv3atm
-  branch = catastrophic-typo
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/SamuelTrahanNOAA/fv3atm
+  branch = catastrophic-typo
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,16 +1,16 @@
-Sat Jun 11 05:56:36 MDT 2022
+Mon Jun 13 14:35:00 MDT 2022
 Start Regression test
 
-Compile 001 elapsed time 424 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 423 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 875 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 578 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 352 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 007 elapsed time 324 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 420 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 418 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 863 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 216 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 567 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 327 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 007 elapsed time 314 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -57,14 +57,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 274.090618
-0:The maximum resident set size (KB)                   = 433956
+0:The total amount of wall time                        = 275.450375
+0:The maximum resident set size (KB)                   = 433752
 
 Test 001 control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,14 +103,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 135.071093
-0:The maximum resident set size (KB)                   = 183236
+0:The total amount of wall time                        = 137.496927
+0:The maximum resident set size (KB)                   = 183520
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_c48
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_c48
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -149,14 +149,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 816.556024
-0:The maximum resident set size (KB)                   = 676628
+0:The total amount of wall time                        = 815.939224
+0:The maximum resident set size (KB)                   = 676560
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -167,14 +167,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 175.361635
-0:The maximum resident set size (KB)                   = 427804
+0:The total amount of wall time                        = 175.138762
+0:The maximum resident set size (KB)                   = 428052
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_flake
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_flake
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_flake
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -185,14 +185,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 328.902984
-0:The maximum resident set size (KB)                   = 486212
+0:The total amount of wall time                        = 355.203535
+0:The maximum resident set size (KB)                   = 486036
 
 Test 005 control_flake PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -203,14 +203,14 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 368.936083
-0:The maximum resident set size (KB)                   = 795980
+0:The total amount of wall time                        = 377.530275
+0:The maximum resident set size (KB)                   = 796060
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_thompson_no_aero
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_no_aero
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -221,14 +221,14 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 357.247640
-0:The maximum resident set size (KB)                   = 789868
+0:The total amount of wall time                        = 376.998256
+0:The maximum resident set size (KB)                   = 789904
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_ras
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_ras
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_ras
 Checking test 008 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -239,14 +239,14 @@ Checking test 008 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 290.383580
-0:The maximum resident set size (KB)                   = 446284
+0:The total amount of wall time                        = 291.405494
+0:The maximum resident set size (KB)                   = 446476
 
 Test 008 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_p8
 Checking test 009 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -293,14 +293,14 @@ Checking test 009 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 313.356784
-0:The maximum resident set size (KB)                   = 818580
+0:The total amount of wall time                        = 328.196610
+0:The maximum resident set size (KB)                   = 818644
 
 Test 009 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_control
 Checking test 010 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -347,14 +347,14 @@ Checking test 010 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 700.542221
-0:The maximum resident set size (KB)                   = 774840
+0:The total amount of wall time                        = 706.131387
+0:The maximum resident set size (KB)                   = 774848
 
 Test 010 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_2threads
 Checking test 011 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -401,14 +401,14 @@ Checking test 011 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1236.604214
-0:The maximum resident set size (KB)                   = 842928
+0:The total amount of wall time                        = 1241.509281
+0:The maximum resident set size (KB)                   = 842908
 
 Test 011 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_restart
 Checking test 012 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -447,14 +447,14 @@ Checking test 012 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 349.804076
-0:The maximum resident set size (KB)                   = 522932
+0:The total amount of wall time                        = 352.241829
+0:The maximum resident set size (KB)                   = 523496
 
 Test 012 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_sfcdiff
 Checking test 013 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -501,14 +501,14 @@ Checking test 013 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 705.182036
-0:The maximum resident set size (KB)                   = 774720
+0:The total amount of wall time                        = 705.273706
+0:The maximum resident set size (KB)                   = 774688
 
 Test 013 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_sfcdiff_restart
 Checking test 014 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -547,14 +547,14 @@ Checking test 014 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 350.251854
-0:The maximum resident set size (KB)                   = 522608
+0:The total amount of wall time                        = 356.818190
+0:The maximum resident set size (KB)                   = 522584
 
 Test 014 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/hrrr_control
 Checking test 015 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -601,14 +601,14 @@ Checking test 015 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 675.972227
-0:The maximum resident set size (KB)                   = 772232
+0:The total amount of wall time                        = 684.286927
+0:The maximum resident set size (KB)                   = 772228
 
 Test 015 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -655,14 +655,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 696.109207
-0:The maximum resident set size (KB)                   = 771920
+0:The total amount of wall time                        = 696.419602
+0:The maximum resident set size (KB)                   = 771880
 
 Test 016 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rrfs_conus13km_hrrr_warm
 Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -671,14 +671,14 @@ Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 320.343591
-0:The maximum resident set size (KB)                   = 593324
+0:The total amount of wall time                        = 319.806284
+0:The maximum resident set size (KB)                   = 593304
 
 Test 017 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rrfs_conus13km_radar_tten_warm
 Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -687,14 +687,14 @@ Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 319.683146
-0:The maximum resident set size (KB)                   = 595980
+0:The total amount of wall time                        = 321.771516
+0:The maximum resident set size (KB)                   = 595992
 
 Test 018 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rrfs_smoke_conus13km_hrrr_warm
 Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -703,236 +703,236 @@ Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 341.189288
-0:The maximum resident set size (KB)                   = 607248
+0:The total amount of wall time                        = 343.922769
+0:The maximum resident set size (KB)                   = 607352
 
 Test 019 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 81.048334
-0:The maximum resident set size (KB)                   = 424808
+0:The total amount of wall time                        = 81.059575
+0:The maximum resident set size (KB)                   = 424804
 
 Test 020 control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.721520
-0:The maximum resident set size (KB)                   = 482036
+0:The total amount of wall time                        = 92.121149
+0:The maximum resident set size (KB)                   = 482004
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/fv3_regional_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/fv3_regional_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 131.870403
-0:The maximum resident set size (KB)                   = 536828
+0:The total amount of wall time                        = 132.228170
+0:The maximum resident set size (KB)                   = 536824
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.271084
-0:The maximum resident set size (KB)                   = 797220
+0:The total amount of wall time                        = 147.059252
+0:The maximum resident set size (KB)                   = 797228
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 154.964276
-0:The maximum resident set size (KB)                   = 879560
+0:The total amount of wall time                        = 155.658004
+0:The maximum resident set size (KB)                   = 879600
 
 Test 024 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 237.063349
-0:The maximum resident set size (KB)                   = 795764
+0:The total amount of wall time                        = 236.099866
+0:The maximum resident set size (KB)                   = 795816
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.492365
-0:The maximum resident set size (KB)                   = 797256
+0:The total amount of wall time                        = 148.155019
+0:The maximum resident set size (KB)                   = 797208
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 146.215745
-0:The maximum resident set size (KB)                   = 791608
+0:The total amount of wall time                        = 146.180512
+0:The maximum resident set size (KB)                   = 791536
 
 Test 027 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 95.304009
-0:The maximum resident set size (KB)                   = 782936
+0:The total amount of wall time                        = 96.010039
+0:The maximum resident set size (KB)                   = 782952
 
 Test 028 control_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_thompson_no_aero_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_no_aero_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.259359
+0:The total amount of wall time                        = 92.323837
 0:The maximum resident set size (KB)                   = 778352
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_thompson_extdiag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_debug_extdiag
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 104.155426
-0:The maximum resident set size (KB)                   = 824248
+0:The total amount of wall time                        = 103.361263
+0:The maximum resident set size (KB)                   = 823800
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_thompson_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 95.814768
-0:The maximum resident set size (KB)                   = 782960
+0:The total amount of wall time                        = 96.953804
+0:The maximum resident set size (KB)                   = 782924
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_ras_debug
 Checking test 032 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 84.575035
-0:The maximum resident set size (KB)                   = 434688
+0:The total amount of wall time                        = 83.494619
+0:The maximum resident set size (KB)                   = 434652
 
 Test 032 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_stochy_debug
 Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.030924
-0:The maximum resident set size (KB)                   = 428568
+0:The total amount of wall time                        = 91.088906
+0:The maximum resident set size (KB)                   = 428672
 
 Test 033 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_debug_p8
 Checking test 034 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 95.001269
-0:The maximum resident set size (KB)                   = 809336
+0:The total amount of wall time                        = 97.877017
+0:The maximum resident set size (KB)                   = 809348
 
 Test 034 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/control_wam_debug
 Checking test 035 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 143.043868
-0:The maximum resident set size (KB)                   = 171664
+0:The total amount of wall time                        = 143.098664
+0:The maximum resident set size (KB)                   = 171644
 
 Test 035 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/cpld_control_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/cpld_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/cpld_control_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/cpld_control_noaero_p8
 Checking test 036 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -996,14 +996,14 @@ Checking test 036 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 540.434131
-0:The maximum resident set size (KB)                   = 795768
+0:The total amount of wall time                        = 564.308204
+0:The maximum resident set size (KB)                   = 794480
 
 Test 036 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/cpld_debug_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/cpld_debug_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/cpld_debug_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/cpld_debug_noaero_p8
 Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1055,25 +1055,25 @@ Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 209.451551
-0:The maximum resident set size (KB)                   = 814052
+0:The total amount of wall time                        = 234.326518
+0:The maximum resident set size (KB)                   = 813060
 
 Test 037 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-gnu/jongkim/FV3_RT/rt_43813/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/GNU/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-gnu/jongkim/FV3_RT/rt_26739/datm_cdeps_control_cfsr
 Checking test 038 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.593987
-0:The maximum resident set size (KB)                   = 647732
+0:The total amount of wall time                        = 174.530388
+0:The maximum resident set size (KB)                   = 645808
 
 Test 038 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 11 06:27:16 MDT 2022
-Elapsed time: 00h:30m:41s. Have a nice day!
+Mon Jun 13 15:26:28 MDT 2022
+Elapsed time: 00h:51m:29s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,26 +1,26 @@
-Sat Jun 11 05:54:34 MDT 2022
+Mon Jun 13 14:34:41 MDT 2022
 Start Regression test
 
-Compile 001 elapsed time 1184 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 506 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 879 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 749 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 810 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 793 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 619 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 393 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 341 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 359 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 263 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 934 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 891 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 436 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 232 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 815 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 649 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1173 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 461 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 874 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 716 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 799 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 787 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 605 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 381 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 320 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 333 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 259 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 913 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 865 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 433 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 208 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 778 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 651 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 380.424397
-0:The maximum resident set size (KB)                   = 4407212
+0:The total amount of wall time                        = 375.161884
+0:The maximum resident set size (KB)                   = 4406856
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -145,14 +145,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 227.525008
-0:The maximum resident set size (KB)                   = 4365820
+0:The total amount of wall time                        = 228.858873
+0:The maximum resident set size (KB)                   = 4365652
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -205,14 +205,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 654.070730
-0:The maximum resident set size (KB)                   = 4812488
+0:The total amount of wall time                        = 658.115244
+0:The maximum resident set size (KB)                   = 4812716
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_decomp_p8
 Checking test 004 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -265,14 +265,14 @@ Checking test 004 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 372.398411
-0:The maximum resident set size (KB)                   = 4394496
+0:The total amount of wall time                        = 379.770042
+0:The maximum resident set size (KB)                   = 4394608
 
 Test 004 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_mpi_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_mpi_p8
 Checking test 005 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 343.079273
-0:The maximum resident set size (KB)                   = 4279776
+0:The total amount of wall time                        = 344.774764
+0:The maximum resident set size (KB)                   = 4279528
 
 Test 005 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_control_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_control_c192_p8
 Checking test 006 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -385,14 +385,14 @@ Checking test 006 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1451.590893
-0:The maximum resident set size (KB)                   = 4744840
+0:The total amount of wall time                        = 1467.498908
+0:The maximum resident set size (KB)                   = 4744204
 
 Test 006 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_restart_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_restart_c192_p8
 Checking test 007 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -445,14 +445,14 @@ Checking test 007 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 810.278735
-0:The maximum resident set size (KB)                   = 4709292
+0:The total amount of wall time                        = 843.585461
+0:The maximum resident set size (KB)                   = 4709224
 
 Test 007 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_bmark_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_bmark_p8
 Checking test 008 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -498,14 +498,14 @@ Checking test 008 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1701.255742
-0:The maximum resident set size (KB)                   = 5054036
+0:The total amount of wall time                        = 1724.914393
+0:The maximum resident set size (KB)                   = 5053388
 
 Test 008 cpld_bmark_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_restart_bmark_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_restart_bmark_p8
 Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -551,14 +551,14 @@ Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1113.660221
-0:The maximum resident set size (KB)                   = 5021004
+0:The total amount of wall time                        = 1107.508101
+0:The maximum resident set size (KB)                   = 5022008
 
 Test 009 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -611,14 +611,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 542.774847
-0:The maximum resident set size (KB)                   = 4494508
+0:The total amount of wall time                        = 543.852451
+0:The maximum resident set size (KB)                   = 4494672
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/cpld_control_noaero_p8_agrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/cpld_control_noaero_p8_agrid
 Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -680,14 +680,14 @@ Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 301.308391
-0:The maximum resident set size (KB)                   = 884312
+0:The total amount of wall time                        = 328.601208
+0:The maximum resident set size (KB)                   = 884284
 
 Test 011 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control
 Checking test 012 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -734,14 +734,14 @@ Checking test 012 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 141.687291
-0:The maximum resident set size (KB)                   = 452968
+0:The total amount of wall time                        = 145.507263
+0:The maximum resident set size (KB)                   = 452804
 
 Test 012 control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_decomp
 Checking test 013 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 013 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 144.271103
-0:The maximum resident set size (KB)                   = 453232
+0:The total amount of wall time                        = 145.662157
+0:The maximum resident set size (KB)                   = 453420
 
 Test 013 control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_2dwrtdecomp
 Checking test 014 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -802,14 +802,14 @@ Checking test 014 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 139.777669
-0:The maximum resident set size (KB)                   = 453564
+0:The total amount of wall time                        = 142.620884
+0:The maximum resident set size (KB)                   = 453428
 
 Test 014 control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_2threads
 Checking test 015 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -852,14 +852,14 @@ Checking test 015 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 369.439382
-0:The maximum resident set size (KB)                   = 500336
+0:The total amount of wall time                        = 370.353428
+0:The maximum resident set size (KB)                   = 500284
 
 Test 015 control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_restart
 Checking test 016 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -898,14 +898,14 @@ Checking test 016 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 73.671130
-0:The maximum resident set size (KB)                   = 193336
+0:The total amount of wall time                        = 71.583143
+0:The maximum resident set size (KB)                   = 193360
 
 Test 016 control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_fhzero
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_fhzero
 Checking test 017 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -948,14 +948,14 @@ Checking test 017 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 132.855156
-0:The maximum resident set size (KB)                   = 452884
+0:The total amount of wall time                        = 133.014701
+0:The maximum resident set size (KB)                   = 452936
 
 Test 017 control_fhzero PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_CubedSphereGrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -982,14 +982,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 136.562507
-0:The maximum resident set size (KB)                   = 453032
+0:The total amount of wall time                        = 134.210211
+0:The maximum resident set size (KB)                   = 453060
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_latlon
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_latlon
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1000,32 +1000,32 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 139.008921
-0:The maximum resident set size (KB)                   = 453068
+0:The total amount of wall time                        = 140.810337
+0:The maximum resident set size (KB)                   = 453032
 
 Test 019 control_latlon PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 141.930370
-0:The maximum resident set size (KB)                   = 452888
+0:The total amount of wall time                        = 142.407703
+0:The maximum resident set size (KB)                   = 452896
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c48
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1064,14 +1064,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 431.712630
-0:The maximum resident set size (KB)                   = 627844
+0:The total amount of wall time                        = 428.457861
+0:The maximum resident set size (KB)                   = 627872
 
 Test 021 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c192
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_c192
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 550.319820
-0:The maximum resident set size (KB)                   = 557764
+0:The total amount of wall time                        = 568.710516
+0:The maximum resident set size (KB)                   = 557696
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_c384
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1100,14 +1100,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1270.479230
-0:The maximum resident set size (KB)                   = 834204
+0:The total amount of wall time                        = 1282.519301
+0:The maximum resident set size (KB)                   = 834268
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384gdas
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_c384gdas
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1337.978282
-0:The maximum resident set size (KB)                   = 970556
+0:The total amount of wall time                        = 1356.361541
+0:The maximum resident set size (KB)                   = 970332
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384_progsigma
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_c384_progsigma
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_c384_progsigma
 Checking test 025 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 025 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1284.196268
-0:The maximum resident set size (KB)                   = 855544
+0:The total amount of wall time                        = 1287.031317
+0:The maximum resident set size (KB)                   = 855556
 
 Test 025 control_c384_progsigma PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1186,28 +1186,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 92.877340
-0:The maximum resident set size (KB)                   = 456844
+0:The total amount of wall time                        = 92.840814
+0:The maximum resident set size (KB)                   = 456804
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_stochy_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 49.439988
-0:The maximum resident set size (KB)                   = 223484
+0:The total amount of wall time                        = 49.422928
+0:The maximum resident set size (KB)                   = 223284
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 84.589921
-0:The maximum resident set size (KB)                   = 456160
+0:The total amount of wall time                        = 85.210292
+0:The maximum resident set size (KB)                   = 456196
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr4
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_iovr4
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 141.394397
-0:The maximum resident set size (KB)                   = 453068
+0:The total amount of wall time                        = 141.418518
+0:The maximum resident set size (KB)                   = 453040
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr5
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_iovr5
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 139.769765
-0:The maximum resident set size (KB)                   = 452928
+0:The total amount of wall time                        = 140.722216
+0:The maximum resident set size (KB)                   = 452832
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1316,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 182.334578
-0:The maximum resident set size (KB)                   = 850088
+0:The total amount of wall time                        = 182.810913
+0:The maximum resident set size (KB)                   = 850080
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_lndp
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_p8_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 345.539428
-0:The maximum resident set size (KB)                   = 850288
+0:The total amount of wall time                        = 345.688983
+0:The maximum resident set size (KB)                   = 850320
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1388,14 +1388,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 99.027179
-0:The maximum resident set size (KB)                   = 580200
+0:The total amount of wall time                        = 106.060809
+0:The maximum resident set size (KB)                   = 580220
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1438,14 +1438,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 189.728102
-0:The maximum resident set size (KB)                   = 844424
+0:The total amount of wall time                        = 189.911133
+0:The maximum resident set size (KB)                   = 844384
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 498.595981
-0:The maximum resident set size (KB)                   = 919260
+0:The total amount of wall time                        = 499.012506
+0:The maximum resident set size (KB)                   = 919256
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_p8_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1542,14 +1542,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 241.650239
-0:The maximum resident set size (KB)                   = 968616
+0:The total amount of wall time                        = 246.518767
+0:The maximum resident set size (KB)                   = 968592
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1560,28 +1560,28 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 363.184260
-0:The maximum resident set size (KB)                   = 564816
+0:The total amount of wall time                        = 361.847961
+0:The maximum resident set size (KB)                   = 564988
 
 Test 037 regional_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 198.770592
-0:The maximum resident set size (KB)                   = 557340
+0:The total amount of wall time                        = 198.060458
+0:The maximum resident set size (KB)                   = 557416
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_control_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 356.528832
-0:The maximum resident set size (KB)                   = 563976
+0:The total amount of wall time                        = 362.368313
+0:The maximum resident set size (KB)                   = 564644
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_noquilt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 374.554157
+0:The total amount of wall time                        = 378.489697
 0:The maximum resident set size (KB)                   = 557612
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,28 +1625,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 1168.739339
-0:The maximum resident set size (KB)                   = 557924
+0:The total amount of wall time                        = 1174.536064
+0:The maximum resident set size (KB)                   = 557720
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 359.243814
-0:The maximum resident set size (KB)                   = 555164
+0:The total amount of wall time                        = 368.421007
+0:The maximum resident set size (KB)                   = 555212
 
 Test 042 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_3km
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_3km
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 298.362686
-0:The maximum resident set size (KB)                   = 595928
+0:The total amount of wall time                        = 296.071134
+0:The maximum resident set size (KB)                   = 595848
 
 Test 043 regional_3km PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1711,14 +1711,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 456.815428
-0:The maximum resident set size (KB)                   = 823092
+0:The total amount of wall time                        = 472.203809
+0:The maximum resident set size (KB)                   = 823200
 
 Test 044 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1765,14 +1765,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 521.833773
-0:The maximum resident set size (KB)                   = 948816
+0:The total amount of wall time                        = 517.812765
+0:The maximum resident set size (KB)                   = 948872
 
 Test 045 rap_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_spp_sppt_shum_skeb
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1783,14 +1783,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 700.548309
-0:The maximum resident set size (KB)                   = 931620
+0:The total amount of wall time                        = 703.479220
+0:The maximum resident set size (KB)                   = 931568
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1837,14 +1837,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1099.184255
-0:The maximum resident set size (KB)                   = 882212
+0:The total amount of wall time                        = 1103.588318
+0:The maximum resident set size (KB)                   = 882280
 
 Test 047 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1883,14 +1883,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 228.513561
-0:The maximum resident set size (KB)                   = 567364
+0:The total amount of wall time                        = 233.417715
+0:The maximum resident set size (KB)                   = 567356
 
 Test 048 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1937,14 +1937,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 453.750235
-0:The maximum resident set size (KB)                   = 823068
+0:The total amount of wall time                        = 460.966839
+0:The maximum resident set size (KB)                   = 823024
 
 Test 049 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1983,14 +1983,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 236.915555
-0:The maximum resident set size (KB)                   = 566964
+0:The total amount of wall time                        = 233.808716
+0:The maximum resident set size (KB)                   = 567156
 
 Test 050 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 439.925838
-0:The maximum resident set size (KB)                   = 823192
+0:The total amount of wall time                        = 443.375870
+0:The maximum resident set size (KB)                   = 823220
 
 Test 051 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 445.388213
-0:The maximum resident set size (KB)                   = 817720
+0:The total amount of wall time                        = 452.639564
+0:The maximum resident set size (KB)                   = 817616
 
 Test 052 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_v1nssl
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2113,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 555.025000
-0:The maximum resident set size (KB)                   = 506996
+0:The total amount of wall time                        = 552.482118
+0:The maximum resident set size (KB)                   = 506868
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_v1nssl_nohailnoccn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2135,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 532.081157
-0:The maximum resident set size (KB)                   = 500404
+0:The total amount of wall time                        = 541.688996
+0:The maximum resident set size (KB)                   = 500380
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2151,14 +2151,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 195.367966
-0:The maximum resident set size (KB)                   = 638420
+0:The total amount of wall time                        = 193.832974
+0:The maximum resident set size (KB)                   = 638308
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 194.343757
-0:The maximum resident set size (KB)                   = 640436
+0:The total amount of wall time                        = 199.143721
+0:The maximum resident set size (KB)                   = 640612
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2183,14 +2183,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 215.679822
-0:The maximum resident set size (KB)                   = 653424
+0:The total amount of wall time                        = 215.214135
+0:The maximum resident set size (KB)                   = 653448
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_csawmg
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 386.995116
-0:The maximum resident set size (KB)                   = 530144
+0:The total amount of wall time                        = 399.154855
+0:The maximum resident set size (KB)                   = 530764
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_csawmgt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 384.131571
-0:The maximum resident set size (KB)                   = 529980
+0:The total amount of wall time                        = 387.650486
+0:The maximum resident set size (KB)                   = 530032
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_flake
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_flake
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2237,14 +2237,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 249.084939
-0:The maximum resident set size (KB)                   = 525836
+0:The total amount of wall time                        = 249.190156
+0:The maximum resident set size (KB)                   = 525764
 
 Test 060 control_flake PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2255,14 +2255,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 197.170613
-0:The maximum resident set size (KB)                   = 487960
+0:The total amount of wall time                        = 196.342630
+0:The maximum resident set size (KB)                   = 487932
 
 Test 061 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2273,14 +2273,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 258.942872
-0:The maximum resident set size (KB)                   = 840412
+0:The total amount of wall time                        = 270.471012
+0:The maximum resident set size (KB)                   = 840284
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_thompson_no_aero
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2291,54 +2291,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 251.916407
-0:The maximum resident set size (KB)                   = 832736
+0:The total amount of wall time                        = 249.860589
+0:The maximum resident set size (KB)                   = 832676
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_wam
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 121.220457
-0:The maximum resident set size (KB)                   = 204532
+0:The total amount of wall time                        = 120.209284
+0:The maximum resident set size (KB)                   = 204500
 
 Test 064 control_wam PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 158.843880
-0:The maximum resident set size (KB)                   = 620716
+0:The total amount of wall time                        = 157.478661
+0:The maximum resident set size (KB)                   = 620560
 
 Test 065 control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_2threads_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 277.331505
-0:The maximum resident set size (KB)                   = 668572
+0:The total amount of wall time                        = 276.808483
+0:The maximum resident set size (KB)                   = 668032
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_CubedSphereGrid_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2365,415 +2365,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 172.123615
-0:The maximum resident set size (KB)                   = 620728
+0:The total amount of wall time                        = 171.229164
+0:The maximum resident set size (KB)                   = 620692
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.270222
-0:The maximum resident set size (KB)                   = 620696
+0:The total amount of wall time                        = 160.003160
+0:The maximum resident set size (KB)                   = 620644
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 181.043026
-0:The maximum resident set size (KB)                   = 626136
+0:The total amount of wall time                        = 180.876922
+0:The maximum resident set size (KB)                   = 626036
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.405144
-0:The maximum resident set size (KB)                   = 626860
+0:The total amount of wall time                        = 163.570503
+0:The maximum resident set size (KB)                   = 626844
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_csawmg_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 252.139697
-0:The maximum resident set size (KB)                   = 671516
+0:The total amount of wall time                        = 259.124149
+0:The maximum resident set size (KB)                   = 671540
 
 Test 071 control_csawmg_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_csawmgt_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 249.873821
-0:The maximum resident set size (KB)                   = 671416
+0:The total amount of wall time                        = 256.791369
+0:The maximum resident set size (KB)                   = 671412
 
 Test 072 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.816444
-0:The maximum resident set size (KB)                   = 634880
+0:The total amount of wall time                        = 165.540374
+0:The maximum resident set size (KB)                   = 634868
 
 Test 073 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 166.362491
-0:The maximum resident set size (KB)                   = 678664
+0:The total amount of wall time                        = 166.012685
+0:The maximum resident set size (KB)                   = 678472
 
 Test 074 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 178.435495
-0:The maximum resident set size (KB)                   = 1017516
+0:The total amount of wall time                        = 199.096499
+0:The maximum resident set size (KB)                   = 1017520
 
 Test 075 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 188.080750
-0:The maximum resident set size (KB)                   = 980184
+0:The total amount of wall time                        = 185.975058
+0:The maximum resident set size (KB)                   = 980048
 
 Test 076 control_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_thompson_no_aero_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 185.214127
-0:The maximum resident set size (KB)                   = 977316
+0:The total amount of wall time                        = 180.116926
+0:The maximum resident set size (KB)                   = 977268
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_thompson_extdiag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 195.384260
-0:The maximum resident set size (KB)                   = 1010636
+0:The total amount of wall time                        = 199.795043
+0:The maximum resident set size (KB)                   = 1010620
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_thompson_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 187.446726
-0:The maximum resident set size (KB)                   = 980088
+0:The total amount of wall time                        = 185.141103
+0:The maximum resident set size (KB)                   = 979996
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 262.784239
-0:The maximum resident set size (KB)                   = 588520
+0:The total amount of wall time                        = 262.414992
+0:The maximum resident set size (KB)                   = 588484
 
 Test 080 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.032884
-0:The maximum resident set size (KB)                   = 988280
+0:The total amount of wall time                        = 286.945005
+0:The maximum resident set size (KB)                   = 988416
 
 Test 081 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_unified_drag_suite_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.270102
-0:The maximum resident set size (KB)                   = 988248
+0:The total amount of wall time                        = 290.890061
+0:The maximum resident set size (KB)                   = 988388
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 300.951345
-0:The maximum resident set size (KB)                   = 1071016
+0:The total amount of wall time                        = 300.750512
+0:The maximum resident set size (KB)                   = 1071180
 
 Test 083 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.605973
-0:The maximum resident set size (KB)                   = 987016
+0:The total amount of wall time                        = 292.931771
+0:The maximum resident set size (KB)                   = 987168
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_unified_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.041859
-0:The maximum resident set size (KB)                   = 988372
+0:The total amount of wall time                        = 292.818788
+0:The maximum resident set size (KB)                   = 988344
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.489468
-0:The maximum resident set size (KB)                   = 989044
+0:The total amount of wall time                        = 288.841484
+0:The maximum resident set size (KB)                   = 988996
 
 Test 086 rap_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_flake_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.585763
-0:The maximum resident set size (KB)                   = 988296
+0:The total amount of wall time                        = 289.002853
+0:The maximum resident set size (KB)                   = 988280
 
 Test 087 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.347841
-0:The maximum resident set size (KB)                   = 988224
+0:The total amount of wall time                        = 286.819169
+0:The maximum resident set size (KB)                   = 988248
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_noah_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 283.027355
-0:The maximum resident set size (KB)                   = 986972
+0:The total amount of wall time                        = 286.009900
+0:The maximum resident set size (KB)                   = 987064
 
 Test 089 rap_noah_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_rrtmgp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 483.080937
-0:The maximum resident set size (KB)                   = 1118100
+0:The total amount of wall time                        = 483.719454
+0:The maximum resident set size (KB)                   = 1118156
 
 Test 090 rap_rrtmgp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_sfcdiff_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.152670
-0:The maximum resident set size (KB)                   = 988068
+0:The total amount of wall time                        = 293.061482
+0:The maximum resident set size (KB)                   = 988128
 
 Test 091 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 472.750033
-0:The maximum resident set size (KB)                   = 986920
+0:The total amount of wall time                        = 473.386158
+0:The maximum resident set size (KB)                   = 986996
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.621383
-0:The maximum resident set size (KB)                   = 983420
+0:The total amount of wall time                        = 285.351426
+0:The maximum resident set size (KB)                   = 983200
 
 Test 093 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 296.857405
-0:The maximum resident set size (KB)                   = 237900
+0:The total amount of wall time                        = 295.110317
+0:The maximum resident set size (KB)                   = 237980
 
 Test 094 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 645.794598
-0:The maximum resident set size (KB)                   = 691460
+0:The total amount of wall time                        = 770.728414
+0:The maximum resident set size (KB)                   = 691380
 
 Test 095 hafs_regional_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 711.798585
-0:The maximum resident set size (KB)                   = 1053480
+0:The total amount of wall time                        = 719.335297
+0:The maximum resident set size (KB)                   = 1053144
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2782,14 +2782,14 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 540.486359
-0:The maximum resident set size (KB)                   = 721884
+0:The total amount of wall time                        = 469.770540
+0:The maximum resident set size (KB)                   = 721992
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_atm_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 098 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1015.380628
-0:The maximum resident set size (KB)                   = 751676
+0:The total amount of wall time                        = 1050.914209
+0:The maximum resident set size (KB)                   = 751648
 
 Test 098 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2816,28 +2816,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1148.057929
-0:The maximum resident set size (KB)                   = 763624
+0:The total amount of wall time                        = 1129.720600
+0:The maximum resident set size (KB)                   = 763612
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 1330.794785
-0:The maximum resident set size (KB)                   = 278632
+0:The total amount of wall time                        = 1328.516424
+0:The maximum resident set size (KB)                   = 278544
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2846,28 +2846,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 1428.560303
-0:The maximum resident set size (KB)                   = 288700
+0:The total amount of wall time                        = 1422.181412
+0:The maximum resident set size (KB)                   = 288748
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_global_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 829.214762
-0:The maximum resident set size (KB)                   = 185096
+0:The total amount of wall time                        = 828.411547
+0:The maximum resident set size (KB)                   = 185200
 
 Test 102 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_global_multiple_4nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2880,42 +2880,42 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-0:The total amount of wall time                        = 1417.609729
-0:The maximum resident set size (KB)                   = 266028
+0:The total amount of wall time                        = 1419.883233
+0:The maximum resident set size (KB)                   = 266228
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_specified_moving_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 732.107101
-0:The maximum resident set size (KB)                   = 288904
+0:The total amount of wall time                        = 733.966864
+0:The maximum resident set size (KB)                   = 288916
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 723.229550
-0:The maximum resident set size (KB)                   = 288804
+0:The total amount of wall time                        = 720.628671
+0:The maximum resident set size (KB)                   = 289000
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2924,14 +2924,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 739.742055
-0:The maximum resident set size (KB)                   = 319736
+0:The total amount of wall time                        = 741.582478
+0:The maximum resident set size (KB)                   = 319752
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2942,28 +2942,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1332.464718
-0:The maximum resident set size (KB)                   = 386856
+0:The total amount of wall time                        = 1337.465609
+0:The maximum resident set size (KB)                   = 386836
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_global_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 413.341774
-0:The maximum resident set size (KB)                   = 205400
+0:The total amount of wall time                        = 417.231234
+0:The maximum resident set size (KB)                   = 205484
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_docn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2971,14 +2971,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 421.910423
-0:The maximum resident set size (KB)                   = 738316
+0:The total amount of wall time                        = 427.659270
+0:The maximum resident set size (KB)                   = 738280
 
 Test 109 hafs_regional_docn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_docn_oisst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2986,118 +2986,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 422.760558
-0:The maximum resident set size (KB)                   = 722100
+0:The total amount of wall time                        = 420.649852
+0:The maximum resident set size (KB)                   = 721832
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/hafs_regional_datm_cdeps
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1282.204605
-0:The maximum resident set size (KB)                   = 867932
+0:The total amount of wall time                        = 1275.482983
+0:The maximum resident set size (KB)                   = 867376
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 163.585134
-0:The maximum resident set size (KB)                   = 692548
+0:The total amount of wall time                        = 167.917664
+0:The maximum resident set size (KB)                   = 681452
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_restart_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 97.861410
-0:The maximum resident set size (KB)                   = 692836
+0:The total amount of wall time                        = 99.659058
+0:The maximum resident set size (KB)                   = 693056
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_control_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 154.974025
-0:The maximum resident set size (KB)                   = 579660
+0:The total amount of wall time                        = 160.959098
+0:The maximum resident set size (KB)                   = 579680
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_iau_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 163.720197
-0:The maximum resident set size (KB)                   = 579668
+0:The total amount of wall time                        = 163.987644
+0:The maximum resident set size (KB)                   = 579692
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_stochy_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 162.029747
-0:The maximum resident set size (KB)                   = 579660
+0:The total amount of wall time                        = 164.948926
+0:The maximum resident set size (KB)                   = 579700
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_bulk_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.719929
-0:The maximum resident set size (KB)                   = 692472
+0:The total amount of wall time                        = 168.517463
+0:The maximum resident set size (KB)                   = 681480
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_bulk_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 154.417622
-0:The maximum resident set size (KB)                   = 579700
+0:The total amount of wall time                        = 155.729697
+0:The maximum resident set size (KB)                   = 579660
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_mx025_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3106,14 +3106,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 353.281342
-0:The maximum resident set size (KB)                   = 508908
+0:The total amount of wall time                        = 356.180094
+0:The maximum resident set size (KB)                   = 509164
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_mx025_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3122,64 +3122,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 350.609777
-0:The maximum resident set size (KB)                   = 490320
+0:The total amount of wall time                        = 360.164188
+0:The maximum resident set size (KB)                   = 490364
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.520406
-0:The maximum resident set size (KB)                   = 681500
+0:The total amount of wall time                        = 161.420735
+0:The maximum resident set size (KB)                   = 692580
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 269.948691
-0:The maximum resident set size (KB)                   = 1825356
+0:The total amount of wall time                        = 256.302150
+0:The maximum resident set size (KB)                   = 1826916
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_gfs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_gfs
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 255.942748
-0:The maximum resident set size (KB)                   = 1826088
+0:The total amount of wall time                        = 238.385440
+0:The maximum resident set size (KB)                   = 1825304
 
 Test 123 datm_cdeps_gfs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/datm_cdeps_debug_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 454.892444
-0:The maximum resident set size (KB)                   = 700824
+0:The total amount of wall time                        = 454.465993
+0:The maximum resident set size (KB)                   = 689724
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220601/INTEL/control_atmwav
-working dir  = /glade/scratch/jongkim/rt-1211-intel/jongkim/FV3_RT/rt_55234/control_atmwav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220613/INTEL/control_atmwav
+working dir  = /glade/scratch/jongkim/rt-1266-intel/jongkim/FV3_RT/rt_27574/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3223,12 +3223,12 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 92.889705
-0:The maximum resident set size (KB)                   = 478184
+0:The total amount of wall time                        = 104.528474
+0:The maximum resident set size (KB)                   = 478248
 
 Test 125 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 11 07:24:04 MDT 2022
-Elapsed time: 01h:29m:30s. Have a nice day!
+Mon Jun 13 18:57:53 MDT 2022
+Elapsed time: 04h:23m:12s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,26 +1,26 @@
-Fri Jun 10 18:19:03 EDT 2022
+Mon Jun 13 17:07:31 EDT 2022
 Start Regression test
 
-Compile 001 elapsed time 679 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 272 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 555 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 481 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 551 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 480 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 494 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 268 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 219 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 221 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 262 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 648 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 624 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 255 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 153 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 632 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 433 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 665 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 269 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 509 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 443 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 468 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 475 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 409 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 236 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 214 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 217 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 583 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 615 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 245 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 151 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 555 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 430 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 437.408831
-  0: The maximum resident set size (KB)                   = 1594132
+  0: The total amount of wall time                        = 426.542400
+  0: The maximum resident set size (KB)                   = 1593676
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -145,14 +145,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 358.895697
-  0: The maximum resident set size (KB)                   = 1558480
+  0: The total amount of wall time                        = 259.914338
+  0: The maximum resident set size (KB)                   = 1558648
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -205,14 +205,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 586.709126
-  0: The maximum resident set size (KB)                   = 2369480
+  0: The total amount of wall time                        = 574.121498
+  0: The maximum resident set size (KB)                   = 2432444
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_decomp_p8
 Checking test 004 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -265,14 +265,14 @@ Checking test 004 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 443.695284
-  0: The maximum resident set size (KB)                   = 1660932
+  0: The total amount of wall time                        = 426.605854
+  0: The maximum resident set size (KB)                   = 1674448
 
 Test 004 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_mpi_p8
 Checking test 005 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 370.488252
-  0: The maximum resident set size (KB)                   = 1323444
+  0: The total amount of wall time                        = 360.279973
+  0: The maximum resident set size (KB)                   = 1158904
 
 Test 005 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_control_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_control_c192_p8
 Checking test 006 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -385,14 +385,14 @@ Checking test 006 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1011.890864
-  0: The maximum resident set size (KB)                   = 1663576
+  0: The total amount of wall time                        = 916.711472
+  0: The maximum resident set size (KB)                   = 1662548
 
 Test 006 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_restart_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_restart_c192_p8
 Checking test 007 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -445,14 +445,14 @@ Checking test 007 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 550.509301
-  0: The maximum resident set size (KB)                   = 1634628
+  0: The total amount of wall time                        = 586.684001
+  0: The maximum resident set size (KB)                   = 1635544
 
 Test 007 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_bmark_p8
 Checking test 008 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -498,14 +498,14 @@ Checking test 008 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1456.801589
-  0: The maximum resident set size (KB)                   = 2472400
+  0: The total amount of wall time                        = 1533.628044
+  0: The maximum resident set size (KB)                   = 2528468
 
 Test 008 cpld_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_restart_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_restart_bmark_p8
 Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -551,14 +551,14 @@ Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 970.499637
-  0: The maximum resident set size (KB)                   = 2420424
+  0: The total amount of wall time                        = 904.245135
+  0: The maximum resident set size (KB)                   = 2425296
 
 Test 009 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -611,14 +611,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 644.021602
-  0: The maximum resident set size (KB)                   = 1644648
+  0: The total amount of wall time                        = 629.941340
+  0: The maximum resident set size (KB)                   = 1674708
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/cpld_control_noaero_p8_agrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/cpld_control_noaero_p8_agrid
 Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -680,14 +680,14 @@ Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 327.532166
-  0: The maximum resident set size (KB)                   = 927508
+  0: The total amount of wall time                        = 315.475887
+  0: The maximum resident set size (KB)                   = 915476
 
 Test 011 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control
 Checking test 012 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -734,14 +734,14 @@ Checking test 012 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 143.922801
-  0: The maximum resident set size (KB)                   = 435440
+  0: The total amount of wall time                        = 154.962545
+  0: The maximum resident set size (KB)                   = 435364
 
 Test 012 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_decomp
 Checking test 013 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 013 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.463277
-  0: The maximum resident set size (KB)                   = 434260
+  0: The total amount of wall time                        = 140.125813
+  0: The maximum resident set size (KB)                   = 434148
 
 Test 013 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_2dwrtdecomp
 Checking test 014 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -802,14 +802,14 @@ Checking test 014 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.919584
-  0: The maximum resident set size (KB)                   = 435536
+  0: The total amount of wall time                        = 133.227294
+  0: The maximum resident set size (KB)                   = 435464
 
 Test 014 control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_2threads
 Checking test 015 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -852,14 +852,14 @@ Checking test 015 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 172.906381
- 0: The maximum resident set size (KB)                   = 487560
+ 0: The total amount of wall time                        = 170.702060
+ 0: The maximum resident set size (KB)                   = 487368
 
 Test 015 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_restart
 Checking test 016 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -898,14 +898,14 @@ Checking test 016 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 72.456026
-  0: The maximum resident set size (KB)                   = 172920
+  0: The total amount of wall time                        = 72.213305
+  0: The maximum resident set size (KB)                   = 172904
 
 Test 016 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_fhzero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_fhzero
 Checking test 017 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -948,14 +948,14 @@ Checking test 017 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 136.384891
-  0: The maximum resident set size (KB)                   = 435404
+  0: The total amount of wall time                        = 125.916270
+  0: The maximum resident set size (KB)                   = 435480
 
 Test 017 control_fhzero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -982,14 +982,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.149875
-  0: The maximum resident set size (KB)                   = 435524
+  0: The total amount of wall time                        = 127.894976
+  0: The maximum resident set size (KB)                   = 435580
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1000,14 +1000,14 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.392349
-  0: The maximum resident set size (KB)                   = 435452
+  0: The total amount of wall time                        = 132.234623
+  0: The maximum resident set size (KB)                   = 435340
 
 Test 019 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1018,14 +1018,14 @@ Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.120299
-  0: The maximum resident set size (KB)                   = 435276
+  0: The total amount of wall time                        = 139.915710
+  0: The maximum resident set size (KB)                   = 435504
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1064,14 +1064,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 359.456381
-0: The maximum resident set size (KB)                   = 629968
+0: The total amount of wall time                        = 359.069688
+0: The maximum resident set size (KB)                   = 629992
 
 Test 021 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 545.569253
-  0: The maximum resident set size (KB)                   = 539352
+  0: The total amount of wall time                        = 543.524070
+  0: The maximum resident set size (KB)                   = 539364
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1100,14 +1100,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 859.287004
-  0: The maximum resident set size (KB)                   = 811080
+  0: The total amount of wall time                        = 763.097518
+  0: The maximum resident set size (KB)                   = 810996
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 766.747946
-  0: The maximum resident set size (KB)                   = 934128
+  0: The total amount of wall time                        = 710.051699
+  0: The maximum resident set size (KB)                   = 934552
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384_progsigma
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_c384_progsigma
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_c384_progsigma
 Checking test 025 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 025 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 858.777428
-  0: The maximum resident set size (KB)                   = 832608
+  0: The total amount of wall time                        = 775.992811
+  0: The maximum resident set size (KB)                   = 832684
 
 Test 025 control_c384_progsigma PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1186,28 +1186,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 102.660912
-  0: The maximum resident set size (KB)                   = 439992
+  0: The total amount of wall time                        = 87.825872
+  0: The maximum resident set size (KB)                   = 439888
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 128.279829
-  0: The maximum resident set size (KB)                   = 190416
+  0: The total amount of wall time                        = 48.202564
+  0: The maximum resident set size (KB)                   = 190344
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 80.008221
-  0: The maximum resident set size (KB)                   = 440100
+  0: The total amount of wall time                        = 79.924488
+  0: The maximum resident set size (KB)                   = 440020
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_iovr4
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.230024
-  0: The maximum resident set size (KB)                   = 435220
+  0: The total amount of wall time                        = 132.281159
+  0: The maximum resident set size (KB)                   = 435476
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_iovr5
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.729201
-  0: The maximum resident set size (KB)                   = 435268
+  0: The total amount of wall time                        = 132.688483
+  0: The maximum resident set size (KB)                   = 435364
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1316,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 182.645520
-  0: The maximum resident set size (KB)                   = 825324
+  0: The total amount of wall time                        = 176.217386
+  0: The maximum resident set size (KB)                   = 801672
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_p8_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 346.440025
-  0: The maximum resident set size (KB)                   = 825560
+  0: The total amount of wall time                        = 333.812377
+  0: The maximum resident set size (KB)                   = 825504
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1388,14 +1388,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 105.863107
-  0: The maximum resident set size (KB)                   = 561004
+  0: The total amount of wall time                        = 107.275487
+  0: The maximum resident set size (KB)                   = 546856
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1438,14 +1438,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.501244
-  0: The maximum resident set size (KB)                   = 821524
+  0: The total amount of wall time                        = 179.480723
+  0: The maximum resident set size (KB)                   = 797896
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 332.673726
- 0: The maximum resident set size (KB)                   = 900396
+ 0: The total amount of wall time                        = 221.876147
+ 0: The maximum resident set size (KB)                   = 897488
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_p8_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1542,14 +1542,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 303.545018
-  0: The maximum resident set size (KB)                   = 940644
+  0: The total amount of wall time                        = 225.075637
+  0: The maximum resident set size (KB)                   = 940692
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1560,28 +1560,28 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 361.090602
- 0: The maximum resident set size (KB)                   = 544720
+ 0: The total amount of wall time                        = 355.495263
+ 0: The maximum resident set size (KB)                   = 544704
 
 Test 037 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 196.526949
- 0: The maximum resident set size (KB)                   = 542716
+ 0: The total amount of wall time                        = 196.064663
+ 0: The maximum resident set size (KB)                   = 542212
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 445.122008
- 0: The maximum resident set size (KB)                   = 544212
+ 0: The total amount of wall time                        = 356.641406
+ 0: The maximum resident set size (KB)                   = 544152
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 455.913983
- 0: The maximum resident set size (KB)                   = 548332
+ 0: The total amount of wall time                        = 378.011675
+ 0: The maximum resident set size (KB)                   = 548316
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,28 +1625,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 369.268483
- 0: The maximum resident set size (KB)                   = 546656
+ 0: The total amount of wall time                        = 275.020990
+ 0: The maximum resident set size (KB)                   = 546572
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 444.960166
- 0: The maximum resident set size (KB)                   = 541944
+ 0: The total amount of wall time                        = 360.356591
+ 0: The maximum resident set size (KB)                   = 541952
 
 Test 042 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_3km
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_3km
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 277.671955
-  0: The maximum resident set size (KB)                   = 572120
+  0: The total amount of wall time                        = 276.268218
+  0: The maximum resident set size (KB)                   = 572216
 
 Test 043 regional_3km PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1711,14 +1711,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 517.680876
-  0: The maximum resident set size (KB)                   = 805636
+  0: The total amount of wall time                        = 451.001417
+  0: The maximum resident set size (KB)                   = 805700
 
 Test 044 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1765,14 +1765,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 570.061986
-  0: The maximum resident set size (KB)                   = 923156
+  0: The total amount of wall time                        = 490.545911
+  0: The maximum resident set size (KB)                   = 923160
 
 Test 045 rap_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_spp_sppt_shum_skeb
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1783,14 +1783,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 419.298347
-  0: The maximum resident set size (KB)                   = 879964
+  0: The total amount of wall time                        = 338.388706
+  0: The maximum resident set size (KB)                   = 879752
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1837,14 +1837,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 637.073539
- 0: The maximum resident set size (KB)                   = 868324
+ 0: The total amount of wall time                        = 564.089808
+ 0: The maximum resident set size (KB)                   = 868460
 
 Test 047 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1883,14 +1883,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.743090
-  0: The maximum resident set size (KB)                   = 546892
+  0: The total amount of wall time                        = 232.057527
+  0: The maximum resident set size (KB)                   = 547060
 
 Test 048 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1937,14 +1937,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 540.854933
-  0: The maximum resident set size (KB)                   = 805684
+  0: The total amount of wall time                        = 449.325511
+  0: The maximum resident set size (KB)                   = 805688
 
 Test 049 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1983,14 +1983,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 251.324326
-  0: The maximum resident set size (KB)                   = 546164
+  0: The total amount of wall time                        = 230.776707
+  0: The maximum resident set size (KB)                   = 546352
 
 Test 050 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 502.874804
-  0: The maximum resident set size (KB)                   = 802792
+  0: The total amount of wall time                        = 432.898466
+  0: The maximum resident set size (KB)                   = 802732
 
 Test 051 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 513.593644
-  0: The maximum resident set size (KB)                   = 799512
+  0: The total amount of wall time                        = 439.809229
+  0: The maximum resident set size (KB)                   = 799388
 
 Test 052 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_v1nssl
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2113,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 622.938505
-  0: The maximum resident set size (KB)                   = 489640
+  0: The total amount of wall time                        = 532.852806
+  0: The maximum resident set size (KB)                   = 489684
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_v1nssl_nohailnoccn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2135,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 627.795693
-  0: The maximum resident set size (KB)                   = 482464
+  0: The total amount of wall time                        = 519.722837
+  0: The maximum resident set size (KB)                   = 482232
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2151,14 +2151,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 266.706875
-  0: The maximum resident set size (KB)                   = 616400
+  0: The total amount of wall time                        = 204.998571
+  0: The maximum resident set size (KB)                   = 616700
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_conus13km_radar_tten_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 196.769970
-  0: The maximum resident set size (KB)                   = 619428
+  0: The total amount of wall time                        = 208.397425
+  0: The maximum resident set size (KB)                   = 619540
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2183,14 +2183,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 221.554938
-  0: The maximum resident set size (KB)                   = 627096
+  0: The total amount of wall time                        = 224.572713
+  0: The maximum resident set size (KB)                   = 627112
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_csawmgt
 Checking test 058 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 363.960039
-  0: The maximum resident set size (KB)                   = 504676
+  0: The total amount of wall time                        = 369.613290
+  0: The maximum resident set size (KB)                   = 504644
 
 Test 058 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_flake
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_flake
 Checking test 059 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 059 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 240.130447
-  0: The maximum resident set size (KB)                   = 506092
+  0: The total amount of wall time                        = 249.619065
+  0: The maximum resident set size (KB)                   = 506032
 
 Test 059 control_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_ras
 Checking test 060 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2237,14 +2237,14 @@ Checking test 060 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 182.479818
-  0: The maximum resident set size (KB)                   = 470052
+  0: The total amount of wall time                        = 183.471773
+  0: The maximum resident set size (KB)                   = 469948
 
 Test 060 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_thompson
 Checking test 061 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2255,14 +2255,14 @@ Checking test 061 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 247.649540
-  0: The maximum resident set size (KB)                   = 822296
+  0: The total amount of wall time                        = 251.065138
+  0: The maximum resident set size (KB)                   = 822448
 
 Test 061 control_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_thompson_no_aero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_thompson_no_aero
 Checking test 062 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2273,54 +2273,54 @@ Checking test 062 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 234.432647
-  0: The maximum resident set size (KB)                   = 815076
+  0: The total amount of wall time                        = 235.737054
+  0: The maximum resident set size (KB)                   = 814944
 
 Test 062 control_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_wam
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_wam
 Checking test 063 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 113.348727
-  0: The maximum resident set size (KB)                   = 184412
+  0: The total amount of wall time                        = 112.666082
+  0: The maximum resident set size (KB)                   = 184436
 
 Test 063 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_debug
 Checking test 064 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 183.105335
-  0: The maximum resident set size (KB)                   = 600012
+  0: The total amount of wall time                        = 177.070727
+  0: The maximum resident set size (KB)                   = 599792
 
 Test 064 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_2threads_debug
 Checking test 065 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 262.601822
- 0: The maximum resident set size (KB)                   = 654124
+ 0: The total amount of wall time                        = 256.777044
+ 0: The maximum resident set size (KB)                   = 654164
 
 Test 065 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_CubedSphereGrid_debug
 Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2347,415 +2347,415 @@ Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 194.991139
-  0: The maximum resident set size (KB)                   = 600524
+  0: The total amount of wall time                        = 159.155483
+  0: The maximum resident set size (KB)                   = 600520
 
 Test 066 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_wrtGauss_netcdf_parallel_debug
 Checking test 067 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.478402
-  0: The maximum resident set size (KB)                   = 599932
+  0: The total amount of wall time                        = 166.716251
+  0: The maximum resident set size (KB)                   = 599936
 
 Test 067 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_stochy_debug
 Checking test 068 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 200.018063
-  0: The maximum resident set size (KB)                   = 606796
+  0: The total amount of wall time                        = 173.358035
+  0: The maximum resident set size (KB)                   = 606756
 
 Test 068 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_lndp_debug
 Checking test 069 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 208.320745
-  0: The maximum resident set size (KB)                   = 604860
+  0: The total amount of wall time                        = 172.633665
+  0: The maximum resident set size (KB)                   = 604836
 
 Test 069 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_csawmg_debug
 Checking test 070 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 250.340554
-  0: The maximum resident set size (KB)                   = 641976
+  0: The total amount of wall time                        = 243.695326
+  0: The maximum resident set size (KB)                   = 641992
 
 Test 070 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_csawmgt_debug
 Checking test 071 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 250.108603
-  0: The maximum resident set size (KB)                   = 641492
+  0: The total amount of wall time                        = 239.850460
+  0: The maximum resident set size (KB)                   = 641584
 
 Test 071 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_ras_debug
 Checking test 072 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 184.765411
-  0: The maximum resident set size (KB)                   = 612864
+  0: The total amount of wall time                        = 156.140103
+  0: The maximum resident set size (KB)                   = 612988
 
 Test 072 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 204.623380
-  0: The maximum resident set size (KB)                   = 656980
+  0: The total amount of wall time                        = 175.784618
+  0: The maximum resident set size (KB)                   = 657040
 
 Test 073 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_debug_p8
 Checking test 074 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.005366
-  0: The maximum resident set size (KB)                   = 947128
+  0: The total amount of wall time                        = 170.172095
+  0: The maximum resident set size (KB)                   = 989468
 
 Test 074 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_thompson_debug
 Checking test 075 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 204.280242
-  0: The maximum resident set size (KB)                   = 962260
+  0: The total amount of wall time                        = 178.325984
+  0: The maximum resident set size (KB)                   = 962252
 
 Test 075 control_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_thompson_no_aero_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_thompson_no_aero_debug
 Checking test 076 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 198.956918
-  0: The maximum resident set size (KB)                   = 959052
+  0: The total amount of wall time                        = 171.036139
+  0: The maximum resident set size (KB)                   = 958988
 
 Test 076 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_thompson_extdiag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_thompson_extdiag_debug
 Checking test 077 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.695534
-  0: The maximum resident set size (KB)                   = 990712
+  0: The total amount of wall time                        = 188.251307
+  0: The maximum resident set size (KB)                   = 990992
 
 Test 077 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_thompson_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_thompson_progcld_thompson_debug
 Checking test 078 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.708464
-  0: The maximum resident set size (KB)                   = 962052
+  0: The total amount of wall time                        = 178.387365
+  0: The maximum resident set size (KB)                   = 961956
 
 Test 078 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/regional_debug
 Checking test 079 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 292.910974
- 0: The maximum resident set size (KB)                   = 570528
+ 0: The total amount of wall time                        = 256.324355
+ 0: The maximum resident set size (KB)                   = 570092
 
 Test 079 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_control_debug
 Checking test 080 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.184781
-  0: The maximum resident set size (KB)                   = 968196
+  0: The total amount of wall time                        = 279.503916
+  0: The maximum resident set size (KB)                   = 968192
 
 Test 080 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_unified_drag_suite_debug
 Checking test 081 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 302.611387
-  0: The maximum resident set size (KB)                   = 968416
+  0: The total amount of wall time                        = 279.763572
+  0: The maximum resident set size (KB)                   = 968336
 
 Test 081 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_diag_debug
 Checking test 082 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.515988
-  0: The maximum resident set size (KB)                   = 1051156
+  0: The total amount of wall time                        = 293.710248
+  0: The maximum resident set size (KB)                   = 1051044
 
 Test 082 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_cires_ugwp_debug
 Checking test 083 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.931402
-  0: The maximum resident set size (KB)                   = 969444
+  0: The total amount of wall time                        = 284.263232
+  0: The maximum resident set size (KB)                   = 969140
 
 Test 083 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_unified_ugwp_debug
 Checking test 084 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.104892
-  0: The maximum resident set size (KB)                   = 968428
+  0: The total amount of wall time                        = 286.469281
+  0: The maximum resident set size (KB)                   = 968408
 
 Test 084 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_lndp_debug
 Checking test 085 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.536260
-  0: The maximum resident set size (KB)                   = 969308
+  0: The total amount of wall time                        = 280.241850
+  0: The maximum resident set size (KB)                   = 969352
 
 Test 085 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_flake_debug
 Checking test 086 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.697312
-  0: The maximum resident set size (KB)                   = 968556
+  0: The total amount of wall time                        = 280.572186
+  0: The maximum resident set size (KB)                   = 968576
 
 Test 086 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_progcld_thompson_debug
 Checking test 087 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 327.402355
-  0: The maximum resident set size (KB)                   = 968184
+  0: The total amount of wall time                        = 280.649408
+  0: The maximum resident set size (KB)                   = 968464
 
 Test 087 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_noah_debug
 Checking test 088 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.258578
-  0: The maximum resident set size (KB)                   = 966948
+  0: The total amount of wall time                        = 278.057026
+  0: The maximum resident set size (KB)                   = 967000
 
 Test 088 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_rrtmgp_debug
 Checking test 089 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 476.743322
-  0: The maximum resident set size (KB)                   = 1091740
+  0: The total amount of wall time                        = 494.782074
+  0: The maximum resident set size (KB)                   = 1091960
 
 Test 089 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.166158
-  0: The maximum resident set size (KB)                   = 968396
+  0: The total amount of wall time                        = 280.438695
+  0: The maximum resident set size (KB)                   = 968024
 
 Test 090 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 091 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 463.696750
-  0: The maximum resident set size (KB)                   = 969064
+  0: The total amount of wall time                        = 463.301089
+  0: The maximum resident set size (KB)                   = 969124
 
 Test 091 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/rrfs_v1beta_debug
 Checking test 092 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 297.848756
-  0: The maximum resident set size (KB)                   = 963528
+  0: The total amount of wall time                        = 284.507876
+  0: The maximum resident set size (KB)                   = 963608
 
 Test 092 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_wam_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_wam_debug
 Checking test 093 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 290.878235
-  0: The maximum resident set size (KB)                   = 215020
+  0: The total amount of wall time                        = 293.011346
+  0: The maximum resident set size (KB)                   = 214964
 
 Test 093 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_atm
 Checking test 094 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 339.376415
-  0: The maximum resident set size (KB)                   = 661552
+  0: The total amount of wall time                        = 350.648622
+  0: The maximum resident set size (KB)                   = 661776
 
 Test 094 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_atm_thompson_gfdlsf
 Checking test 095 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 386.700240
-  0: The maximum resident set size (KB)                   = 1022144
+  0: The total amount of wall time                        = 407.699873
+  0: The maximum resident set size (KB)                   = 1021992
 
 Test 095 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_atm_ocn
 Checking test 096 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2764,14 +2764,14 @@ Checking test 096 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 434.157003
-  0: The maximum resident set size (KB)                   = 692980
+  0: The total amount of wall time                        = 449.029862
+  0: The maximum resident set size (KB)                   = 692828
 
 Test 096 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_atm_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_atm_wav
 Checking test 097 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2780,14 +2780,14 @@ Checking test 097 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 954.540101
-  0: The maximum resident set size (KB)                   = 725748
+  0: The total amount of wall time                        = 929.566692
+  0: The maximum resident set size (KB)                   = 726480
 
 Test 097 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_atm_ocn_wav
 Checking test 098 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2798,28 +2798,28 @@ Checking test 098 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1018.392214
-  0: The maximum resident set size (KB)                   = 735700
+  0: The total amount of wall time                        = 1017.547872
+  0: The maximum resident set size (KB)                   = 735280
 
 Test 098 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_1nest_atm
 Checking test 099 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 554.721084
-  0: The maximum resident set size (KB)                   = 266644
+  0: The total amount of wall time                        = 558.072782
+  0: The maximum resident set size (KB)                   = 265780
 
 Test 099 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_telescopic_2nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_telescopic_2nests_atm
 Checking test 100 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2828,28 +2828,28 @@ Checking test 100 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 606.050175
-  0: The maximum resident set size (KB)                   = 268348
+  0: The total amount of wall time                        = 605.665373
+  0: The maximum resident set size (KB)                   = 266956
 
 Test 100 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_global_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_global_1nest_atm
 Checking test 101 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 246.378574
-  0: The maximum resident set size (KB)                   = 165696
+  0: The total amount of wall time                        = 269.735009
+  0: The maximum resident set size (KB)                   = 165288
 
 Test 101 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_global_multiple_4nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_global_multiple_4nests_atm
 Checking test 102 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2862,42 +2862,42 @@ Checking test 102 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 721.704225
+  0: The total amount of wall time                        = 707.022211
   0: The maximum resident set size (KB)                   = 233968
 
 Test 102 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_specified_moving_1nest_atm
 Checking test 103 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 325.958835
-  0: The maximum resident set size (KB)                   = 273828
+  0: The total amount of wall time                        = 329.584787
+  0: The maximum resident set size (KB)                   = 273836
 
 Test 103 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_storm_following_1nest_atm
 Checking test 104 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 316.592127
-  0: The maximum resident set size (KB)                   = 273840
+  0: The total amount of wall time                        = 318.753084
+  0: The maximum resident set size (KB)                   = 273532
 
 Test 104 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 105 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2906,14 +2906,14 @@ Checking test 105 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 351.915665
-  0: The maximum resident set size (KB)                   = 300196
+  0: The total amount of wall time                        = 330.190135
+  0: The maximum resident set size (KB)                   = 300272
 
 Test 105 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2924,28 +2924,28 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 877.757932
-  0: The maximum resident set size (KB)                   = 359296
+  0: The total amount of wall time                        = 862.011751
+  0: The maximum resident set size (KB)                   = 359456
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_global_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_global_storm_following_1nest_atm
 Checking test 107 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 94.110273
-  0: The maximum resident set size (KB)                   = 184912
+  0: The total amount of wall time                        = 100.362225
+  0: The maximum resident set size (KB)                   = 184752
 
 Test 107 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_docn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_docn
 Checking test 108 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2953,14 +2953,14 @@ Checking test 108 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 425.852244
-  0: The maximum resident set size (KB)                   = 703044
+  0: The total amount of wall time                        = 421.584508
+  0: The maximum resident set size (KB)                   = 703552
 
 Test 108 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_docn_oisst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_docn_oisst
 Checking test 109 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2968,118 +2968,118 @@ Checking test 109 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 442.654982
-  0: The maximum resident set size (KB)                   = 694004
+  0: The total amount of wall time                        = 417.756960
+  0: The maximum resident set size (KB)                   = 693892
 
 Test 109 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/hafs_regional_datm_cdeps
 Checking test 110 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1056.259384
-  0: The maximum resident set size (KB)                   = 806884
+  0: The total amount of wall time                        = 1051.636474
+  0: The maximum resident set size (KB)                   = 806872
 
 Test 110 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_control_cfsr
 Checking test 111 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.382721
- 0: The maximum resident set size (KB)                   = 687948
+ 0: The total amount of wall time                        = 149.347149
+ 0: The maximum resident set size (KB)                   = 687944
 
 Test 111 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_restart_cfsr
 Checking test 112 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 108.346067
- 0: The maximum resident set size (KB)                   = 693544
+ 0: The total amount of wall time                        = 88.452702
+ 0: The maximum resident set size (KB)                   = 687980
 
 Test 112 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_control_gefs
 Checking test 113 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.395818
- 0: The maximum resident set size (KB)                   = 571064
+ 0: The total amount of wall time                        = 145.468770
+ 0: The maximum resident set size (KB)                   = 567216
 
 Test 113 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_iau_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_iau_gefs
 Checking test 114 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 175.013900
- 0: The maximum resident set size (KB)                   = 569144
+ 0: The total amount of wall time                        = 151.852274
+ 0: The maximum resident set size (KB)                   = 567028
 
 Test 114 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_stochy_gefs
 Checking test 115 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 167.759887
- 0: The maximum resident set size (KB)                   = 573336
+ 0: The total amount of wall time                        = 150.157485
+ 0: The maximum resident set size (KB)                   = 569028
 
 Test 115 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_bulk_cfsr
 Checking test 116 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 171.320945
- 0: The maximum resident set size (KB)                   = 687784
+ 0: The total amount of wall time                        = 150.140544
+ 0: The maximum resident set size (KB)                   = 687952
 
 Test 116 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_bulk_gefs
 Checking test 117 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 166.710300
- 0: The maximum resident set size (KB)                   = 569184
+ 0: The total amount of wall time                        = 146.635234
+ 0: The maximum resident set size (KB)                   = 569080
 
 Test 117 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_mx025_cfsr
 Checking test 118 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3088,14 +3088,14 @@ Checking test 118 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 362.315978
-  0: The maximum resident set size (KB)                   = 487640
+  0: The total amount of wall time                        = 354.116787
+  0: The maximum resident set size (KB)                   = 489288
 
 Test 118 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_mx025_gefs
 Checking test 119 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3104,64 +3104,64 @@ Checking test 119 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 370.767537
-  0: The maximum resident set size (KB)                   = 469468
+  0: The total amount of wall time                        = 355.415454
+  0: The maximum resident set size (KB)                   = 469160
 
 Test 119 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_multiple_files_cfsr
 Checking test 120 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 172.072822
- 0: The maximum resident set size (KB)                   = 687904
+ 0: The total amount of wall time                        = 151.185661
+ 0: The maximum resident set size (KB)                   = 693436
 
 Test 120 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_3072x1536_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_3072x1536_cfsr
 Checking test 121 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 222.943327
- 0: The maximum resident set size (KB)                   = 1843188
+ 0: The total amount of wall time                        = 203.794250
+ 0: The maximum resident set size (KB)                   = 1843140
 
 Test 121 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_gfs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_gfs
 Checking test 122 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 222.935987
- 0: The maximum resident set size (KB)                   = 1847656
+ 0: The total amount of wall time                        = 203.894134
+ 0: The maximum resident set size (KB)                   = 1843204
 
 Test 122 datm_cdeps_gfs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/datm_cdeps_debug_cfsr
 Checking test 123 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 386.820492
- 0: The maximum resident set size (KB)                   = 693388
+ 0: The total amount of wall time                        = 366.982595
+ 0: The maximum resident set size (KB)                   = 693264
 
 Test 123 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/control_atmwav
 Checking test 124 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3205,14 +3205,14 @@ Checking test 124 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 114.634490
-  0: The maximum resident set size (KB)                   = 450348
+  0: The total amount of wall time                        = 91.014053
+  0: The maximum resident set size (KB)                   = 450128
 
 Test 124 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/atmaero_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_29096/atmaero_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/atmaero_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_19824/atmaero_control_p8
 Checking test 125 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3256,12 +3256,12 @@ Checking test 125 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 368.720072
-  0: The maximum resident set size (KB)                   = 1346892
+  0: The total amount of wall time                        = 354.633107
+  0: The maximum resident set size (KB)                   = 1362704
 
 Test 125 atmaero_control_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 10 19:56:19 EDT 2022
-Elapsed time: 01h:37m:17s. Have a nice day!
+Mon Jun 13 18:30:14 EDT 2022
+Elapsed time: 01h:22m:43s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,921 +1,1079 @@
-Mon Jun 13 15:46:00 UTC 2022
+Mon Jun 13 16:34:23 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 186 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 298 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 94 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 295 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 95 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 005 elapsed time 230 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 006 elapsed time 122 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 007 elapsed time 108 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 107 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control
 Checking test 001 control results ....
-Moving baseline 001 control files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 799.456689
-  0: The maximum resident set size (KB)                   = 480776
+  0: The total amount of wall time                        = 772.668098
+  0: The maximum resident set size (KB)                   = 481160
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_c48
-Checking test 002 control_c48 results ....
-Moving baseline 002 control_c48 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-0: The total amount of wall time                        = 670.341364
-0: The maximum resident set size (KB)                   = 697792
-
-Test 002 control_c48 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_stochy
-Checking test 003 control_stochy results ....
-Moving baseline 003 control_stochy files ....
- Moving sfcf000.nc .........OK
- Moving sfcf012.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf012.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF12 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 620.374509
-  0: The maximum resident set size (KB)                   = 487132
-
-Test 003 control_stochy PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_flake
-Checking test 004 control_flake results ....
-Moving baseline 004 control_flake files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 1374.004749
-  0: The maximum resident set size (KB)                   = 526604
-
-Test 004 control_flake PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson
-Checking test 005 control_thompson results ....
-Moving baseline 005 control_thompson files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 1002.099042
-  0: The maximum resident set size (KB)                   = 843708
-
-Test 005 control_thompson PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_no_aero
-Checking test 006 control_thompson_no_aero results ....
-Moving baseline 006 control_thompson_no_aero files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 991.599369
-  0: The maximum resident set size (KB)                   = 835068
-
-Test 006 control_thompson_no_aero PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_ras
-Checking test 007 control_ras results ....
-Moving baseline 007 control_ras files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 813.684149
-  0: The maximum resident set size (KB)                   = 491172
-
-Test 007 control_ras PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_p8
-Checking test 008 control_p8 results ....
-Moving baseline 008 control_p8 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 887.693889
-  0: The maximum resident set size (KB)                   = 837080
-
-Test 008 control_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_control
-Checking test 009 rap_control results ....
-Moving baseline 009 rap_control files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 1443.424338
-  0: The maximum resident set size (KB)                   = 835768
-
-Test 009 rap_control PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_sfcdiff
-Checking test 010 rap_sfcdiff results ....
-Moving baseline 010 rap_sfcdiff files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 1393.218910
-  0: The maximum resident set size (KB)                   = 833540
-
-Test 010 rap_sfcdiff PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/hrrr_control
-Checking test 011 hrrr_control results ....
-Moving baseline 011 hrrr_control files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 1430.363890
-  0: The maximum resident set size (KB)                   = 833172
-
-Test 011 hrrr_control PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_v1beta
-Checking test 012 rrfs_v1beta results ....
-Moving baseline 012 rrfs_v1beta files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 1409.348743
-  0: The maximum resident set size (KB)                   = 832840
-
-Test 012 rrfs_v1beta PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_conus13km_hrrr_warm
-Checking test 013 rrfs_conus13km_hrrr_warm results ....
-Moving baseline 013 rrfs_conus13km_hrrr_warm files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving sfcf002.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
- Moving atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 1489.256449
-  0: The maximum resident set size (KB)                   = 635684
-
-Test 013 rrfs_conus13km_hrrr_warm PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_conus13km_radar_tten_warm
-Checking test 014 rrfs_conus13km_radar_tten_warm results ....
-Moving baseline 014 rrfs_conus13km_radar_tten_warm files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving sfcf002.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
- Moving atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 1507.049888
-  0: The maximum resident set size (KB)                   = 639420
-
-Test 014 rrfs_conus13km_radar_tten_warm PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_smoke_conus13km_hrrr_warm
-Checking test 015 rrfs_smoke_conus13km_hrrr_warm results ....
-Moving baseline 015 rrfs_smoke_conus13km_hrrr_warm files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving sfcf002.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
- Moving atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 1572.530287
-  0: The maximum resident set size (KB)                   = 650124
-
-Test 015 rrfs_smoke_conus13km_hrrr_warm PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_debug
-Checking test 016 control_debug results ....
-Moving baseline 016 control_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 96.859648
-  0: The maximum resident set size (KB)                   = 474560
-
-Test 016 control_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_diag_debug
-Checking test 017 control_diag_debug results ....
-Moving baseline 017 control_diag_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 123.871468
-  0: The maximum resident set size (KB)                   = 536128
-
-Test 017 control_diag_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/regional_debug
-Checking test 018 regional_debug results ....
-Moving baseline 018 regional_debug files ....
- Moving dynf000.nc .........OK
- Moving dynf001.nc .........OK
- Moving phyf000.nc .........OK
- Moving phyf001.nc .........OK
-
- 0: The total amount of wall time                        = 124.183441
- 0: The maximum resident set size (KB)                   = 553600
-
-Test 018 regional_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_control_debug
-Checking test 019 rap_control_debug results ....
-Moving baseline 019 rap_control_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 164.829079
-  0: The maximum resident set size (KB)                   = 847828
-
-Test 019 rap_control_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_diag_debug
-Checking test 020 rap_diag_debug results ....
-Moving baseline 020 rap_diag_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 202.470166
-  0: The maximum resident set size (KB)                   = 930596
-
-Test 020 rap_diag_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_noah_sfcdiff_cires_ugwp_debug
-Checking test 021 rap_noah_sfcdiff_cires_ugwp_debug results ....
-Moving baseline 021 rap_noah_sfcdiff_cires_ugwp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 254.398206
-  0: The maximum resident set size (KB)                   = 846416
-
-Test 021 rap_noah_sfcdiff_cires_ugwp_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_progcld_thompson_debug
-Checking test 022 rap_progcld_thompson_debug results ....
-Moving baseline 022 rap_progcld_thompson_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 166.923212
-  0: The maximum resident set size (KB)                   = 851888
-
-Test 022 rap_progcld_thompson_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_v1beta_debug
-Checking test 023 rrfs_v1beta_debug results ....
-Moving baseline 023 rrfs_v1beta_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 164.856931
-  0: The maximum resident set size (KB)                   = 849632
-
-Test 023 rrfs_v1beta_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_debug
-Checking test 024 control_thompson_debug results ....
-Moving baseline 024 control_thompson_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 111.546272
-  0: The maximum resident set size (KB)                   = 837452
-
-Test 024 control_thompson_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_no_aero_debug
-Checking test 025 control_thompson_no_aero_debug results ....
-Moving baseline 025 control_thompson_no_aero_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 114.785976
-  0: The maximum resident set size (KB)                   = 833576
-
-Test 025 control_thompson_no_aero_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_extdiag_debug
-Checking test 026 control_thompson_extdiag_debug results ....
-Moving baseline 026 control_thompson_extdiag_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 129.792872
-  0: The maximum resident set size (KB)                   = 869572
-
-Test 026 control_thompson_extdiag_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_progcld_thompson_debug
-Checking test 027 control_thompson_progcld_thompson_debug results ....
-Moving baseline 027 control_thompson_progcld_thompson_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 114.041795
-  0: The maximum resident set size (KB)                   = 842732
-
-Test 027 control_thompson_progcld_thompson_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_ras_debug
-Checking test 028 control_ras_debug results ....
-Moving baseline 028 control_ras_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 102.800001
-  0: The maximum resident set size (KB)                   = 488900
-
-Test 028 control_ras_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_stochy_debug
-Checking test 029 control_stochy_debug results ....
-Moving baseline 029 control_stochy_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 116.030002
-  0: The maximum resident set size (KB)                   = 480280
-
-Test 029 control_stochy_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_debug_p8
-Checking test 030 control_debug_p8 results ....
-Moving baseline 030 control_debug_p8 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 111.420351
-  0: The maximum resident set size (KB)                   = 837176
-
-Test 030 control_debug_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_wam_debug
-Checking test 031 control_wam_debug results ....
-Moving baseline 031 control_wam_debug files ....
- Moving sfcf019.nc .........OK
- Moving atmf019.nc .........OK
-
-  0: The total amount of wall time                        = 179.678942
-  0: The maximum resident set size (KB)                   = 196424
-
-Test 031 control_wam_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/cpld_control_noaero_p8
-Checking test 032 cpld_control_noaero_p8 results ....
-Moving baseline 032 cpld_control_noaero_p8 files ....
- Moving sfcf021.tile1.nc .........OK
- Moving sfcf021.tile2.nc .........OK
- Moving sfcf021.tile3.nc .........OK
- Moving sfcf021.tile4.nc .........OK
- Moving sfcf021.tile5.nc .........OK
- Moving sfcf021.tile6.nc .........OK
- Moving atmf021.tile1.nc .........OK
- Moving atmf021.tile2.nc .........OK
- Moving atmf021.tile3.nc .........OK
- Moving atmf021.tile4.nc .........OK
- Moving atmf021.tile5.nc .........OK
- Moving atmf021.tile6.nc .........OK
- Moving sfcf024.tile1.nc .........OK
- Moving sfcf024.tile2.nc .........OK
- Moving sfcf024.tile3.nc .........OK
- Moving sfcf024.tile4.nc .........OK
- Moving sfcf024.tile5.nc .........OK
- Moving sfcf024.tile6.nc .........OK
- Moving atmf024.tile1.nc .........OK
- Moving atmf024.tile2.nc .........OK
- Moving atmf024.tile3.nc .........OK
- Moving atmf024.tile4.nc .........OK
- Moving atmf024.tile5.nc .........OK
- Moving atmf024.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-23-21600.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Moving 20210323.060000.out_pnt.ww3 .........OK
- Moving 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 1293.650542
-  0: The maximum resident set size (KB)                   = 874280
-
-Test 032 cpld_control_noaero_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/cpld_debug_noaero_p8
-Checking test 033 cpld_debug_noaero_p8 results ....
-Moving baseline 033 cpld_debug_noaero_p8 files ....
- Moving sfcf003.tile1.nc .........OK
- Moving sfcf003.tile2.nc .........OK
- Moving sfcf003.tile3.nc .........OK
- Moving sfcf003.tile4.nc .........OK
- Moving sfcf003.tile5.nc .........OK
- Moving sfcf003.tile6.nc .........OK
- Moving atmf003.tile1.nc .........OK
- Moving atmf003.tile2.nc .........OK
- Moving atmf003.tile3.nc .........OK
- Moving atmf003.tile4.nc .........OK
- Moving atmf003.tile5.nc .........OK
- Moving atmf003.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-22-32400.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
- Moving 20210322.090000.out_pnt.ww3 .........OK
- Moving 20210322.090000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 439.544205
-  0: The maximum resident set size (KB)                   = 890332
-
-Test 033 cpld_debug_noaero_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/datm_cdeps_control_cfsr
-Checking test 034 datm_cdeps_control_cfsr results ....
-Moving baseline 034 datm_cdeps_control_cfsr files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 163.529307
- 0: The maximum resident set size (KB)                   = 628008
-
-Test 034 datm_cdeps_control_cfsr PASS
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_restart
+Checking test 002 control_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 381.882755
+  0: The maximum resident set size (KB)                   = 186508
+
+Test 002 control_restart PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_c48
+Checking test 003 control_c48 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+0: The total amount of wall time                        = 671.442357
+0: The maximum resident set size (KB)                   = 702444
+
+Test 003 control_c48 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_stochy
+Checking test 004 control_stochy results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 607.853519
+  0: The maximum resident set size (KB)                   = 482712
+
+Test 004 control_stochy PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_flake
+Checking test 005 control_flake results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 1365.063472
+  0: The maximum resident set size (KB)                   = 529304
+
+Test 005 control_flake PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson
+Checking test 006 control_thompson results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 977.659863
+  0: The maximum resident set size (KB)                   = 844876
+
+Test 006 control_thompson PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_no_aero
+Checking test 007 control_thompson_no_aero results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 968.749830
+  0: The maximum resident set size (KB)                   = 836104
+
+Test 007 control_thompson_no_aero PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_ras
+Checking test 008 control_ras results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 800.908217
+  0: The maximum resident set size (KB)                   = 490168
+
+Test 008 control_ras PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_p8
+Checking test 009 control_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 869.716157
+  0: The maximum resident set size (KB)                   = 832320
+
+Test 009 control_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_control
+Checking test 010 rap_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 1429.447834
+  0: The maximum resident set size (KB)                   = 833688
+
+Test 010 rap_control PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_2threads
+Checking test 011 rap_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+ 0: The total amount of wall time                        = 1435.764102
+ 0: The maximum resident set size (KB)                   = 896648
+
+Test 011 rap_2threads PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_restart
+Checking test 012 rap_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 698.012106
+  0: The maximum resident set size (KB)                   = 541416
+
+Test 012 rap_restart PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_sfcdiff
+Checking test 013 rap_sfcdiff results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 1425.191763
+  0: The maximum resident set size (KB)                   = 836672
+
+Test 013 rap_sfcdiff PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_sfcdiff_restart
+Checking test 014 rap_sfcdiff_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 682.305130
+  0: The maximum resident set size (KB)                   = 539524
+
+Test 014 rap_sfcdiff_restart PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/hrrr_control
+Checking test 015 hrrr_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 1399.981609
+  0: The maximum resident set size (KB)                   = 832468
+
+Test 015 hrrr_control PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_v1beta
+Checking test 016 rrfs_v1beta results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 1448.695657
+  0: The maximum resident set size (KB)                   = 835652
+
+Test 016 rrfs_v1beta PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_conus13km_hrrr_warm
+Checking test 017 rrfs_conus13km_hrrr_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 1575.071868
+  0: The maximum resident set size (KB)                   = 634988
+
+Test 017 rrfs_conus13km_hrrr_warm PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_conus13km_radar_tten_warm
+Checking test 018 rrfs_conus13km_radar_tten_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 1527.340573
+  0: The maximum resident set size (KB)                   = 642176
+
+Test 018 rrfs_conus13km_radar_tten_warm PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_smoke_conus13km_hrrr_warm
+Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 1564.516769
+  0: The maximum resident set size (KB)                   = 654824
+
+Test 019 rrfs_smoke_conus13km_hrrr_warm PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_debug
+Checking test 020 control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 99.602602
+  0: The maximum resident set size (KB)                   = 477900
+
+Test 020 control_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_diag_debug
+Checking test 021 control_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 124.750736
+  0: The maximum resident set size (KB)                   = 532652
+
+Test 021 control_diag_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/regional_debug
+Checking test 022 regional_debug results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+
+ 0: The total amount of wall time                        = 124.863963
+ 0: The maximum resident set size (KB)                   = 555144
+
+Test 022 regional_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_control_debug
+Checking test 023 rap_control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 164.978662
+  0: The maximum resident set size (KB)                   = 850316
+
+Test 023 rap_control_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_diag_debug
+Checking test 024 rap_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 205.289767
+  0: The maximum resident set size (KB)                   = 930620
+
+Test 024 rap_diag_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 267.865890
+  0: The maximum resident set size (KB)                   = 845800
+
+Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_progcld_thompson_debug
+Checking test 026 rap_progcld_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 166.055119
+  0: The maximum resident set size (KB)                   = 844544
+
+Test 026 rap_progcld_thompson_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_v1beta_debug
+Checking test 027 rrfs_v1beta_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 167.064384
+  0: The maximum resident set size (KB)                   = 848652
+
+Test 027 rrfs_v1beta_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_debug
+Checking test 028 control_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 110.316104
+  0: The maximum resident set size (KB)                   = 841328
+
+Test 028 control_thompson_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_no_aero_debug
+Checking test 029 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 105.920136
+  0: The maximum resident set size (KB)                   = 834928
+
+Test 029 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_extdiag_debug
+Checking test 030 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 133.841397
+  0: The maximum resident set size (KB)                   = 866744
+
+Test 030 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_progcld_thompson_debug
+Checking test 031 control_thompson_progcld_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 115.615824
+  0: The maximum resident set size (KB)                   = 841464
+
+Test 031 control_thompson_progcld_thompson_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_ras_debug
+Checking test 032 control_ras_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 101.760428
+  0: The maximum resident set size (KB)                   = 487936
+
+Test 032 control_ras_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_stochy_debug
+Checking test 033 control_stochy_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 117.071574
+  0: The maximum resident set size (KB)                   = 479080
+
+Test 033 control_stochy_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_debug_p8
+Checking test 034 control_debug_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 110.212486
+  0: The maximum resident set size (KB)                   = 835224
+
+Test 034 control_debug_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_wam_debug
+Checking test 035 control_wam_debug results ....
+ Comparing sfcf019.nc .........OK
+ Comparing atmf019.nc .........OK
+
+  0: The total amount of wall time                        = 178.951419
+  0: The maximum resident set size (KB)                   = 193512
+
+Test 035 control_wam_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/cpld_control_noaero_p8
+Checking test 036 cpld_control_noaero_p8 results ....
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 1216.576257
+  0: The maximum resident set size (KB)                   = 876844
+
+Test 036 cpld_control_noaero_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/cpld_debug_noaero_p8
+Checking test 037 cpld_debug_noaero_p8 results ....
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
+ Comparing atmf003.tile1.nc .........OK
+ Comparing atmf003.tile2.nc .........OK
+ Comparing atmf003.tile3.nc .........OK
+ Comparing atmf003.tile4.nc .........OK
+ Comparing atmf003.tile5.nc .........OK
+ Comparing atmf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-22-32400.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
+ Comparing 20210322.090000.out_pnt.ww3 .........OK
+ Comparing 20210322.090000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 439.532382
+  0: The maximum resident set size (KB)                   = 888736
+
+Test 037 cpld_debug_noaero_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/datm_cdeps_control_cfsr
+Checking test 038 datm_cdeps_control_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 162.829394
+ 0: The maximum resident set size (KB)                   = 629164
+
+Test 038 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jun 13 16:18:21 UTC 2022
-Elapsed time: 00h:32m:23s. Have a nice day!
+Mon Jun 13 17:17:22 UTC 2022
+Elapsed time: 00h:43m:00s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,16 +1,16 @@
-Mon Jun 13 16:34:23 UTC 2022
+Mon Jun 13 20:42:24 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 295 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 95 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 297 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 96 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 005 elapsed time 230 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 122 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 007 elapsed time 107 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 123 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 007 elapsed time 114 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -57,14 +57,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 772.668098
-  0: The maximum resident set size (KB)                   = 481160
+  0: The total amount of wall time                        = 787.713479
+  0: The maximum resident set size (KB)                   = 479568
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,14 +103,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 381.882755
-  0: The maximum resident set size (KB)                   = 186508
+  0: The total amount of wall time                        = 385.755239
+  0: The maximum resident set size (KB)                   = 184268
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -149,14 +149,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 671.442357
-0: The maximum resident set size (KB)                   = 702444
+0: The total amount of wall time                        = 677.995020
+0: The maximum resident set size (KB)                   = 698820
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -167,14 +167,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 607.853519
-  0: The maximum resident set size (KB)                   = 482712
+  0: The total amount of wall time                        = 629.176069
+  0: The maximum resident set size (KB)                   = 485056
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -185,14 +185,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1365.063472
-  0: The maximum resident set size (KB)                   = 529304
+  0: The total amount of wall time                        = 1373.012181
+  0: The maximum resident set size (KB)                   = 530088
 
 Test 005 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -203,14 +203,14 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 977.659863
-  0: The maximum resident set size (KB)                   = 844876
+  0: The total amount of wall time                        = 997.821087
+  0: The maximum resident set size (KB)                   = 841752
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -221,14 +221,14 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 968.749830
-  0: The maximum resident set size (KB)                   = 836104
+  0: The total amount of wall time                        = 963.026843
+  0: The maximum resident set size (KB)                   = 839248
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_ras
 Checking test 008 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -239,14 +239,14 @@ Checking test 008 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 800.908217
-  0: The maximum resident set size (KB)                   = 490168
+  0: The total amount of wall time                        = 808.236202
+  0: The maximum resident set size (KB)                   = 492260
 
 Test 008 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_p8
 Checking test 009 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -293,14 +293,14 @@ Checking test 009 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 869.716157
-  0: The maximum resident set size (KB)                   = 832320
+  0: The total amount of wall time                        = 867.450872
+  0: The maximum resident set size (KB)                   = 837108
 
 Test 009 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_control
 Checking test 010 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -347,14 +347,14 @@ Checking test 010 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1429.447834
-  0: The maximum resident set size (KB)                   = 833688
+  0: The total amount of wall time                        = 1396.546637
+  0: The maximum resident set size (KB)                   = 829136
 
 Test 010 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_2threads
 Checking test 011 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -401,14 +401,14 @@ Checking test 011 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1435.764102
- 0: The maximum resident set size (KB)                   = 896648
+ 0: The total amount of wall time                        = 1432.085613
+ 0: The maximum resident set size (KB)                   = 892020
 
 Test 011 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_restart
 Checking test 012 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -447,14 +447,14 @@ Checking test 012 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 698.012106
-  0: The maximum resident set size (KB)                   = 541416
+  0: The total amount of wall time                        = 692.496143
+  0: The maximum resident set size (KB)                   = 540928
 
 Test 012 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_sfcdiff
 Checking test 013 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -501,14 +501,14 @@ Checking test 013 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1425.191763
-  0: The maximum resident set size (KB)                   = 836672
+  0: The total amount of wall time                        = 1392.802291
+  0: The maximum resident set size (KB)                   = 832896
 
 Test 013 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_sfcdiff_restart
 Checking test 014 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -547,14 +547,14 @@ Checking test 014 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 682.305130
-  0: The maximum resident set size (KB)                   = 539524
+  0: The total amount of wall time                        = 704.270196
+  0: The maximum resident set size (KB)                   = 542948
 
 Test 014 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/hrrr_control
 Checking test 015 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -601,14 +601,14 @@ Checking test 015 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1399.981609
-  0: The maximum resident set size (KB)                   = 832468
+  0: The total amount of wall time                        = 1358.520603
+  0: The maximum resident set size (KB)                   = 836472
 
 Test 015 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -655,14 +655,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1448.695657
-  0: The maximum resident set size (KB)                   = 835652
+  0: The total amount of wall time                        = 1403.448444
+  0: The maximum resident set size (KB)                   = 829000
 
 Test 016 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rrfs_conus13km_hrrr_warm
 Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -671,14 +671,14 @@ Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1575.071868
-  0: The maximum resident set size (KB)                   = 634988
+  0: The total amount of wall time                        = 1484.381273
+  0: The maximum resident set size (KB)                   = 636736
 
 Test 017 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rrfs_conus13km_radar_tten_warm
 Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -687,14 +687,14 @@ Checking test 018 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1527.340573
-  0: The maximum resident set size (KB)                   = 642176
+  0: The total amount of wall time                        = 1548.058502
+  0: The maximum resident set size (KB)                   = 641944
 
 Test 018 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rrfs_smoke_conus13km_hrrr_warm
 Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -703,236 +703,236 @@ Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1564.516769
-  0: The maximum resident set size (KB)                   = 654824
+  0: The total amount of wall time                        = 1607.295065
+  0: The maximum resident set size (KB)                   = 652376
 
 Test 019 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 99.602602
-  0: The maximum resident set size (KB)                   = 477900
+  0: The total amount of wall time                        = 96.857814
+  0: The maximum resident set size (KB)                   = 483648
 
 Test 020 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 124.750736
-  0: The maximum resident set size (KB)                   = 532652
+  0: The total amount of wall time                        = 124.080540
+  0: The maximum resident set size (KB)                   = 541556
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 124.863963
- 0: The maximum resident set size (KB)                   = 555144
+ 0: The total amount of wall time                        = 125.889466
+ 0: The maximum resident set size (KB)                   = 556656
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.978662
-  0: The maximum resident set size (KB)                   = 850316
+  0: The total amount of wall time                        = 164.515638
+  0: The maximum resident set size (KB)                   = 854048
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.289767
-  0: The maximum resident set size (KB)                   = 930620
+  0: The total amount of wall time                        = 206.737900
+  0: The maximum resident set size (KB)                   = 935312
 
 Test 024 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.865890
-  0: The maximum resident set size (KB)                   = 845800
+  0: The total amount of wall time                        = 258.634689
+  0: The maximum resident set size (KB)                   = 854120
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.055119
-  0: The maximum resident set size (KB)                   = 844544
+  0: The total amount of wall time                        = 172.889708
+  0: The maximum resident set size (KB)                   = 848796
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.064384
-  0: The maximum resident set size (KB)                   = 848652
+  0: The total amount of wall time                        = 167.407800
+  0: The maximum resident set size (KB)                   = 852336
 
 Test 027 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.316104
-  0: The maximum resident set size (KB)                   = 841328
+  0: The total amount of wall time                        = 114.669911
+  0: The maximum resident set size (KB)                   = 845580
 
 Test 028 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.920136
-  0: The maximum resident set size (KB)                   = 834928
+  0: The total amount of wall time                        = 109.154068
+  0: The maximum resident set size (KB)                   = 841060
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 133.841397
-  0: The maximum resident set size (KB)                   = 866744
+  0: The total amount of wall time                        = 131.975258
+  0: The maximum resident set size (KB)                   = 874748
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_thompson_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.615824
-  0: The maximum resident set size (KB)                   = 841464
+  0: The total amount of wall time                        = 113.893843
+  0: The maximum resident set size (KB)                   = 844704
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_ras_debug
 Checking test 032 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.760428
-  0: The maximum resident set size (KB)                   = 487936
+  0: The total amount of wall time                        = 99.323775
+  0: The maximum resident set size (KB)                   = 495532
 
 Test 032 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_stochy_debug
 Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 117.071574
-  0: The maximum resident set size (KB)                   = 479080
+  0: The total amount of wall time                        = 113.991843
+  0: The maximum resident set size (KB)                   = 488496
 
 Test 033 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_debug_p8
 Checking test 034 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.212486
-  0: The maximum resident set size (KB)                   = 835224
+  0: The total amount of wall time                        = 111.239018
+  0: The maximum resident set size (KB)                   = 840848
 
 Test 034 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/control_wam_debug
 Checking test 035 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 178.951419
-  0: The maximum resident set size (KB)                   = 193512
+  0: The total amount of wall time                        = 180.442781
+  0: The maximum resident set size (KB)                   = 191932
 
 Test 035 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/cpld_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/cpld_control_noaero_p8
 Checking test 036 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -996,14 +996,14 @@ Checking test 036 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1216.576257
-  0: The maximum resident set size (KB)                   = 876844
+  0: The total amount of wall time                        = 1226.053307
+  0: The maximum resident set size (KB)                   = 879344
 
 Test 036 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/cpld_debug_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/cpld_debug_noaero_p8
 Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1055,25 +1055,25 @@ Checking test 037 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 439.532382
-  0: The maximum resident set size (KB)                   = 888736
+  0: The total amount of wall time                        = 436.853621
+  0: The maximum resident set size (KB)                   = 890428
 
 Test 037 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/stmp4/Samuel.Trahan/TYPO_RT/REGRESSION_TEST_GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_177281/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_8122/datm_cdeps_control_cfsr
 Checking test 038 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 162.829394
- 0: The maximum resident set size (KB)                   = 629164
+ 0: The total amount of wall time                        = 166.754967
+ 0: The maximum resident set size (KB)                   = 628208
 
 Test 038 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jun 13 17:17:22 UTC 2022
-Elapsed time: 00h:43m:00s. Have a nice day!
+Mon Jun 13 22:02:57 UTC 2022
+Elapsed time: 01h:20m:33s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,1079 +1,921 @@
-Fri Jun 10 23:47:49 UTC 2022
+Mon Jun 13 15:46:00 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 307 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 109 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 235 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 133 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 007 elapsed time 111 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 186 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 298 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 94 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 230 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 122 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 007 elapsed time 108 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control
 Checking test 001 control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+Moving baseline 001 control files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 801.598672
-  0: The maximum resident set size (KB)                   = 479136
+  0: The total amount of wall time                        = 799.456689
+  0: The maximum resident set size (KB)                   = 480776
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_restart
-Checking test 002 control_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 393.093463
-  0: The maximum resident set size (KB)                   = 185380
-
-Test 002 control_restart PASS
-
-
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_c48
-Checking test 003 control_c48 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_c48
+Checking test 002 control_c48 results ....
+Moving baseline 002 control_c48 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 672.396272
-0: The maximum resident set size (KB)                   = 697820
+0: The total amount of wall time                        = 670.341364
+0: The maximum resident set size (KB)                   = 697792
 
-Test 003 control_c48 PASS
+Test 002 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_stochy
-Checking test 004 control_stochy results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_stochy
+Checking test 003 control_stochy results ....
+Moving baseline 003 control_stochy files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf012.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf012.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF12 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 624.105720
-  0: The maximum resident set size (KB)                   = 483908
+  0: The total amount of wall time                        = 620.374509
+  0: The maximum resident set size (KB)                   = 487132
 
-Test 004 control_stochy PASS
+Test 003 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_flake
-Checking test 005 control_flake results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_flake
+Checking test 004 control_flake results ....
+Moving baseline 004 control_flake files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1371.792018
-  0: The maximum resident set size (KB)                   = 529512
+  0: The total amount of wall time                        = 1374.004749
+  0: The maximum resident set size (KB)                   = 526604
 
-Test 005 control_flake PASS
+Test 004 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_thompson
-Checking test 006 control_thompson results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson
+Checking test 005 control_thompson results ....
+Moving baseline 005 control_thompson files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1006.188558
-  0: The maximum resident set size (KB)                   = 843920
+  0: The total amount of wall time                        = 1002.099042
+  0: The maximum resident set size (KB)                   = 843708
 
-Test 006 control_thompson PASS
+Test 005 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_thompson_no_aero
-Checking test 007 control_thompson_no_aero results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_no_aero
+Checking test 006 control_thompson_no_aero results ....
+Moving baseline 006 control_thompson_no_aero files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 977.034200
-  0: The maximum resident set size (KB)                   = 836416
+  0: The total amount of wall time                        = 991.599369
+  0: The maximum resident set size (KB)                   = 835068
 
-Test 007 control_thompson_no_aero PASS
+Test 006 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_ras
-Checking test 008 control_ras results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_ras
+Checking test 007 control_ras results ....
+Moving baseline 007 control_ras files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 807.038609
-  0: The maximum resident set size (KB)                   = 491468
+  0: The total amount of wall time                        = 813.684149
+  0: The maximum resident set size (KB)                   = 491172
 
-Test 008 control_ras PASS
+Test 007 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_p8
-Checking test 009 control_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_p8
+Checking test 008 control_p8 results ....
+Moving baseline 008 control_p8 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 890.448669
-  0: The maximum resident set size (KB)                   = 832612
+  0: The total amount of wall time                        = 887.693889
+  0: The maximum resident set size (KB)                   = 837080
 
-Test 009 control_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_control
-Checking test 010 rap_control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 1384.566306
-  0: The maximum resident set size (KB)                   = 831188
-
-Test 010 rap_control PASS
+Test 008 control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_2threads
-Checking test 011 rap_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_control
+Checking test 009 rap_control results ....
+Moving baseline 009 rap_control files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1418.440119
- 0: The maximum resident set size (KB)                   = 896448
+  0: The total amount of wall time                        = 1443.424338
+  0: The maximum resident set size (KB)                   = 835768
 
-Test 011 rap_2threads PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_restart
-Checking test 012 rap_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 664.405331
-  0: The maximum resident set size (KB)                   = 541296
-
-Test 012 rap_restart PASS
+Test 009 rap_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_sfcdiff
-Checking test 013 rap_sfcdiff results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_sfcdiff
+Checking test 010 rap_sfcdiff results ....
+Moving baseline 010 rap_sfcdiff files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1383.867337
-  0: The maximum resident set size (KB)                   = 835520
+  0: The total amount of wall time                        = 1393.218910
+  0: The maximum resident set size (KB)                   = 833540
 
-Test 013 rap_sfcdiff PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_sfcdiff_restart
-Checking test 014 rap_sfcdiff_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 679.887127
-  0: The maximum resident set size (KB)                   = 539632
-
-Test 014 rap_sfcdiff_restart PASS
+Test 010 rap_sfcdiff PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/hrrr_control
-Checking test 015 hrrr_control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/hrrr_control
+Checking test 011 hrrr_control results ....
+Moving baseline 011 hrrr_control files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1366.254515
-  0: The maximum resident set size (KB)                   = 831148
+  0: The total amount of wall time                        = 1430.363890
+  0: The maximum resident set size (KB)                   = 833172
 
-Test 015 hrrr_control PASS
+Test 011 hrrr_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rrfs_v1beta
-Checking test 016 rrfs_v1beta results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_v1beta
+Checking test 012 rrfs_v1beta results ....
+Moving baseline 012 rrfs_v1beta files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1395.626554
-  0: The maximum resident set size (KB)                   = 828352
+  0: The total amount of wall time                        = 1409.348743
+  0: The maximum resident set size (KB)                   = 832840
 
-Test 016 rrfs_v1beta PASS
+Test 012 rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rrfs_conus13km_hrrr_warm
-Checking test 017 rrfs_conus13km_hrrr_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_conus13km_hrrr_warm
+Checking test 013 rrfs_conus13km_hrrr_warm results ....
+Moving baseline 013 rrfs_conus13km_hrrr_warm files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving sfcf002.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+ Moving atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1502.689716
-  0: The maximum resident set size (KB)                   = 638164
+  0: The total amount of wall time                        = 1489.256449
+  0: The maximum resident set size (KB)                   = 635684
 
-Test 017 rrfs_conus13km_hrrr_warm PASS
+Test 013 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rrfs_conus13km_radar_tten_warm
-Checking test 018 rrfs_conus13km_radar_tten_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_conus13km_radar_tten_warm
+Checking test 014 rrfs_conus13km_radar_tten_warm results ....
+Moving baseline 014 rrfs_conus13km_radar_tten_warm files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving sfcf002.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+ Moving atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1495.893594
-  0: The maximum resident set size (KB)                   = 639196
+  0: The total amount of wall time                        = 1507.049888
+  0: The maximum resident set size (KB)                   = 639420
 
-Test 018 rrfs_conus13km_radar_tten_warm PASS
+Test 014 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rrfs_smoke_conus13km_hrrr_warm
-Checking test 019 rrfs_smoke_conus13km_hrrr_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_smoke_conus13km_hrrr_warm
+Checking test 015 rrfs_smoke_conus13km_hrrr_warm results ....
+Moving baseline 015 rrfs_smoke_conus13km_hrrr_warm files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving sfcf002.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+ Moving atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1540.278938
-  0: The maximum resident set size (KB)                   = 652876
+  0: The total amount of wall time                        = 1572.530287
+  0: The maximum resident set size (KB)                   = 650124
 
-Test 019 rrfs_smoke_conus13km_hrrr_warm PASS
+Test 015 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_debug
-Checking test 020 control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_debug
+Checking test 016 control_debug results ....
+Moving baseline 016 control_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 102.176459
-  0: The maximum resident set size (KB)                   = 478452
+  0: The total amount of wall time                        = 96.859648
+  0: The maximum resident set size (KB)                   = 474560
 
-Test 020 control_debug PASS
+Test 016 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_diag_debug
-Checking test 021 control_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_diag_debug
+Checking test 017 control_diag_debug results ....
+Moving baseline 017 control_diag_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 127.490131
-  0: The maximum resident set size (KB)                   = 535848
+  0: The total amount of wall time                        = 123.871468
+  0: The maximum resident set size (KB)                   = 536128
 
-Test 021 control_diag_debug PASS
+Test 017 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/regional_debug
-Checking test 022 regional_debug results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/regional_debug
+Checking test 018 regional_debug results ....
+Moving baseline 018 regional_debug files ....
+ Moving dynf000.nc .........OK
+ Moving dynf001.nc .........OK
+ Moving phyf000.nc .........OK
+ Moving phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 127.389144
- 0: The maximum resident set size (KB)                   = 553248
+ 0: The total amount of wall time                        = 124.183441
+ 0: The maximum resident set size (KB)                   = 553600
 
-Test 022 regional_debug PASS
+Test 018 regional_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_control_debug
-Checking test 023 rap_control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_control_debug
+Checking test 019 rap_control_debug results ....
+Moving baseline 019 rap_control_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.161302
-  0: The maximum resident set size (KB)                   = 846020
+  0: The total amount of wall time                        = 164.829079
+  0: The maximum resident set size (KB)                   = 847828
 
-Test 023 rap_control_debug PASS
+Test 019 rap_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_diag_debug
-Checking test 024 rap_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_diag_debug
+Checking test 020 rap_diag_debug results ....
+Moving baseline 020 rap_diag_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 208.802498
-  0: The maximum resident set size (KB)                   = 929136
+  0: The total amount of wall time                        = 202.470166
+  0: The maximum resident set size (KB)                   = 930596
 
-Test 024 rap_diag_debug PASS
+Test 020 rap_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_noah_sfcdiff_cires_ugwp_debug
-Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 021 rap_noah_sfcdiff_cires_ugwp_debug results ....
+Moving baseline 021 rap_noah_sfcdiff_cires_ugwp_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.915515
-  0: The maximum resident set size (KB)                   = 844260
+  0: The total amount of wall time                        = 254.398206
+  0: The maximum resident set size (KB)                   = 846416
 
-Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
+Test 021 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rap_progcld_thompson_debug
-Checking test 026 rap_progcld_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rap_progcld_thompson_debug
+Checking test 022 rap_progcld_thompson_debug results ....
+Moving baseline 022 rap_progcld_thompson_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.327797
-  0: The maximum resident set size (KB)                   = 845996
+  0: The total amount of wall time                        = 166.923212
+  0: The maximum resident set size (KB)                   = 851888
 
-Test 026 rap_progcld_thompson_debug PASS
+Test 022 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/rrfs_v1beta_debug
-Checking test 027 rrfs_v1beta_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/rrfs_v1beta_debug
+Checking test 023 rrfs_v1beta_debug results ....
+Moving baseline 023 rrfs_v1beta_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.247412
-  0: The maximum resident set size (KB)                   = 841964
+  0: The total amount of wall time                        = 164.856931
+  0: The maximum resident set size (KB)                   = 849632
 
-Test 027 rrfs_v1beta_debug PASS
+Test 023 rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_thompson_debug
-Checking test 028 control_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_debug
+Checking test 024 control_thompson_debug results ....
+Moving baseline 024 control_thompson_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 116.106462
-  0: The maximum resident set size (KB)                   = 837908
+  0: The total amount of wall time                        = 111.546272
+  0: The maximum resident set size (KB)                   = 837452
 
-Test 028 control_thompson_debug PASS
+Test 024 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_thompson_no_aero_debug
-Checking test 029 control_thompson_no_aero_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_no_aero_debug
+Checking test 025 control_thompson_no_aero_debug results ....
+Moving baseline 025 control_thompson_no_aero_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 116.227238
-  0: The maximum resident set size (KB)                   = 834908
+  0: The total amount of wall time                        = 114.785976
+  0: The maximum resident set size (KB)                   = 833576
 
-Test 029 control_thompson_no_aero_debug PASS
+Test 025 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_thompson_extdiag_debug
-Checking test 030 control_thompson_extdiag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_extdiag_debug
+Checking test 026 control_thompson_extdiag_debug results ....
+Moving baseline 026 control_thompson_extdiag_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 136.261781
-  0: The maximum resident set size (KB)                   = 874148
+  0: The total amount of wall time                        = 129.792872
+  0: The maximum resident set size (KB)                   = 869572
 
-Test 030 control_thompson_extdiag_debug PASS
+Test 026 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_thompson_progcld_thompson_debug
-Checking test 031 control_thompson_progcld_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_thompson_progcld_thompson_debug
+Checking test 027 control_thompson_progcld_thompson_debug results ....
+Moving baseline 027 control_thompson_progcld_thompson_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.826499
-  0: The maximum resident set size (KB)                   = 842060
+  0: The total amount of wall time                        = 114.041795
+  0: The maximum resident set size (KB)                   = 842732
 
-Test 031 control_thompson_progcld_thompson_debug PASS
+Test 027 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_ras_debug
-Checking test 032 control_ras_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_ras_debug
+Checking test 028 control_ras_debug results ....
+Moving baseline 028 control_ras_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 109.901955
-  0: The maximum resident set size (KB)                   = 485856
+  0: The total amount of wall time                        = 102.800001
+  0: The maximum resident set size (KB)                   = 488900
 
-Test 032 control_ras_debug PASS
+Test 028 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_stochy_debug
-Checking test 033 control_stochy_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_stochy_debug
+Checking test 029 control_stochy_debug results ....
+Moving baseline 029 control_stochy_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 129.541765
-  0: The maximum resident set size (KB)                   = 480920
+  0: The total amount of wall time                        = 116.030002
+  0: The maximum resident set size (KB)                   = 480280
 
-Test 033 control_stochy_debug PASS
+Test 029 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_debug_p8
-Checking test 034 control_debug_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_debug_p8
+Checking test 030 control_debug_p8 results ....
+Moving baseline 030 control_debug_p8 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 119.176470
-  0: The maximum resident set size (KB)                   = 833540
+  0: The total amount of wall time                        = 111.420351
+  0: The maximum resident set size (KB)                   = 837176
 
-Test 034 control_debug_p8 PASS
+Test 030 control_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/control_wam_debug
-Checking test 035 control_wam_debug results ....
- Comparing sfcf019.nc .........OK
- Comparing atmf019.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/control_wam_debug
+Checking test 031 control_wam_debug results ....
+Moving baseline 031 control_wam_debug files ....
+ Moving sfcf019.nc .........OK
+ Moving atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 179.524262
-  0: The maximum resident set size (KB)                   = 193400
+  0: The total amount of wall time                        = 179.678942
+  0: The maximum resident set size (KB)                   = 196424
 
-Test 035 control_wam_debug PASS
+Test 031 control_wam_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/cpld_control_noaero_p8
-Checking test 036 cpld_control_noaero_p8 results ....
- Comparing sfcf021.tile1.nc .........OK
- Comparing sfcf021.tile2.nc .........OK
- Comparing sfcf021.tile3.nc .........OK
- Comparing sfcf021.tile4.nc .........OK
- Comparing sfcf021.tile5.nc .........OK
- Comparing sfcf021.tile6.nc .........OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/cpld_control_noaero_p8
+Checking test 032 cpld_control_noaero_p8 results ....
+Moving baseline 032 cpld_control_noaero_p8 files ....
+ Moving sfcf021.tile1.nc .........OK
+ Moving sfcf021.tile2.nc .........OK
+ Moving sfcf021.tile3.nc .........OK
+ Moving sfcf021.tile4.nc .........OK
+ Moving sfcf021.tile5.nc .........OK
+ Moving sfcf021.tile6.nc .........OK
+ Moving atmf021.tile1.nc .........OK
+ Moving atmf021.tile2.nc .........OK
+ Moving atmf021.tile3.nc .........OK
+ Moving atmf021.tile4.nc .........OK
+ Moving atmf021.tile5.nc .........OK
+ Moving atmf021.tile6.nc .........OK
+ Moving sfcf024.tile1.nc .........OK
+ Moving sfcf024.tile2.nc .........OK
+ Moving sfcf024.tile3.nc .........OK
+ Moving sfcf024.tile4.nc .........OK
+ Moving sfcf024.tile5.nc .........OK
+ Moving sfcf024.tile6.nc .........OK
+ Moving atmf024.tile1.nc .........OK
+ Moving atmf024.tile2.nc .........OK
+ Moving atmf024.tile3.nc .........OK
+ Moving atmf024.tile4.nc .........OK
+ Moving atmf024.tile5.nc .........OK
+ Moving atmf024.tile6.nc .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2021-03-23-21600.nc .........OK
+ Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Moving 20210323.060000.out_pnt.ww3 .........OK
+ Moving 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1242.692785
-  0: The maximum resident set size (KB)                   = 875468
+  0: The total amount of wall time                        = 1293.650542
+  0: The maximum resident set size (KB)                   = 874280
 
-Test 036 cpld_control_noaero_p8 PASS
+Test 032 cpld_control_noaero_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/cpld_debug_noaero_p8
-Checking test 037 cpld_debug_noaero_p8 results ....
- Comparing sfcf003.tile1.nc .........OK
- Comparing sfcf003.tile2.nc .........OK
- Comparing sfcf003.tile3.nc .........OK
- Comparing sfcf003.tile4.nc .........OK
- Comparing sfcf003.tile5.nc .........OK
- Comparing sfcf003.tile6.nc .........OK
- Comparing atmf003.tile1.nc .........OK
- Comparing atmf003.tile2.nc .........OK
- Comparing atmf003.tile3.nc .........OK
- Comparing atmf003.tile4.nc .........OK
- Comparing atmf003.tile5.nc .........OK
- Comparing atmf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-22-32400.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
- Comparing 20210322.090000.out_pnt.ww3 .........OK
- Comparing 20210322.090000.out_grd.ww3 .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/cpld_debug_noaero_p8
+Checking test 033 cpld_debug_noaero_p8 results ....
+Moving baseline 033 cpld_debug_noaero_p8 files ....
+ Moving sfcf003.tile1.nc .........OK
+ Moving sfcf003.tile2.nc .........OK
+ Moving sfcf003.tile3.nc .........OK
+ Moving sfcf003.tile4.nc .........OK
+ Moving sfcf003.tile5.nc .........OK
+ Moving sfcf003.tile6.nc .........OK
+ Moving atmf003.tile1.nc .........OK
+ Moving atmf003.tile2.nc .........OK
+ Moving atmf003.tile3.nc .........OK
+ Moving atmf003.tile4.nc .........OK
+ Moving atmf003.tile5.nc .........OK
+ Moving atmf003.tile6.nc .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2021-03-22-32400.nc .........OK
+ Moving RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
+ Moving 20210322.090000.out_pnt.ww3 .........OK
+ Moving 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 449.046331
-  0: The maximum resident set size (KB)                   = 894424
+  0: The total amount of wall time                        = 439.544205
+  0: The maximum resident set size (KB)                   = 890332
 
-Test 037 cpld_debug_noaero_p8 PASS
+Test 033 cpld_debug_noaero_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10833/datm_cdeps_control_cfsr
-Checking test 038 datm_cdeps_control_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_275871/datm_cdeps_control_cfsr
+Checking test 034 datm_cdeps_control_cfsr results ....
+Moving baseline 034 datm_cdeps_control_cfsr files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 167.254367
- 0: The maximum resident set size (KB)                   = 627220
+ 0: The total amount of wall time                        = 163.529307
+ 0: The maximum resident set size (KB)                   = 628008
 
-Test 038 datm_cdeps_control_cfsr PASS
+Test 034 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 11 00:39:00 UTC 2022
-Elapsed time: 00h:51m:12s. Have a nice day!
+Mon Jun 13 16:18:21 UTC 2022
+Elapsed time: 00h:32m:23s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,26 +1,26 @@
-Fri Jun 10 23:32:06 UTC 2022
+Mon Jun 13 21:10:35 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 576 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 212 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 391 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 341 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 370 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 362 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 316 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 192 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 170 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 172 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 569 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 545 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 176 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 110 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 499 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 579 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 204 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 386 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 347 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 369 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 350 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 313 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 189 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 188 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 188 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 535 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 564 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 179 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 106 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 500 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 017 elapsed time 345 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 411.478392
-  0: The maximum resident set size (KB)                   = 4994720
+  0: The total amount of wall time                        = 400.830853
+  0: The maximum resident set size (KB)                   = 5001420
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -145,14 +145,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 246.049205
-  0: The maximum resident set size (KB)                   = 4973796
+  0: The total amount of wall time                        = 248.180927
+  0: The maximum resident set size (KB)                   = 4970584
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -205,14 +205,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 510.314476
-  0: The maximum resident set size (KB)                   = 5493044
+  0: The total amount of wall time                        = 500.610391
+  0: The maximum resident set size (KB)                   = 5480968
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_decomp_p8
 Checking test 004 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -265,14 +265,14 @@ Checking test 004 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 412.211045
-  0: The maximum resident set size (KB)                   = 5183484
+  0: The total amount of wall time                        = 399.999370
+  0: The maximum resident set size (KB)                   = 5177968
 
 Test 004 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_mpi_p8
 Checking test 005 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 337.596683
-  0: The maximum resident set size (KB)                   = 4740540
+  0: The total amount of wall time                        = 331.182480
+  0: The maximum resident set size (KB)                   = 4739088
 
 Test 005 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_control_c192_p8
 Checking test 006 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -385,14 +385,14 @@ Checking test 006 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 815.947190
-  0: The maximum resident set size (KB)                   = 4858948
+  0: The total amount of wall time                        = 797.130562
+  0: The maximum resident set size (KB)                   = 4867384
 
 Test 006 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_restart_c192_p8
 Checking test 007 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -445,14 +445,14 @@ Checking test 007 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 485.557067
-  0: The maximum resident set size (KB)                   = 4913004
+  0: The total amount of wall time                        = 468.432032
+  0: The maximum resident set size (KB)                   = 4911504
 
 Test 007 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_bmark_p8
 Checking test 008 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -498,14 +498,14 @@ Checking test 008 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1241.214569
-  0: The maximum resident set size (KB)                   = 5660420
+  0: The total amount of wall time                        = 1215.553132
+  0: The maximum resident set size (KB)                   = 5656984
 
 Test 008 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_restart_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_restart_bmark_p8
 Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -551,14 +551,14 @@ Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 824.291697
-  0: The maximum resident set size (KB)                   = 5611660
+  0: The total amount of wall time                        = 761.337368
+  0: The maximum resident set size (KB)                   = 5616940
 
 Test 009 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -611,14 +611,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 775.288634
-  0: The maximum resident set size (KB)                   = 5070732
+  0: The total amount of wall time                        = 767.437531
+  0: The maximum resident set size (KB)                   = 5063084
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/cpld_control_noaero_p8_agrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/cpld_control_noaero_p8_agrid
 Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -680,14 +680,14 @@ Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 295.626983
-  0: The maximum resident set size (KB)                   = 1252448
+  0: The total amount of wall time                        = 292.715429
+  0: The maximum resident set size (KB)                   = 1253232
 
 Test 011 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control
 Checking test 012 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -734,14 +734,14 @@ Checking test 012 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.920848
-  0: The maximum resident set size (KB)                   = 642588
+  0: The total amount of wall time                        = 127.224505
+  0: The maximum resident set size (KB)                   = 637288
 
 Test 012 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_decomp
 Checking test 013 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 013 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 132.063350
-  0: The maximum resident set size (KB)                   = 633368
+  0: The total amount of wall time                        = 131.677261
+  0: The maximum resident set size (KB)                   = 635368
 
 Test 013 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_2dwrtdecomp
 Checking test 014 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -802,14 +802,14 @@ Checking test 014 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 124.452075
-  0: The maximum resident set size (KB)                   = 640684
+  0: The total amount of wall time                        = 124.261883
+  0: The maximum resident set size (KB)                   = 644596
 
 Test 014 control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_2threads
 Checking test 015 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -852,14 +852,14 @@ Checking test 015 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 151.834658
- 0: The maximum resident set size (KB)                   = 690828
+ 0: The total amount of wall time                        = 155.452290
+ 0: The maximum resident set size (KB)                   = 690544
 
 Test 015 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_restart
 Checking test 016 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -898,14 +898,14 @@ Checking test 016 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 66.015480
-  0: The maximum resident set size (KB)                   = 457480
+  0: The total amount of wall time                        = 65.752987
+  0: The maximum resident set size (KB)                   = 459396
 
 Test 016 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_fhzero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_fhzero
 Checking test 017 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -948,14 +948,14 @@ Checking test 017 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.238675
-  0: The maximum resident set size (KB)                   = 639820
+  0: The total amount of wall time                        = 118.095232
+  0: The maximum resident set size (KB)                   = 641808
 
 Test 017 control_fhzero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -982,14 +982,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.741118
-  0: The maximum resident set size (KB)                   = 643856
+  0: The total amount of wall time                        = 120.535985
+  0: The maximum resident set size (KB)                   = 637988
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1000,32 +1000,32 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 123.311873
-  0: The maximum resident set size (KB)                   = 633720
+  0: The total amount of wall time                        = 123.786890
+  0: The maximum resident set size (KB)                   = 642912
 
 Test 019 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.108114
-  0: The maximum resident set size (KB)                   = 643132
+  0: The total amount of wall time                        = 126.342776
+  0: The maximum resident set size (KB)                   = 640280
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1064,14 +1064,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 336.597308
-0: The maximum resident set size (KB)                   = 812064
+0: The total amount of wall time                        = 332.063092
+0: The maximum resident set size (KB)                   = 812892
 
 Test 021 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 485.752359
-  0: The maximum resident set size (KB)                   = 800156
+  0: The total amount of wall time                        = 484.418322
+  0: The maximum resident set size (KB)                   = 801048
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1100,14 +1100,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 654.475988
-  0: The maximum resident set size (KB)                   = 1075212
+  0: The total amount of wall time                        = 653.741436
+  0: The maximum resident set size (KB)                   = 1079104
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 598.118036
-  0: The maximum resident set size (KB)                   = 1244020
+  0: The total amount of wall time                        = 595.177258
+  0: The maximum resident set size (KB)                   = 1242196
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384_progsigma
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_c384_progsigma
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_c384_progsigma
 Checking test 025 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 025 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 663.964908
-  0: The maximum resident set size (KB)                   = 1071016
+  0: The total amount of wall time                        = 670.687612
+  0: The maximum resident set size (KB)                   = 1080276
 
 Test 025 control_c384_progsigma PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1186,28 +1186,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 82.881524
-  0: The maximum resident set size (KB)                   = 646764
+  0: The total amount of wall time                        = 80.789529
+  0: The maximum resident set size (KB)                   = 648148
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.102302
-  0: The maximum resident set size (KB)                   = 481604
+  0: The total amount of wall time                        = 43.921218
+  0: The maximum resident set size (KB)                   = 481524
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.235430
-  0: The maximum resident set size (KB)                   = 642844
+  0: The total amount of wall time                        = 73.920295
+  0: The maximum resident set size (KB)                   = 643408
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.442205
-  0: The maximum resident set size (KB)                   = 637348
+  0: The total amount of wall time                        = 125.879634
+  0: The maximum resident set size (KB)                   = 643044
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 127.638899
-  0: The maximum resident set size (KB)                   = 640380
+  0: The total amount of wall time                        = 125.668549
+  0: The maximum resident set size (KB)                   = 639808
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1316,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.289000
-  0: The maximum resident set size (KB)                   = 1036072
+  0: The total amount of wall time                        = 166.889317
+  0: The maximum resident set size (KB)                   = 1037496
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_p8_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 323.889747
-  0: The maximum resident set size (KB)                   = 1028404
+  0: The total amount of wall time                        = 317.204405
+  0: The maximum resident set size (KB)                   = 1034168
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1388,14 +1388,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 90.233903
-  0: The maximum resident set size (KB)                   = 869148
+  0: The total amount of wall time                        = 88.337536
+  0: The maximum resident set size (KB)                   = 860056
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1438,14 +1438,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.137374
-  0: The maximum resident set size (KB)                   = 1020876
+  0: The total amount of wall time                        = 173.253218
+  0: The maximum resident set size (KB)                   = 1014972
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 203.919425
- 0: The maximum resident set size (KB)                   = 1105592
+ 0: The total amount of wall time                        = 205.101908
+ 0: The maximum resident set size (KB)                   = 1111256
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_p8_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1542,14 +1542,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.380434
-  0: The maximum resident set size (KB)                   = 1163424
+  0: The total amount of wall time                        = 196.661936
+  0: The maximum resident set size (KB)                   = 1158924
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1560,28 +1560,28 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 331.547554
- 0: The maximum resident set size (KB)                   = 819832
+ 0: The total amount of wall time                        = 328.764814
+ 0: The maximum resident set size (KB)                   = 820364
 
 Test 037 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 186.795537
- 0: The maximum resident set size (KB)                   = 821228
+ 0: The total amount of wall time                        = 181.868773
+ 0: The maximum resident set size (KB)                   = 822988
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 329.746166
- 0: The maximum resident set size (KB)                   = 826184
+ 0: The total amount of wall time                        = 329.849247
+ 0: The maximum resident set size (KB)                   = 823620
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 342.609702
- 0: The maximum resident set size (KB)                   = 802636
+ 0: The total amount of wall time                        = 342.168173
+ 0: The maximum resident set size (KB)                   = 805528
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,28 +1625,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 231.884777
- 0: The maximum resident set size (KB)                   = 828928
+ 0: The total amount of wall time                        = 237.266438
+ 0: The maximum resident set size (KB)                   = 828520
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 327.332762
- 0: The maximum resident set size (KB)                   = 809848
+ 0: The total amount of wall time                        = 325.187747
+ 0: The maximum resident set size (KB)                   = 812628
 
 Test 042 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_3km
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_3km
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 255.191572
-  0: The maximum resident set size (KB)                   = 888068
+  0: The total amount of wall time                        = 251.873187
+  0: The maximum resident set size (KB)                   = 888500
 
 Test 043 regional_3km PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1711,14 +1711,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 434.565902
-  0: The maximum resident set size (KB)                   = 1028740
+  0: The total amount of wall time                        = 434.561123
+  0: The maximum resident set size (KB)                   = 1022056
 
 Test 044 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1765,14 +1765,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.928691
-  0: The maximum resident set size (KB)                   = 1183436
+  0: The total amount of wall time                        = 464.400116
+  0: The maximum resident set size (KB)                   = 1171588
 
 Test 045 rap_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_spp_sppt_shum_skeb
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1783,14 +1783,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 294.280836
-  0: The maximum resident set size (KB)                   = 1202072
+  0: The total amount of wall time                        = 301.602534
+  0: The maximum resident set size (KB)                   = 1200848
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1837,14 +1837,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 512.638797
- 0: The maximum resident set size (KB)                   = 1096116
+ 0: The total amount of wall time                        = 520.147289
+ 0: The maximum resident set size (KB)                   = 1084720
 
 Test 047 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1883,14 +1883,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 221.957831
-  0: The maximum resident set size (KB)                   = 946100
+  0: The total amount of wall time                        = 220.518511
+  0: The maximum resident set size (KB)                   = 928648
 
 Test 048 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1937,14 +1937,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 434.956675
-  0: The maximum resident set size (KB)                   = 1041372
+  0: The total amount of wall time                        = 433.012192
+  0: The maximum resident set size (KB)                   = 1038892
 
 Test 049 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1983,14 +1983,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 222.176838
-  0: The maximum resident set size (KB)                   = 947652
+  0: The total amount of wall time                        = 219.800913
+  0: The maximum resident set size (KB)                   = 950900
 
 Test 050 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 417.952284
-  0: The maximum resident set size (KB)                   = 1036064
+  0: The total amount of wall time                        = 419.577056
+  0: The maximum resident set size (KB)                   = 1034504
 
 Test 051 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 426.384085
-  0: The maximum resident set size (KB)                   = 1030072
+  0: The total amount of wall time                        = 423.518285
+  0: The maximum resident set size (KB)                   = 1028136
 
 Test 052 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_v1nssl
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2113,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 506.357301
-  0: The maximum resident set size (KB)                   = 697592
+  0: The total amount of wall time                        = 498.584268
+  0: The maximum resident set size (KB)                   = 704544
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2135,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 490.773179
-  0: The maximum resident set size (KB)                   = 724308
+  0: The total amount of wall time                        = 485.382768
+  0: The maximum resident set size (KB)                   = 726956
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2151,14 +2151,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 179.654609
-  0: The maximum resident set size (KB)                   = 924260
+  0: The total amount of wall time                        = 175.801586
+  0: The maximum resident set size (KB)                   = 922228
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 182.511796
-  0: The maximum resident set size (KB)                   = 927052
+  0: The total amount of wall time                        = 176.948605
+  0: The maximum resident set size (KB)                   = 925888
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2183,14 +2183,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 198.686518
-  0: The maximum resident set size (KB)                   = 955444
+  0: The total amount of wall time                        = 196.061664
+  0: The maximum resident set size (KB)                   = 948624
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 327.917515
-  0: The maximum resident set size (KB)                   = 747032
+  0: The total amount of wall time                        = 323.988722
+  0: The maximum resident set size (KB)                   = 753728
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 323.997698
-  0: The maximum resident set size (KB)                   = 757880
+  0: The total amount of wall time                        = 319.959239
+  0: The maximum resident set size (KB)                   = 753036
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2237,14 +2237,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 210.307274
-  0: The maximum resident set size (KB)                   = 756768
+  0: The total amount of wall time                        = 208.205649
+  0: The maximum resident set size (KB)                   = 758132
 
 Test 060 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2255,14 +2255,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 169.401737
-  0: The maximum resident set size (KB)                   = 717392
+  0: The total amount of wall time                        = 167.469308
+  0: The maximum resident set size (KB)                   = 718112
 
 Test 061 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2273,14 +2273,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 234.663561
-  0: The maximum resident set size (KB)                   = 1082144
+  0: The total amount of wall time                        = 232.608739
+  0: The maximum resident set size (KB)                   = 1081596
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2291,54 +2291,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 220.418565
-  0: The maximum resident set size (KB)                   = 1060824
+  0: The total amount of wall time                        = 218.160491
+  0: The maximum resident set size (KB)                   = 1062800
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_wam
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 102.566271
-  0: The maximum resident set size (KB)                   = 617124
+  0: The total amount of wall time                        = 101.307591
+  0: The maximum resident set size (KB)                   = 620896
 
 Test 064 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.698419
-  0: The maximum resident set size (KB)                   = 808860
+  0: The total amount of wall time                        = 143.075827
+  0: The maximum resident set size (KB)                   = 801700
 
 Test 065 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 220.181923
- 0: The maximum resident set size (KB)                   = 861896
+ 0: The total amount of wall time                        = 210.513646
+ 0: The maximum resident set size (KB)                   = 861196
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2365,415 +2365,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.426033
-  0: The maximum resident set size (KB)                   = 804792
+  0: The total amount of wall time                        = 159.194021
+  0: The maximum resident set size (KB)                   = 806624
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.646457
-  0: The maximum resident set size (KB)                   = 809844
+  0: The total amount of wall time                        = 148.914780
+  0: The maximum resident set size (KB)                   = 806280
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.095392
-  0: The maximum resident set size (KB)                   = 810404
+  0: The total amount of wall time                        = 164.685832
+  0: The maximum resident set size (KB)                   = 814016
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.199016
-  0: The maximum resident set size (KB)                   = 810780
+  0: The total amount of wall time                        = 152.694105
+  0: The maximum resident set size (KB)                   = 812936
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.249195
-  0: The maximum resident set size (KB)                   = 857584
+  0: The total amount of wall time                        = 226.027921
+  0: The maximum resident set size (KB)                   = 860652
 
 Test 071 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 221.483824
-  0: The maximum resident set size (KB)                   = 856860
+  0: The total amount of wall time                        = 228.072368
+  0: The maximum resident set size (KB)                   = 853408
 
 Test 072 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.666201
-  0: The maximum resident set size (KB)                   = 824340
+  0: The total amount of wall time                        = 151.976502
+  0: The maximum resident set size (KB)                   = 829092
 
 Test 073 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.796581
-  0: The maximum resident set size (KB)                   = 868208
+  0: The total amount of wall time                        = 157.139747
+  0: The maximum resident set size (KB)                   = 867432
 
 Test 074 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.109480
-  0: The maximum resident set size (KB)                   = 1197216
+  0: The total amount of wall time                        = 163.719457
+  0: The maximum resident set size (KB)                   = 1201704
 
 Test 075 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.352107
-  0: The maximum resident set size (KB)                   = 1176904
+  0: The total amount of wall time                        = 173.035398
+  0: The maximum resident set size (KB)                   = 1182944
 
 Test 076 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.093873
-  0: The maximum resident set size (KB)                   = 1165980
+  0: The total amount of wall time                        = 162.018889
+  0: The maximum resident set size (KB)                   = 1169188
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 183.412546
-  0: The maximum resident set size (KB)                   = 1206344
+  0: The total amount of wall time                        = 180.544953
+  0: The maximum resident set size (KB)                   = 1206984
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_thompson_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.941492
-  0: The maximum resident set size (KB)                   = 1177268
+  0: The total amount of wall time                        = 171.232143
+  0: The maximum resident set size (KB)                   = 1171252
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 245.443956
- 0: The maximum resident set size (KB)                   = 838252
+ 0: The total amount of wall time                        = 240.413681
+ 0: The maximum resident set size (KB)                   = 848952
 
 Test 080 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.879943
-  0: The maximum resident set size (KB)                   = 1189628
+  0: The total amount of wall time                        = 264.929695
+  0: The maximum resident set size (KB)                   = 1192648
 
 Test 081 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.995476
-  0: The maximum resident set size (KB)                   = 1184676
+  0: The total amount of wall time                        = 261.653564
+  0: The maximum resident set size (KB)                   = 1188048
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.417856
-  0: The maximum resident set size (KB)                   = 1263924
+  0: The total amount of wall time                        = 277.584358
+  0: The maximum resident set size (KB)                   = 1268108
 
 Test 083 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.654111
-  0: The maximum resident set size (KB)                   = 1181152
+  0: The total amount of wall time                        = 269.151197
+  0: The maximum resident set size (KB)                   = 1186056
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.384571
-  0: The maximum resident set size (KB)                   = 1189196
+  0: The total amount of wall time                        = 275.085725
+  0: The maximum resident set size (KB)                   = 1185088
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.497332
-  0: The maximum resident set size (KB)                   = 1185848
+  0: The total amount of wall time                        = 266.948208
+  0: The maximum resident set size (KB)                   = 1188708
 
 Test 086 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.630497
-  0: The maximum resident set size (KB)                   = 1188120
+  0: The total amount of wall time                        = 264.406239
+  0: The maximum resident set size (KB)                   = 1185348
 
 Test 087 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.638543
-  0: The maximum resident set size (KB)                   = 1188504
+  0: The total amount of wall time                        = 263.623995
+  0: The maximum resident set size (KB)                   = 1184944
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.283707
-  0: The maximum resident set size (KB)                   = 1175524
+  0: The total amount of wall time                        = 260.198382
+  0: The maximum resident set size (KB)                   = 1182940
 
 Test 089 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 447.690173
-  0: The maximum resident set size (KB)                   = 1312308
+  0: The total amount of wall time                        = 450.832581
+  0: The maximum resident set size (KB)                   = 1308416
 
 Test 090 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.618915
-  0: The maximum resident set size (KB)                   = 1190124
+  0: The total amount of wall time                        = 259.094170
+  0: The maximum resident set size (KB)                   = 1180224
 
 Test 091 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 439.204792
-  0: The maximum resident set size (KB)                   = 1178928
+  0: The total amount of wall time                        = 436.964707
+  0: The maximum resident set size (KB)                   = 1181736
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.856852
-  0: The maximum resident set size (KB)                   = 1176780
+  0: The total amount of wall time                        = 261.905856
+  0: The maximum resident set size (KB)                   = 1185156
 
 Test 093 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 287.845324
-  0: The maximum resident set size (KB)                   = 515256
+  0: The total amount of wall time                        = 282.151559
+  0: The maximum resident set size (KB)                   = 513024
 
 Test 094 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 318.499241
-  0: The maximum resident set size (KB)                   = 989040
+  0: The total amount of wall time                        = 315.068169
+  0: The maximum resident set size (KB)                   = 979564
 
 Test 095 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 470.355036
-  0: The maximum resident set size (KB)                   = 1341860
+  0: The total amount of wall time                        = 396.183493
+  0: The maximum resident set size (KB)                   = 1345004
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2782,14 +2782,14 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 405.902439
-  0: The maximum resident set size (KB)                   = 1198332
+  0: The total amount of wall time                        = 395.008126
+  0: The maximum resident set size (KB)                   = 1195832
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 098 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 751.554466
-  0: The maximum resident set size (KB)                   = 1230588
+  0: The total amount of wall time                        = 745.277101
+  0: The maximum resident set size (KB)                   = 1226844
 
 Test 098 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2816,28 +2816,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 847.524697
-  0: The maximum resident set size (KB)                   = 1194668
+  0: The total amount of wall time                        = 843.460992
+  0: The maximum resident set size (KB)                   = 1192452
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 447.621869
-  0: The maximum resident set size (KB)                   = 536580
+  0: The total amount of wall time                        = 448.447150
+  0: The maximum resident set size (KB)                   = 535656
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2846,28 +2846,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 500.783543
-  0: The maximum resident set size (KB)                   = 590564
+  0: The total amount of wall time                        = 502.602134
+  0: The maximum resident set size (KB)                   = 591052
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 206.619436
-  0: The maximum resident set size (KB)                   = 379772
+  0: The total amount of wall time                        = 206.618507
+  0: The maximum resident set size (KB)                   = 377772
 
 Test 102 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2880,42 +2880,42 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 573.957980
-  0: The maximum resident set size (KB)                   = 420796
+  0: The total amount of wall time                        = 570.278962
+  0: The maximum resident set size (KB)                   = 418360
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 273.017085
-  0: The maximum resident set size (KB)                   = 547620
+  0: The total amount of wall time                        = 270.283311
+  0: The maximum resident set size (KB)                   = 543628
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 264.605095
-  0: The maximum resident set size (KB)                   = 545140
+  0: The total amount of wall time                        = 259.597460
+  0: The maximum resident set size (KB)                   = 542756
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2924,14 +2924,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 270.797934
-  0: The maximum resident set size (KB)                   = 626448
+  0: The total amount of wall time                        = 269.555067
+  0: The maximum resident set size (KB)                   = 627148
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2942,28 +2942,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 616.139913
-  0: The maximum resident set size (KB)                   = 559372
+  0: The total amount of wall time                        = 613.134939
+  0: The maximum resident set size (KB)                   = 559696
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 78.207171
-  0: The maximum resident set size (KB)                   = 398652
+  0: The total amount of wall time                        = 77.068692
+  0: The maximum resident set size (KB)                   = 396000
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2971,14 +2971,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 399.738529
-  0: The maximum resident set size (KB)                   = 1215872
+  0: The total amount of wall time                        = 388.497075
+  0: The maximum resident set size (KB)                   = 1211520
 
 Test 109 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2986,118 +2986,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 393.471271
-  0: The maximum resident set size (KB)                   = 1206784
+  0: The total amount of wall time                        = 392.046125
+  0: The maximum resident set size (KB)                   = 1202356
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 948.258590
-  0: The maximum resident set size (KB)                   = 1019076
+  0: The total amount of wall time                        = 930.877473
+  0: The maximum resident set size (KB)                   = 1019600
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.385387
- 0: The maximum resident set size (KB)                   = 1026124
+ 0: The total amount of wall time                        = 151.119336
+ 0: The maximum resident set size (KB)                   = 1026704
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 89.306331
- 0: The maximum resident set size (KB)                   = 993468
+ 0: The total amount of wall time                        = 89.971034
+ 0: The maximum resident set size (KB)                   = 985576
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.859476
- 0: The maximum resident set size (KB)                   = 931516
+ 0: The total amount of wall time                        = 144.439845
+ 0: The maximum resident set size (KB)                   = 939088
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_iau_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.518856
- 0: The maximum resident set size (KB)                   = 948200
+ 0: The total amount of wall time                        = 146.101442
+ 0: The maximum resident set size (KB)                   = 934528
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.670727
- 0: The maximum resident set size (KB)                   = 951276
+ 0: The total amount of wall time                        = 148.875511
+ 0: The maximum resident set size (KB)                   = 942124
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.412800
- 0: The maximum resident set size (KB)                   = 1036332
+ 0: The total amount of wall time                        = 144.499753
+ 0: The maximum resident set size (KB)                   = 1015556
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.977300
- 0: The maximum resident set size (KB)                   = 939984
+ 0: The total amount of wall time                        = 144.442799
+ 0: The maximum resident set size (KB)                   = 934200
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3106,14 +3106,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 321.618588
-  0: The maximum resident set size (KB)                   = 858944
+  0: The total amount of wall time                        = 308.604954
+  0: The maximum resident set size (KB)                   = 855464
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3122,64 +3122,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 322.760824
-  0: The maximum resident set size (KB)                   = 891104
+  0: The total amount of wall time                        = 306.726641
+  0: The maximum resident set size (KB)                   = 885928
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.108281
- 0: The maximum resident set size (KB)                   = 1033020
+ 0: The total amount of wall time                        = 146.296488
+ 0: The maximum resident set size (KB)                   = 1031836
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 203.498897
- 0: The maximum resident set size (KB)                   = 2196016
+ 0: The total amount of wall time                        = 199.103163
+ 0: The maximum resident set size (KB)                   = 2257260
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_gfs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 217.621983
- 0: The maximum resident set size (KB)                   = 2246192
+ 0: The total amount of wall time                        = 204.767417
+ 0: The maximum resident set size (KB)                   = 2245828
 
 Test 123 datm_cdeps_gfs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 435.876894
- 0: The maximum resident set size (KB)                   = 986580
+ 0: The total amount of wall time                        = 439.897278
+ 0: The maximum resident set size (KB)                   = 998868
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3223,14 +3223,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 81.649451
-  0: The maximum resident set size (KB)                   = 669380
+  0: The total amount of wall time                        = 80.125545
+  0: The maximum resident set size (KB)                   = 665512
 
 Test 125 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/atmaero_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26182/atmaero_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/atmaero_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24880/atmaero_control_p8
 Checking test 126 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3274,12 +3274,12 @@ Checking test 126 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 331.587276
-  0: The maximum resident set size (KB)                   = 5119872
+  0: The total amount of wall time                        = 322.751814
+  0: The maximum resident set size (KB)                   = 5112512
 
 Test 126 atmaero_control_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 11 00:47:10 UTC 2022
-Elapsed time: 01h:15m:05s. Have a nice day!
+Mon Jun 13 23:58:45 UTC 2022
+Elapsed time: 02h:48m:10s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,2847 +1,2147 @@
-Sat Jun 11 02:47:34 GMT 2022
+Mon Jun 13 19:47:05 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1729 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 304 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1403 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 004 elapsed time 1371 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 1442 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 1406 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 007 elapsed time 1233 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 262 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 324 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 293 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 246 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 1548 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 013 elapsed time 1615 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 276 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 015 elapsed time 139 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 1550 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 017 elapsed time 1282 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 1891 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 287 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1372 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 004 elapsed time 1359 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 1434 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 1447 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 007 elapsed time 1234 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 008 elapsed time 264 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 250 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 198 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 231 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 1618 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 1634 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 281 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 015 elapsed time 155 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 1592 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 017 elapsed time 1292 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc .........OK
- Comparing sfcf021.tile2.nc .........OK
- Comparing sfcf021.tile3.nc .........OK
- Comparing sfcf021.tile4.nc .........OK
- Comparing sfcf021.tile5.nc .........OK
- Comparing sfcf021.tile6.nc .........OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
+Moving baseline 001 cpld_control_p8 files ....
+ Moving sfcf021.tile1.nc .........OK
+ Moving sfcf021.tile2.nc .........OK
+ Moving sfcf021.tile3.nc .........OK
+ Moving sfcf021.tile4.nc .........OK
+ Moving sfcf021.tile5.nc .........OK
+ Moving sfcf021.tile6.nc .........OK
+ Moving atmf021.tile1.nc .........OK
+ Moving atmf021.tile2.nc .........OK
+ Moving atmf021.tile3.nc .........OK
+ Moving atmf021.tile4.nc .........OK
+ Moving atmf021.tile5.nc .........OK
+ Moving atmf021.tile6.nc .........OK
+ Moving sfcf024.tile1.nc .........OK
+ Moving sfcf024.tile2.nc .........OK
+ Moving sfcf024.tile3.nc .........OK
+ Moving sfcf024.tile4.nc .........OK
+ Moving sfcf024.tile5.nc .........OK
+ Moving sfcf024.tile6.nc .........OK
+ Moving atmf024.tile1.nc .........OK
+ Moving atmf024.tile2.nc .........OK
+ Moving atmf024.tile3.nc .........OK
+ Moving atmf024.tile4.nc .........OK
+ Moving atmf024.tile5.nc .........OK
+ Moving atmf024.tile6.nc .........OK
+ Moving gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2021-03-23-21600.nc .........OK
+ Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Moving 20210323.060000.out_pnt.ww3 .........OK
+ Moving 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 623.968548
-  0: The maximum resident set size (KB)                   = 1997424
+  0: The total amount of wall time                        = 564.701857
+  0: The maximum resident set size (KB)                   = 2012368
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_restart_p8
-Checking test 002 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 349.173267
-  0: The maximum resident set size (KB)                   = 1971484
-
-Test 002 cpld_restart_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_2threads_p8
-Checking test 003 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 1067.512141
-  0: The maximum resident set size (KB)                   = 2609004
-
-Test 003 cpld_2threads_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_decomp_p8
-Checking test 004 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 558.978390
-  0: The maximum resident set size (KB)                   = 2195196
-
-Test 004 cpld_decomp_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_mpi_p8
-Checking test 005 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 500.632190
-  0: The maximum resident set size (KB)                   = 1876176
-
-Test 005 cpld_mpi_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_debug_p8
-Checking test 006 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc .........OK
- Comparing sfcf003.tile2.nc .........OK
- Comparing sfcf003.tile3.nc .........OK
- Comparing sfcf003.tile4.nc .........OK
- Comparing sfcf003.tile5.nc .........OK
- Comparing sfcf003.tile6.nc .........OK
- Comparing atmf003.tile1.nc .........OK
- Comparing atmf003.tile2.nc .........OK
- Comparing atmf003.tile3.nc .........OK
- Comparing atmf003.tile4.nc .........OK
- Comparing atmf003.tile5.nc .........OK
- Comparing atmf003.tile6.nc .........OK
- Comparing gocart.inst_aod.20210322_0900z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-22-32400.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
- Comparing 20210322.090000.out_pnt.ww3 .........OK
- Comparing 20210322.090000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 1027.172054
-  0: The maximum resident set size (KB)                   = 2075216
-
-Test 006 cpld_debug_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/cpld_control_noaero_p8_agrid
-Checking test 007 cpld_control_noaero_p8_agrid results ....
- Comparing sfcf021.tile1.nc .........OK
- Comparing sfcf021.tile2.nc .........OK
- Comparing sfcf021.tile3.nc .........OK
- Comparing sfcf021.tile4.nc .........OK
- Comparing sfcf021.tile5.nc .........OK
- Comparing sfcf021.tile6.nc .........OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
-
-  0: The total amount of wall time                        = 452.612149
-  0: The maximum resident set size (KB)                   = 1164520
-
-Test 007 cpld_control_noaero_p8_agrid PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control
-Checking test 008 control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 204.143397
-  0: The maximum resident set size (KB)                   = 579752
-
-Test 008 control PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_decomp
-Checking test 009 control_decomp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 210.988946
-  0: The maximum resident set size (KB)                   = 578660
-
-Test 009 control_decomp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_2dwrtdecomp
-Checking test 010 control_2dwrtdecomp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 240.274147
-  0: The maximum resident set size (KB)                   = 580652
-
-Test 010 control_2dwrtdecomp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_2threads
-Checking test 011 control_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
- 0: The total amount of wall time                        = 442.334810
- 0: The maximum resident set size (KB)                   = 639308
-
-Test 011 control_2threads PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_restart
-Checking test 012 control_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 101.208730
-  0: The maximum resident set size (KB)                   = 369640
-
-Test 012 control_restart PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_fhzero
-Checking test 013 control_fhzero results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 222.199054
-  0: The maximum resident set size (KB)                   = 578984
-
-Test 013 control_fhzero PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_CubedSphereGrid
-Checking test 014 control_CubedSphereGrid results ....
- Comparing sfcf000.tile1.nc .........OK
- Comparing sfcf000.tile2.nc .........OK
- Comparing sfcf000.tile3.nc .........OK
- Comparing sfcf000.tile4.nc .........OK
- Comparing sfcf000.tile5.nc .........OK
- Comparing sfcf000.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf000.tile1.nc .........OK
- Comparing atmf000.tile2.nc .........OK
- Comparing atmf000.tile3.nc .........OK
- Comparing atmf000.tile4.nc .........OK
- Comparing atmf000.tile5.nc .........OK
- Comparing atmf000.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 232.363188
-  0: The maximum resident set size (KB)                   = 584144
-
-Test 014 control_CubedSphereGrid PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_latlon
-Checking test 015 control_latlon results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 216.923769
-  0: The maximum resident set size (KB)                   = 581684
-
-Test 015 control_latlon PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_wrtGauss_netcdf_parallel
-Checking test 016 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 217.587021
-  0: The maximum resident set size (KB)                   = 583084
-
-Test 016 control_wrtGauss_netcdf_parallel PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_c48
-Checking test 017 control_c48 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-0: The total amount of wall time                        = 577.668894
-0: The maximum resident set size (KB)                   = 785532
-
-Test 017 control_c48 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_c192
-Checking test 018 control_c192 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 809.250490
-  0: The maximum resident set size (KB)                   = 732656
-
-Test 018 control_c192 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_c384
-Checking test 019 control_c384 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 997.942518
-  0: The maximum resident set size (KB)                   = 1066032
-
-Test 019 control_c384 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_c384gdas
-Checking test 020 control_c384gdas results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF06 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF06 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 869.997265
-  0: The maximum resident set size (KB)                   = 1167628
-
-Test 020 control_c384gdas PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384_progsigma
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_c384_progsigma
-Checking test 021 control_c384_progsigma results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 1093.956351
-  0: The maximum resident set size (KB)                   = 998496
-
-Test 021 control_c384_progsigma PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_stochy
-Checking test 022 control_stochy results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 159.772278
-  0: The maximum resident set size (KB)                   = 586748
-
-Test 022 control_stochy PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_stochy_restart
-Checking test 023 control_stochy_restart results ....
- Comparing sfcf012.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 75.788242
-  0: The maximum resident set size (KB)                   = 387016
-
-Test 023 control_stochy_restart PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_lndp
-Checking test 024 control_lndp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 138.137041
-  0: The maximum resident set size (KB)                   = 585592
-
-Test 024 control_lndp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_iovr4
-Checking test 025 control_iovr4 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 218.041127
-  0: The maximum resident set size (KB)                   = 582468
-
-Test 025 control_iovr4 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_iovr5
-Checking test 026 control_iovr5 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 220.076630
-  0: The maximum resident set size (KB)                   = 583860
-
-Test 026 control_iovr5 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_p8
-Checking test 027 control_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 280.108969
-  0: The maximum resident set size (KB)                   = 977448
-
-Test 027 control_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_p8_lndp
-Checking test 028 control_p8_lndp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing sfcf048.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing atmf048.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSFLX.GrbF48 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing GFSPRS.GrbF48 .........OK
-
-  0: The total amount of wall time                        = 495.511961
-  0: The maximum resident set size (KB)                   = 975300
-
-Test 028 control_p8_lndp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_restart_p8
-Checking test 029 control_restart_p8 results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 129.753797
-  0: The maximum resident set size (KB)                   = 763292
-
-Test 029 control_restart_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_decomp_p8
-Checking test 030 control_decomp_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 262.486050
-  0: The maximum resident set size (KB)                   = 970412
-
-Test 030 control_decomp_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_2threads_p8
-Checking test 031 control_2threads_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
- 0: The total amount of wall time                        = 593.806229
- 0: The maximum resident set size (KB)                   = 1057936
-
-Test 031 control_2threads_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_p8_rrtmgp
-Checking test 032 control_p8_rrtmgp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 302.667569
-  0: The maximum resident set size (KB)                   = 1103532
-
-Test 032 control_p8_rrtmgp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_control
-Checking test 033 regional_control results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF24 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF24 .........OK
-
- 0: The total amount of wall time                        = 520.428919
- 0: The maximum resident set size (KB)                   = 737980
-
-Test 033 regional_control PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_restart
-Checking test 034 regional_restart results ....
- Comparing dynf024.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing PRSLEV.GrbF24 .........OK
- Comparing NATLEV.GrbF24 .........OK
-
- 0: The total amount of wall time                        = 276.042522
- 0: The maximum resident set size (KB)                   = 738892
-
-Test 034 regional_restart PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_control_2dwrtdecomp
-Checking test 035 regional_control_2dwrtdecomp results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF24 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF24 .........OK
-
- 0: The total amount of wall time                        = 566.581705
- 0: The maximum resident set size (KB)                   = 740636
-
-Test 035 regional_control_2dwrtdecomp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_noquilt
-Checking test 036 regional_noquilt results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing fv3_history2d.nc .........OK
- Comparing fv3_history.nc .........OK
- Comparing RESTART/fv_core.res.tile1_new.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-
- 0: The total amount of wall time                        = 604.689048
- 0: The maximum resident set size (KB)                   = 713924
-
-Test 036 regional_noquilt PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_netcdf_parallel
-Checking test 037 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
-
- 0: The total amount of wall time                        = 535.555139
- 0: The maximum resident set size (KB)                   = 743364
-
-Test 037 regional_netcdf_parallel PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_3km
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_3km
-Checking test 038 regional_3km results ....
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF06 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF06 .........OK
-
-  0: The total amount of wall time                        = 420.108263
-  0: The maximum resident set size (KB)                   = 778236
-
-Test 038 regional_3km PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_control
-Checking test 039 rap_control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 633.476406
-  0: The maximum resident set size (KB)                   = 969700
-
-Test 039 rap_control PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_rrtmgp
-Checking test 040 rap_rrtmgp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 658.731136
-  0: The maximum resident set size (KB)                   = 1096008
-
-Test 040 rap_rrtmgp PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_spp_sppt_shum_skeb
-Checking test 041 regional_spp_sppt_shum_skeb results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF01 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF01 .........OK
-
-  0: The total amount of wall time                        = 860.333989
-  0: The maximum resident set size (KB)                   = 1099324
-
-Test 041 regional_spp_sppt_shum_skeb PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_restart
-Checking test 042 rap_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 303.471062
-  0: The maximum resident set size (KB)                   = 804880
-
-Test 042 rap_restart PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_sfcdiff
-Checking test 043 rap_sfcdiff results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 615.977963
-  0: The maximum resident set size (KB)                   = 956716
-
-Test 043 rap_sfcdiff PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_sfcdiff_restart
-Checking test 044 rap_sfcdiff_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 332.215617
-  0: The maximum resident set size (KB)                   = 823536
-
-Test 044 rap_sfcdiff_restart PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hrrr_control
-Checking test 045 hrrr_control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 582.502058
-  0: The maximum resident set size (KB)                   = 966832
-
-Test 045 hrrr_control PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_v1beta
-Checking test 046 rrfs_v1beta results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 585.943069
-  0: The maximum resident set size (KB)                   = 951900
-
-Test 046 rrfs_v1beta PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_v1nssl
-Checking test 047 rrfs_v1nssl results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 706.077253
-  0: The maximum resident set size (KB)                   = 639520
-
-Test 047 rrfs_v1nssl PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_v1nssl_nohailnoccn
-Checking test 048 rrfs_v1nssl_nohailnoccn results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 684.765077
-  0: The maximum resident set size (KB)                   = 641336
-
-Test 048 rrfs_v1nssl_nohailnoccn PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_conus13km_hrrr_warm
-Checking test 049 rrfs_conus13km_hrrr_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 248.606154
-  0: The maximum resident set size (KB)                   = 849704
-
-Test 049 rrfs_conus13km_hrrr_warm PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_conus13km_radar_tten_warm
-Checking test 050 rrfs_conus13km_radar_tten_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 250.539252
-  0: The maximum resident set size (KB)                   = 853272
-
-Test 050 rrfs_conus13km_radar_tten_warm PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_smoke_conus13km_hrrr_warm
-Checking test 051 rrfs_smoke_conus13km_hrrr_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 286.573226
-  0: The maximum resident set size (KB)                   = 879008
-
-Test 051 rrfs_smoke_conus13km_hrrr_warm PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_csawmg
-Checking test 052 control_csawmg results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 470.359016
-  0: The maximum resident set size (KB)                   = 688640
-
-Test 052 control_csawmg PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_csawmgt
-Checking test 053 control_csawmgt results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 445.905730
-  0: The maximum resident set size (KB)                   = 690532
-
-Test 053 control_csawmgt PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_flake
-Checking test 054 control_flake results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 284.108506
-  0: The maximum resident set size (KB)                   = 692916
-
-Test 054 control_flake PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_ras
-Checking test 055 control_ras results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 254.163073
-  0: The maximum resident set size (KB)                   = 657292
-
-Test 055 control_ras PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_thompson
-Checking test 056 control_thompson results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 327.368974
-  0: The maximum resident set size (KB)                   = 1004452
-
-Test 056 control_thompson PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_thompson_no_aero
-Checking test 057 control_thompson_no_aero results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 311.417796
-  0: The maximum resident set size (KB)                   = 999496
-
-Test 057 control_thompson_no_aero PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_wam
-Checking test 058 control_wam results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
-
-  0: The total amount of wall time                        = 145.169037
-  0: The maximum resident set size (KB)                   = 458540
-
-Test 058 control_wam PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_debug
-Checking test 059 control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 188.474575
-  0: The maximum resident set size (KB)                   = 750672
-
-Test 059 control_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_2threads_debug
-Checking test 060 control_2threads_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
- 0: The total amount of wall time                        = 347.375184
- 0: The maximum resident set size (KB)                   = 807856
-
-Test 060 control_2threads_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_CubedSphereGrid_debug
-Checking test 061 control_CubedSphereGrid_debug results ....
- Comparing sfcf000.tile1.nc .........OK
- Comparing sfcf000.tile2.nc .........OK
- Comparing sfcf000.tile3.nc .........OK
- Comparing sfcf000.tile4.nc .........OK
- Comparing sfcf000.tile5.nc .........OK
- Comparing sfcf000.tile6.nc .........OK
- Comparing sfcf001.tile1.nc .........OK
- Comparing sfcf001.tile2.nc .........OK
- Comparing sfcf001.tile3.nc .........OK
- Comparing sfcf001.tile4.nc .........OK
- Comparing sfcf001.tile5.nc .........OK
- Comparing sfcf001.tile6.nc .........OK
- Comparing atmf000.tile1.nc .........OK
- Comparing atmf000.tile2.nc .........OK
- Comparing atmf000.tile3.nc .........OK
- Comparing atmf000.tile4.nc .........OK
- Comparing atmf000.tile5.nc .........OK
- Comparing atmf000.tile6.nc .........OK
- Comparing atmf001.tile1.nc .........OK
- Comparing atmf001.tile2.nc .........OK
- Comparing atmf001.tile3.nc .........OK
- Comparing atmf001.tile4.nc .........OK
- Comparing atmf001.tile5.nc .........OK
- Comparing atmf001.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 221.791809
-  0: The maximum resident set size (KB)                   = 747592
-
-Test 061 control_CubedSphereGrid_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_wrtGauss_netcdf_parallel_debug
-Checking test 062 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 196.565117
-  0: The maximum resident set size (KB)                   = 751988
-
-Test 062 control_wrtGauss_netcdf_parallel_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_stochy_debug
-Checking test 063 control_stochy_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 221.612004
-  0: The maximum resident set size (KB)                   = 752412
-
-Test 063 control_stochy_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_lndp_debug
-Checking test 064 control_lndp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 198.773167
-  0: The maximum resident set size (KB)                   = 755796
-
-Test 064 control_lndp_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_csawmg_debug
-Checking test 065 control_csawmg_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 307.339123
-  0: The maximum resident set size (KB)                   = 796908
-
-Test 065 control_csawmg_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_csawmgt_debug
-Checking test 066 control_csawmgt_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 302.678986
-  0: The maximum resident set size (KB)                   = 796632
-
-Test 066 control_csawmgt_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_ras_debug
-Checking test 067 control_ras_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 196.777463
-  0: The maximum resident set size (KB)                   = 767616
-
-Test 067 control_ras_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_diag_debug
-Checking test 068 control_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 202.111562
-  0: The maximum resident set size (KB)                   = 804548
-
-Test 068 control_diag_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_debug_p8
-Checking test 069 control_debug_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 232.053884
-  0: The maximum resident set size (KB)                   = 1132016
-
-Test 069 control_debug_p8 PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_thompson_debug
-Checking test 070 control_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 238.126731
-  0: The maximum resident set size (KB)                   = 1115824
-
-Test 070 control_thompson_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_thompson_no_aero_debug
-Checking test 071 control_thompson_no_aero_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 220.597242
-  0: The maximum resident set size (KB)                   = 1103428
-
-Test 071 control_thompson_no_aero_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_thompson_extdiag_debug
-Checking test 072 control_thompson_extdiag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 239.446500
-  0: The maximum resident set size (KB)                   = 1151240
-
-Test 072 control_thompson_extdiag_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_thompson_progcld_thompson_debug
-Checking test 073 control_thompson_progcld_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 231.553932
-  0: The maximum resident set size (KB)                   = 1122776
-
-Test 073 control_thompson_progcld_thompson_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/regional_debug
-Checking test 074 regional_debug results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
-
- 0: The total amount of wall time                        = 323.897783
- 0: The maximum resident set size (KB)                   = 758116
-
-Test 074 regional_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_control_debug
-Checking test 075 rap_control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 348.479703
-  0: The maximum resident set size (KB)                   = 1129064
-
-Test 075 rap_control_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_unified_drag_suite_debug
-Checking test 076 rap_unified_drag_suite_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 358.785216
-  0: The maximum resident set size (KB)                   = 1126564
-
-Test 076 rap_unified_drag_suite_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_diag_debug
-Checking test 077 rap_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 370.875998
-  0: The maximum resident set size (KB)                   = 1208500
-
-Test 077 rap_diag_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_cires_ugwp_debug
-Checking test 078 rap_cires_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 392.944619
-  0: The maximum resident set size (KB)                   = 1130692
-
-Test 078 rap_cires_ugwp_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_unified_ugwp_debug
-Checking test 079 rap_unified_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 361.843132
-  0: The maximum resident set size (KB)                   = 1119588
-
-Test 079 rap_unified_ugwp_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_lndp_debug
-Checking test 080 rap_lndp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 352.652375
-  0: The maximum resident set size (KB)                   = 1124952
-
-Test 080 rap_lndp_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_flake_debug
-Checking test 081 rap_flake_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 365.206538
-  0: The maximum resident set size (KB)                   = 1122228
-
-Test 081 rap_flake_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_progcld_thompson_debug
-Checking test 082 rap_progcld_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 347.975873
-  0: The maximum resident set size (KB)                   = 1129116
-
-Test 082 rap_progcld_thompson_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_noah_debug
-Checking test 083 rap_noah_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 347.358916
-  0: The maximum resident set size (KB)                   = 1122764
-
-Test 083 rap_noah_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_rrtmgp_debug
-Checking test 084 rap_rrtmgp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 606.807967
-  0: The maximum resident set size (KB)                   = 1245880
-
-Test 084 rap_rrtmgp_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_sfcdiff_debug
-Checking test 085 rap_sfcdiff_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 360.497633
-  0: The maximum resident set size (KB)                   = 1122500
-
-Test 085 rap_sfcdiff_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rap_noah_sfcdiff_cires_ugwp_debug
-Checking test 086 rap_noah_sfcdiff_cires_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 592.125245
-  0: The maximum resident set size (KB)                   = 1123304
-
-Test 086 rap_noah_sfcdiff_cires_ugwp_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/rrfs_v1beta_debug
-Checking test 087 rrfs_v1beta_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 362.914820
-  0: The maximum resident set size (KB)                   = 1117832
-
-Test 087 rrfs_v1beta_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_wam_debug
-Checking test 088 control_wam_debug results ....
- Comparing sfcf019.nc .........OK
- Comparing atmf019.nc .........OK
-
-  0: The total amount of wall time                        = 367.731463
-  0: The maximum resident set size (KB)                   = 426404
-
-Test 088 control_wam_debug PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_atm
-Checking test 089 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing HURPRS.GrbF06 .........OK
-
-  0: The total amount of wall time                        = 759.551875
-  0: The maximum resident set size (KB)                   = 1179484
-
-Test 089 hafs_regional_atm PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_atm_thompson_gfdlsf
-Checking test 090 hafs_regional_atm_thompson_gfdlsf results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
-
-  0: The total amount of wall time                        = 931.115892
-  0: The maximum resident set size (KB)                   = 1515844
-
-Test 090 hafs_regional_atm_thompson_gfdlsf PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_atm_ocn
-Checking test 091 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing archv.2019_241_06.a .........OK
- Comparing archs.2019_241_06.a .........OK
- Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
-
-  0: The total amount of wall time                        = 586.221956
-  0: The maximum resident set size (KB)                   = 1267008
-
-Test 091 hafs_regional_atm_ocn PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_atm_wav
-Checking test 092 hafs_regional_atm_wav results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing out_grd.ww3 .........OK
- Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
- Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
-
-  0: The total amount of wall time                        = 978.437620
-  0: The maximum resident set size (KB)                   = 1308548
-
-Test 092 hafs_regional_atm_wav PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_atm_ocn_wav
-Checking test 093 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing archv.2019_241_06.a .........OK
- Comparing archs.2019_241_06.a .........OK
- Comparing out_grd.ww3 .........OK
- Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
- Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
-
-  0: The total amount of wall time                        = 1065.728901
-  0: The maximum resident set size (KB)                   = 1314480
-
-Test 093 hafs_regional_atm_ocn_wav PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_docn
-Checking test 094 hafs_regional_docn results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
-
-  0: The total amount of wall time                        = 587.738105
-  0: The maximum resident set size (KB)                   = 1276808
-
-Test 094 hafs_regional_docn PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_docn_oisst
-Checking test 095 hafs_regional_docn_oisst results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
-
-  0: The total amount of wall time                        = 553.012392
-  0: The maximum resident set size (KB)                   = 1257264
-
-Test 095 hafs_regional_docn_oisst PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/hafs_regional_datm_cdeps
-Checking test 096 hafs_regional_datm_cdeps results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/cpld_debug_p8
+Checking test 002 cpld_debug_p8 results ....
+Moving baseline 002 cpld_debug_p8 files ....
+ Moving sfcf003.tile1.nc .........OK
+ Moving sfcf003.tile2.nc .........OK
+ Moving sfcf003.tile3.nc .........OK
+ Moving sfcf003.tile4.nc .........OK
+ Moving sfcf003.tile5.nc .........OK
+ Moving sfcf003.tile6.nc .........OK
+ Moving atmf003.tile1.nc .........OK
+ Moving atmf003.tile2.nc .........OK
+ Moving atmf003.tile3.nc .........OK
+ Moving atmf003.tile4.nc .........OK
+ Moving atmf003.tile5.nc .........OK
+ Moving atmf003.tile6.nc .........OK
+ Moving gocart.inst_aod.20210322_0900z.nc4 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2021-03-22-32400.nc .........OK
+ Moving RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
+ Moving 20210322.090000.out_pnt.ww3 .........OK
+ Moving 20210322.090000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 993.938583
+  0: The maximum resident set size (KB)                   = 2070536
+
+Test 002 cpld_debug_p8 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/cpld_control_noaero_p8_agrid
+Checking test 003 cpld_control_noaero_p8_agrid results ....
+Moving baseline 003 cpld_control_noaero_p8_agrid files ....
+ Moving sfcf021.tile1.nc .........OK
+ Moving sfcf021.tile2.nc .........OK
+ Moving sfcf021.tile3.nc .........OK
+ Moving sfcf021.tile4.nc .........OK
+ Moving sfcf021.tile5.nc .........OK
+ Moving sfcf021.tile6.nc .........OK
+ Moving atmf021.tile1.nc .........OK
+ Moving atmf021.tile2.nc .........OK
+ Moving atmf021.tile3.nc .........OK
+ Moving atmf021.tile4.nc .........OK
+ Moving atmf021.tile5.nc .........OK
+ Moving atmf021.tile6.nc .........OK
+ Moving sfcf024.tile1.nc .........OK
+ Moving sfcf024.tile2.nc .........OK
+ Moving sfcf024.tile3.nc .........OK
+ Moving sfcf024.tile4.nc .........OK
+ Moving sfcf024.tile5.nc .........OK
+ Moving sfcf024.tile6.nc .........OK
+ Moving atmf024.tile1.nc .........OK
+ Moving atmf024.tile2.nc .........OK
+ Moving atmf024.tile3.nc .........OK
+ Moving atmf024.tile4.nc .........OK
+ Moving atmf024.tile5.nc .........OK
+ Moving atmf024.tile6.nc .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2021-03-23-21600.nc .........OK
+ Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+
+  0: The total amount of wall time                        = 395.103349
+  0: The maximum resident set size (KB)                   = 1149108
+
+Test 003 cpld_control_noaero_p8_agrid PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control
+Checking test 004 control results ....
+Moving baseline 004 control files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 180.112752
+  0: The maximum resident set size (KB)                   = 585960
+
+Test 004 control PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_CubedSphereGrid
+Checking test 005 control_CubedSphereGrid results ....
+Moving baseline 005 control_CubedSphereGrid files ....
+ Moving sfcf000.tile1.nc .........OK
+ Moving sfcf000.tile2.nc .........OK
+ Moving sfcf000.tile3.nc .........OK
+ Moving sfcf000.tile4.nc .........OK
+ Moving sfcf000.tile5.nc .........OK
+ Moving sfcf000.tile6.nc .........OK
+ Moving sfcf024.tile1.nc .........OK
+ Moving sfcf024.tile2.nc .........OK
+ Moving sfcf024.tile3.nc .........OK
+ Moving sfcf024.tile4.nc .........OK
+ Moving sfcf024.tile5.nc .........OK
+ Moving sfcf024.tile6.nc .........OK
+ Moving atmf000.tile1.nc .........OK
+ Moving atmf000.tile2.nc .........OK
+ Moving atmf000.tile3.nc .........OK
+ Moving atmf000.tile4.nc .........OK
+ Moving atmf000.tile5.nc .........OK
+ Moving atmf000.tile6.nc .........OK
+ Moving atmf024.tile1.nc .........OK
+ Moving atmf024.tile2.nc .........OK
+ Moving atmf024.tile3.nc .........OK
+ Moving atmf024.tile4.nc .........OK
+ Moving atmf024.tile5.nc .........OK
+ Moving atmf024.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 176.727938
+  0: The maximum resident set size (KB)                   = 578740
+
+Test 005 control_CubedSphereGrid PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_latlon
+Checking test 006 control_latlon results ....
+Moving baseline 006 control_latlon files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 171.630904
+  0: The maximum resident set size (KB)                   = 583088
+
+Test 006 control_latlon PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_wrtGauss_netcdf_parallel
+Checking test 007 control_wrtGauss_netcdf_parallel results ....
+Moving baseline 007 control_wrtGauss_netcdf_parallel files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 178.416556
+  0: The maximum resident set size (KB)                   = 579940
+
+Test 007 control_wrtGauss_netcdf_parallel PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_c48
+Checking test 008 control_c48 results ....
+Moving baseline 008 control_c48 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+0: The total amount of wall time                        = 571.219634
+0: The maximum resident set size (KB)                   = 788232
+
+Test 008 control_c48 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_c192
+Checking test 009 control_c192 results ....
+Moving baseline 009 control_c192 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 690.331145
+  0: The maximum resident set size (KB)                   = 737340
+
+Test 009 control_c192 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_c384
+Checking test 010 control_c384 results ....
+Moving baseline 010 control_c384 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf012.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf012.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF12 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 892.479664
+  0: The maximum resident set size (KB)                   = 1074304
+
+Test 010 control_c384 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_c384gdas
+Checking test 011 control_c384gdas results ....
+Moving baseline 011 control_c384gdas files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf006.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF06 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF06 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 819.649861
+  0: The maximum resident set size (KB)                   = 1162980
+
+Test 011 control_c384gdas PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_c384_progsigma
+Checking test 012 control_c384_progsigma results ....
+Moving baseline 012 control_c384_progsigma files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf012.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf012.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF12 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 912.791222
+  0: The maximum resident set size (KB)                   = 987656
+
+Test 012 control_c384_progsigma PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_stochy
+Checking test 013 control_stochy results ....
+Moving baseline 013 control_stochy files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf012.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf012.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF12 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 113.422657
+  0: The maximum resident set size (KB)                   = 583900
+
+Test 013 control_stochy PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_lndp
+Checking test 014 control_lndp results ....
+Moving baseline 014 control_lndp files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf012.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf012.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF12 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 103.395862
+  0: The maximum resident set size (KB)                   = 582732
+
+Test 014 control_lndp PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_iovr4
+Checking test 015 control_iovr4 results ....
+Moving baseline 015 control_iovr4 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 176.750685
+  0: The maximum resident set size (KB)                   = 580784
+
+Test 015 control_iovr4 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_iovr5
+Checking test 016 control_iovr5 results ....
+Moving baseline 016 control_iovr5 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 181.776436
+  0: The maximum resident set size (KB)                   = 578508
+
+Test 016 control_iovr5 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_p8
+Checking test 017 control_p8 results ....
+Moving baseline 017 control_p8 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 232.562042
+  0: The maximum resident set size (KB)                   = 978716
+
+Test 017 control_p8 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_p8_lndp
+Checking test 018 control_p8_lndp results ....
+Moving baseline 018 control_p8_lndp files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving sfcf048.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving atmf048.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSFLX.GrbF48 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving GFSPRS.GrbF48 .........OK
+
+  0: The total amount of wall time                        = 449.873518
+  0: The maximum resident set size (KB)                   = 966544
+
+Test 018 control_p8_lndp PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_p8_rrtmgp
+Checking test 019 control_p8_rrtmgp results ....
+Moving baseline 019 control_p8_rrtmgp files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 272.592535
+  0: The maximum resident set size (KB)                   = 1093592
+
+Test 019 control_p8_rrtmgp PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/regional_control
+Checking test 020 regional_control results ....
+Moving baseline 020 regional_control files ....
+ Moving dynf000.nc .........OK
+ Moving dynf024.nc .........OK
+ Moving phyf000.nc .........OK
+ Moving phyf024.nc .........OK
+ Moving PRSLEV.GrbF00 .........OK
+ Moving PRSLEV.GrbF24 .........OK
+ Moving NATLEV.GrbF00 .........OK
+ Moving NATLEV.GrbF24 .........OK
+
+ 0: The total amount of wall time                        = 469.362369
+ 0: The maximum resident set size (KB)                   = 742624
+
+Test 020 regional_control PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/regional_noquilt
+Checking test 021 regional_noquilt results ....
+Moving baseline 021 regional_noquilt files ....
+ Moving atmos_4xdaily.nc .........OK
+ Moving fv3_history2d.nc .........OK
+ Moving fv3_history.nc .........OK
+ Moving RESTART/fv_core.res.tile1_new.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1_new.nc .........OK
+
+ 0: The total amount of wall time                        = 488.475595
+ 0: The maximum resident set size (KB)                   = 717936
+
+Test 021 regional_noquilt PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/regional_netcdf_parallel
+Checking test 022 regional_netcdf_parallel results ....
+Moving baseline 022 regional_netcdf_parallel files ....
+ Moving dynf000.nc .........OK
+ Moving dynf024.nc .........OK
+ Moving phyf000.nc .........OK
+ Moving phyf024.nc .........OK
+
+ 0: The total amount of wall time                        = 452.346871
+ 0: The maximum resident set size (KB)                   = 741020
+
+Test 022 regional_netcdf_parallel PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/regional_3km
+Checking test 023 regional_3km results ....
+Moving baseline 023 regional_3km files ....
+ Moving dynf000.nc .........OK
+ Moving dynf006.nc .........OK
+ Moving phyf000.nc .........OK
+ Moving phyf006.nc .........OK
+ Moving PRSLEV.GrbF00 .........OK
+ Moving PRSLEV.GrbF06 .........OK
+ Moving NATLEV.GrbF00 .........OK
+ Moving NATLEV.GrbF06 .........OK
+
+  0: The total amount of wall time                        = 364.804527
+  0: The maximum resident set size (KB)                   = 778108
+
+Test 023 regional_3km PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_control
+Checking test 024 rap_control results ....
+Moving baseline 024 rap_control files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 586.387536
+  0: The maximum resident set size (KB)                   = 965856
+
+Test 024 rap_control PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_rrtmgp
+Checking test 025 rap_rrtmgp results ....
+Moving baseline 025 rap_rrtmgp files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 616.337345
+  0: The maximum resident set size (KB)                   = 1080820
+
+Test 025 rap_rrtmgp PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/regional_spp_sppt_shum_skeb
+Checking test 026 regional_spp_sppt_shum_skeb results ....
+Moving baseline 026 regional_spp_sppt_shum_skeb files ....
+ Moving dynf000.nc .........OK
+ Moving dynf001.nc .........OK
+ Moving phyf000.nc .........OK
+ Moving phyf001.nc .........OK
+ Moving PRSLEV.GrbF00 .........OK
+ Moving PRSLEV.GrbF01 .........OK
+ Moving NATLEV.GrbF00 .........OK
+ Moving NATLEV.GrbF01 .........OK
+
+  0: The total amount of wall time                        = 851.296206
+  0: The maximum resident set size (KB)                   = 1088828
+
+Test 026 regional_spp_sppt_shum_skeb PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_sfcdiff
+Checking test 027 rap_sfcdiff results ....
+Moving baseline 027 rap_sfcdiff files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 589.546892
+  0: The maximum resident set size (KB)                   = 953972
+
+Test 027 rap_sfcdiff PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hrrr_control
+Checking test 028 hrrr_control results ....
+Moving baseline 028 hrrr_control files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 552.292175
+  0: The maximum resident set size (KB)                   = 957220
+
+Test 028 hrrr_control PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_v1beta
+Checking test 029 rrfs_v1beta results ....
+Moving baseline 029 rrfs_v1beta files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 571.690492
+  0: The maximum resident set size (KB)                   = 962760
+
+Test 029 rrfs_v1beta PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_v1nssl
+Checking test 030 rrfs_v1nssl results ....
+Moving baseline 030 rrfs_v1nssl files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 668.136568
+  0: The maximum resident set size (KB)                   = 644200
+
+Test 030 rrfs_v1nssl PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_v1nssl_nohailnoccn
+Checking test 031 rrfs_v1nssl_nohailnoccn results ....
+Moving baseline 031 rrfs_v1nssl_nohailnoccn files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf021.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf021.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF21 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF21 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 662.323366
+  0: The maximum resident set size (KB)                   = 637992
+
+Test 031 rrfs_v1nssl_nohailnoccn PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_conus13km_hrrr_warm
+Checking test 032 rrfs_conus13km_hrrr_warm results ....
+Moving baseline 032 rrfs_conus13km_hrrr_warm files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving sfcf002.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+ Moving atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 237.075720
+  0: The maximum resident set size (KB)                   = 848924
+
+Test 032 rrfs_conus13km_hrrr_warm PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_conus13km_radar_tten_warm
+Checking test 033 rrfs_conus13km_radar_tten_warm results ....
+Moving baseline 033 rrfs_conus13km_radar_tten_warm files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving sfcf002.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+ Moving atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 240.058363
+  0: The maximum resident set size (KB)                   = 852868
+
+Test 033 rrfs_conus13km_radar_tten_warm PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_smoke_conus13km_hrrr_warm
+Checking test 034 rrfs_smoke_conus13km_hrrr_warm results ....
+Moving baseline 034 rrfs_smoke_conus13km_hrrr_warm files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving sfcf002.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+ Moving atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 269.464130
+  0: The maximum resident set size (KB)                   = 877268
+
+Test 034 rrfs_smoke_conus13km_hrrr_warm PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_csawmg
+Checking test 035 control_csawmg results ....
+Moving baseline 035 control_csawmg files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 440.479939
+  0: The maximum resident set size (KB)                   = 689480
+
+Test 035 control_csawmg PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_csawmgt
+Checking test 036 control_csawmgt results ....
+Moving baseline 036 control_csawmgt files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 436.885363
+  0: The maximum resident set size (KB)                   = 690348
+
+Test 036 control_csawmgt PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_flake
+Checking test 037 control_flake results ....
+Moving baseline 037 control_flake files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 280.621251
+  0: The maximum resident set size (KB)                   = 692124
+
+Test 037 control_flake PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_ras
+Checking test 038 control_ras results ....
+Moving baseline 038 control_ras files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 240.786577
+  0: The maximum resident set size (KB)                   = 650916
+
+Test 038 control_ras PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_thompson
+Checking test 039 control_thompson results ....
+Moving baseline 039 control_thompson files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 316.088713
+  0: The maximum resident set size (KB)                   = 1009708
+
+Test 039 control_thompson PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_thompson_no_aero
+Checking test 040 control_thompson_no_aero results ....
+Moving baseline 040 control_thompson_no_aero files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 302.980363
+  0: The maximum resident set size (KB)                   = 989596
+
+Test 040 control_thompson_no_aero PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_wam
+Checking test 041 control_wam results ....
+Moving baseline 041 control_wam files ....
+ Moving sfcf024.nc .........OK
+ Moving atmf024.nc .........OK
+
+  0: The total amount of wall time                        = 135.923549
+  0: The maximum resident set size (KB)                   = 461332
+
+Test 041 control_wam PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_debug
+Checking test 042 control_debug results ....
+Moving baseline 042 control_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 188.244888
+  0: The maximum resident set size (KB)                   = 745624
+
+Test 042 control_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_CubedSphereGrid_debug
+Checking test 043 control_CubedSphereGrid_debug results ....
+Moving baseline 043 control_CubedSphereGrid_debug files ....
+ Moving sfcf000.tile1.nc .........OK
+ Moving sfcf000.tile2.nc .........OK
+ Moving sfcf000.tile3.nc .........OK
+ Moving sfcf000.tile4.nc .........OK
+ Moving sfcf000.tile5.nc .........OK
+ Moving sfcf000.tile6.nc .........OK
+ Moving sfcf001.tile1.nc .........OK
+ Moving sfcf001.tile2.nc .........OK
+ Moving sfcf001.tile3.nc .........OK
+ Moving sfcf001.tile4.nc .........OK
+ Moving sfcf001.tile5.nc .........OK
+ Moving sfcf001.tile6.nc .........OK
+ Moving atmf000.tile1.nc .........OK
+ Moving atmf000.tile2.nc .........OK
+ Moving atmf000.tile3.nc .........OK
+ Moving atmf000.tile4.nc .........OK
+ Moving atmf000.tile5.nc .........OK
+ Moving atmf000.tile6.nc .........OK
+ Moving atmf001.tile1.nc .........OK
+ Moving atmf001.tile2.nc .........OK
+ Moving atmf001.tile3.nc .........OK
+ Moving atmf001.tile4.nc .........OK
+ Moving atmf001.tile5.nc .........OK
+ Moving atmf001.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 205.805529
+  0: The maximum resident set size (KB)                   = 749072
+
+Test 043 control_CubedSphereGrid_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_wrtGauss_netcdf_parallel_debug
+Checking test 044 control_wrtGauss_netcdf_parallel_debug results ....
+Moving baseline 044 control_wrtGauss_netcdf_parallel_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 199.388480
+  0: The maximum resident set size (KB)                   = 746824
+
+Test 044 control_wrtGauss_netcdf_parallel_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_stochy_debug
+Checking test 045 control_stochy_debug results ....
+Moving baseline 045 control_stochy_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 216.580668
+  0: The maximum resident set size (KB)                   = 752916
+
+Test 045 control_stochy_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_lndp_debug
+Checking test 046 control_lndp_debug results ....
+Moving baseline 046 control_lndp_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 194.225857
+  0: The maximum resident set size (KB)                   = 752044
+
+Test 046 control_lndp_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_csawmg_debug
+Checking test 047 control_csawmg_debug results ....
+Moving baseline 047 control_csawmg_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 301.501881
+  0: The maximum resident set size (KB)                   = 794004
+
+Test 047 control_csawmg_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_csawmgt_debug
+Checking test 048 control_csawmgt_debug results ....
+Moving baseline 048 control_csawmgt_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 304.512112
+  0: The maximum resident set size (KB)                   = 795388
+
+Test 048 control_csawmgt_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_ras_debug
+Checking test 049 control_ras_debug results ....
+Moving baseline 049 control_ras_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 197.278501
+  0: The maximum resident set size (KB)                   = 762340
+
+Test 049 control_ras_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_diag_debug
+Checking test 050 control_diag_debug results ....
+Moving baseline 050 control_diag_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 200.391209
+  0: The maximum resident set size (KB)                   = 805816
+
+Test 050 control_diag_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_debug_p8
+Checking test 051 control_debug_p8 results ....
+Moving baseline 051 control_debug_p8 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 214.714035
+  0: The maximum resident set size (KB)                   = 1133920
+
+Test 051 control_debug_p8 PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_thompson_debug
+Checking test 052 control_thompson_debug results ....
+Moving baseline 052 control_thompson_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 229.450795
+  0: The maximum resident set size (KB)                   = 1116644
+
+Test 052 control_thompson_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_thompson_no_aero_debug
+Checking test 053 control_thompson_no_aero_debug results ....
+Moving baseline 053 control_thompson_no_aero_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 216.240598
+  0: The maximum resident set size (KB)                   = 1102512
+
+Test 053 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_thompson_extdiag_debug
+Checking test 054 control_thompson_extdiag_debug results ....
+Moving baseline 054 control_thompson_extdiag_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 233.689555
+  0: The maximum resident set size (KB)                   = 1152284
+
+Test 054 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_thompson_progcld_thompson_debug
+Checking test 055 control_thompson_progcld_thompson_debug results ....
+Moving baseline 055 control_thompson_progcld_thompson_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 227.412335
+  0: The maximum resident set size (KB)                   = 1116228
+
+Test 055 control_thompson_progcld_thompson_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/regional_debug
+Checking test 056 regional_debug results ....
+Moving baseline 056 regional_debug files ....
+ Moving dynf000.nc .........OK
+ Moving dynf001.nc .........OK
+ Moving phyf000.nc .........OK
+ Moving phyf001.nc .........OK
+
+ 0: The total amount of wall time                        = 321.453684
+ 0: The maximum resident set size (KB)                   = 752996
+
+Test 056 regional_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_control_debug
+Checking test 057 rap_control_debug results ....
+Moving baseline 057 rap_control_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 351.382027
+  0: The maximum resident set size (KB)                   = 1126336
+
+Test 057 rap_control_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_diag_debug
+Checking test 058 rap_diag_debug results ....
+Moving baseline 058 rap_diag_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 369.702036
+  0: The maximum resident set size (KB)                   = 1204760
+
+Test 058 rap_diag_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_cires_ugwp_debug
+Checking test 059 rap_cires_ugwp_debug results ....
+Moving baseline 059 rap_cires_ugwp_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 361.403345
+  0: The maximum resident set size (KB)                   = 1124228
+
+Test 059 rap_cires_ugwp_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_lndp_debug
+Checking test 060 rap_lndp_debug results ....
+Moving baseline 060 rap_lndp_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 355.352565
+  0: The maximum resident set size (KB)                   = 1120128
+
+Test 060 rap_lndp_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_flake_debug
+Checking test 061 rap_flake_debug results ....
+Moving baseline 061 rap_flake_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 351.590793
+  0: The maximum resident set size (KB)                   = 1126132
+
+Test 061 rap_flake_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_progcld_thompson_debug
+Checking test 062 rap_progcld_thompson_debug results ....
+Moving baseline 062 rap_progcld_thompson_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 354.973923
+  0: The maximum resident set size (KB)                   = 1125412
+
+Test 062 rap_progcld_thompson_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_noah_debug
+Checking test 063 rap_noah_debug results ....
+Moving baseline 063 rap_noah_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 351.787769
+  0: The maximum resident set size (KB)                   = 1126524
+
+Test 063 rap_noah_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_rrtmgp_debug
+Checking test 064 rap_rrtmgp_debug results ....
+Moving baseline 064 rap_rrtmgp_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 587.569749
+  0: The maximum resident set size (KB)                   = 1238984
+
+Test 064 rap_rrtmgp_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_sfcdiff_debug
+Checking test 065 rap_sfcdiff_debug results ....
+Moving baseline 065 rap_sfcdiff_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 355.284678
+  0: The maximum resident set size (KB)                   = 1125528
+
+Test 065 rap_sfcdiff_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 066 rap_noah_sfcdiff_cires_ugwp_debug results ....
+Moving baseline 066 rap_noah_sfcdiff_cires_ugwp_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 575.582067
+  0: The maximum resident set size (KB)                   = 1123356
+
+Test 066 rap_noah_sfcdiff_cires_ugwp_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/rrfs_v1beta_debug
+Checking test 067 rrfs_v1beta_debug results ....
+Moving baseline 067 rrfs_v1beta_debug files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf001.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 349.701895
+  0: The maximum resident set size (KB)                   = 1119396
+
+Test 067 rrfs_v1beta_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_wam_debug
+Checking test 068 control_wam_debug results ....
+Moving baseline 068 control_wam_debug files ....
+ Moving sfcf019.nc .........OK
+ Moving atmf019.nc .........OK
+
+  0: The total amount of wall time                        = 364.473811
+  0: The maximum resident set size (KB)                   = 421652
+
+Test 068 control_wam_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_atm
+Checking test 069 hafs_regional_atm results ....
+Moving baseline 069 hafs_regional_atm files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving HURPRS.GrbF06 .........OK
+
+  0: The total amount of wall time                        = 751.451934
+  0: The maximum resident set size (KB)                   = 1171848
+
+Test 069 hafs_regional_atm PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_atm_thompson_gfdlsf
+Checking test 070 hafs_regional_atm_thompson_gfdlsf results ....
+Moving baseline 070 hafs_regional_atm_thompson_gfdlsf files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+
+  0: The total amount of wall time                        = 871.888561
+  0: The maximum resident set size (KB)                   = 1538204
+
+Test 070 hafs_regional_atm_thompson_gfdlsf PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_atm_ocn
+Checking test 071 hafs_regional_atm_ocn results ....
+Moving baseline 071 hafs_regional_atm_ocn files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving archv.2019_241_06.a .........OK
+ Moving archs.2019_241_06.a .........OK
+ Moving ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 536.073711
+  0: The maximum resident set size (KB)                   = 1206796
+
+Test 071 hafs_regional_atm_ocn PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_atm_wav
+Checking test 072 hafs_regional_atm_wav results ....
+Moving baseline 072 hafs_regional_atm_wav files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving out_grd.ww3 .........OK
+ Moving out_pnt.ww3 .........OK
+ Moving 20190829.060000.restart.ww3 .........OK
+ Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 931.471387
+  0: The maximum resident set size (KB)                   = 1299548
+
+Test 072 hafs_regional_atm_wav PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_atm_ocn_wav
+Checking test 073 hafs_regional_atm_ocn_wav results ....
+Moving baseline 073 hafs_regional_atm_ocn_wav files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving archv.2019_241_06.a .........OK
+ Moving archs.2019_241_06.a .........OK
+ Moving out_grd.ww3 .........OK
+ Moving out_pnt.ww3 .........OK
+ Moving 20190829.060000.restart.ww3 .........OK
+ Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 1022.694079
+  0: The maximum resident set size (KB)                   = 1314244
+
+Test 073 hafs_regional_atm_ocn_wav PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_docn
+Checking test 074 hafs_regional_docn results ....
+Moving baseline 074 hafs_regional_docn files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+ Moving ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 556.977370
+  0: The maximum resident set size (KB)                   = 1280576
+
+Test 074 hafs_regional_docn PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/hafs_regional_docn_oisst
+Checking test 075 hafs_regional_docn_oisst results ....
+Moving baseline 075 hafs_regional_docn_oisst files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+ Moving ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 540.478845
+  0: The maximum resident set size (KB)                   = 1188136
+
+Test 075 hafs_regional_docn_oisst PASS
+
+Test 076 hafs_regional_datm_cdeps FAIL
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_control_cfsr
+Checking test 077 datm_cdeps_control_cfsr results ....
+Moving baseline 077 datm_cdeps_control_cfsr files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 199.406278
+ 0: The maximum resident set size (KB)                   = 911408
+
+Test 077 datm_cdeps_control_cfsr PASS Tries: 2
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_control_gefs
+Checking test 078 datm_cdeps_control_gefs results ....
+Moving baseline 078 datm_cdeps_control_gefs files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 190.959776
+ 0: The maximum resident set size (KB)                   = 817808
+
+Test 078 datm_cdeps_control_gefs PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_iau_gefs
+Checking test 079 datm_cdeps_iau_gefs results ....
+Moving baseline 079 datm_cdeps_iau_gefs files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 196.036371
+ 0: The maximum resident set size (KB)                   = 817716
+
+Test 079 datm_cdeps_iau_gefs PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_stochy_gefs
+Checking test 080 datm_cdeps_stochy_gefs results ....
+Moving baseline 080 datm_cdeps_stochy_gefs files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 198.857816
+ 0: The maximum resident set size (KB)                   = 818812
+
+Test 080 datm_cdeps_stochy_gefs PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_bulk_cfsr
+Checking test 081 datm_cdeps_bulk_cfsr results ....
+Moving baseline 081 datm_cdeps_bulk_cfsr files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 202.197104
+ 0: The maximum resident set size (KB)                   = 909140
+
+Test 081 datm_cdeps_bulk_cfsr PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_bulk_gefs
+Checking test 082 datm_cdeps_bulk_gefs results ....
+Moving baseline 082 datm_cdeps_bulk_gefs files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 189.852618
+ 0: The maximum resident set size (KB)                   = 816244
+
+Test 082 datm_cdeps_bulk_gefs PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_mx025_cfsr
+Checking test 083 datm_cdeps_mx025_cfsr results ....
+Moving baseline 083 datm_cdeps_mx025_cfsr files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/MOM.res_1.nc .........OK
+ Moving RESTART/MOM.res_2.nc .........OK
+ Moving RESTART/MOM.res_3.nc .........OK
+ Moving RESTART/iced.2011-10-01-43200.nc .........OK
+ Moving RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
+
+  0: The total amount of wall time                        = 476.887557
+  0: The maximum resident set size (KB)                   = 760876
+
+Test 083 datm_cdeps_mx025_cfsr PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_mx025_gefs
+Checking test 084 datm_cdeps_mx025_gefs results ....
+Moving baseline 084 datm_cdeps_mx025_gefs files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/MOM.res_1.nc .........OK
+ Moving RESTART/MOM.res_2.nc .........OK
+ Moving RESTART/MOM.res_3.nc .........OK
+ Moving RESTART/iced.2011-10-01-43200.nc .........OK
+ Moving RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
+
+  0: The total amount of wall time                        = 427.917318
+  0: The maximum resident set size (KB)                   = 728092
+
+Test 084 datm_cdeps_mx025_gefs PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_3072x1536_cfsr
+Checking test 085 datm_cdeps_3072x1536_cfsr results ....
+Moving baseline 085 datm_cdeps_3072x1536_cfsr files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-02-00000.nc .........OK
+ Moving RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 271.568032
+ 0: The maximum resident set size (KB)                   = 2111568
+
+Test 085 datm_cdeps_3072x1536_cfsr PASS Tries: 2
+
+Test 086 datm_cdeps_gfs FAIL
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/datm_cdeps_debug_cfsr
+Checking test 087 datm_cdeps_debug_cfsr results ....
+Moving baseline 087 datm_cdeps_debug_cfsr files ....
+ Moving RESTART/MOM.res.nc .........OK
+ Moving RESTART/iced.2011-10-01-21600.nc .........OK
+ Moving RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
+
+ 0: The total amount of wall time                        = 579.953706
+ 0: The maximum resident set size (KB)                   = 889304
+
+Test 087 datm_cdeps_debug_cfsr PASS Tries: 2
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/control_atmwav
+Checking test 088 control_atmwav results ....
+Moving baseline 088 control_atmwav files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf012.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf012.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF12 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF12 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+ Moving 20210322.180000.restart.glo_1deg .........OK
+
+  0: The total amount of wall time                        = 117.790470
+  0: The maximum resident set size (KB)                   = 610884
+
+Test 088 control_atmwav PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/atmaero_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_64214/atmaero_control_p8
+Checking test 089 atmaero_control_p8 results ....
+Moving baseline 089 atmaero_control_p8 files ....
+ Moving sfcf000.nc .........OK
+ Moving sfcf024.nc .........OK
+ Moving atmf000.nc .........OK
+ Moving atmf024.nc .........OK
+ Moving GFSFLX.GrbF00 .........OK
+ Moving GFSFLX.GrbF24 .........OK
+ Moving GFSPRS.GrbF00 .........OK
+ Moving GFSPRS.GrbF24 .........OK
+ Moving gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Moving RESTART/coupler.res .........OK
+ Moving RESTART/fv_core.res.nc .........OK
+ Moving RESTART/fv_core.res.tile1.nc .........OK
+ Moving RESTART/fv_core.res.tile2.nc .........OK
+ Moving RESTART/fv_core.res.tile3.nc .........OK
+ Moving RESTART/fv_core.res.tile4.nc .........OK
+ Moving RESTART/fv_core.res.tile5.nc .........OK
+ Moving RESTART/fv_core.res.tile6.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/phy_data.tile1.nc .........OK
+ Moving RESTART/phy_data.tile2.nc .........OK
+ Moving RESTART/phy_data.tile3.nc .........OK
+ Moving RESTART/phy_data.tile4.nc .........OK
+ Moving RESTART/phy_data.tile5.nc .........OK
+ Moving RESTART/phy_data.tile6.nc .........OK
+ Moving RESTART/sfc_data.tile1.nc .........OK
+ Moving RESTART/sfc_data.tile2.nc .........OK
+ Moving RESTART/sfc_data.tile3.nc .........OK
+ Moving RESTART/sfc_data.tile4.nc .........OK
+ Moving RESTART/sfc_data.tile5.nc .........OK
+ Moving RESTART/sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 434.225982
+  0: The maximum resident set size (KB)                   = 1745196
+
+Test 089 atmaero_control_p8 PASS
+
+FAILED TESTS: 
+Test hafs_regional_datm_cdeps 076 failed in run_test failed 
+Test datm_cdeps_gfs 086 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Mon Jun 13 21:38:47 GMT 2022
+Elapsed time: 01h:51m:43s. Have a nice day!
+
+Tue Jun 14 04:40:42 GMT 2022
+Start Regression test
+
+Compile 001 elapsed time 1562 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 002 elapsed time 283 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/Jong.Kim/RT_BASELINE/Jong.Kim/FV3_RT/REGRESSION_TEST_INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/hfv3gfs/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_23755/hafs_regional_datm_cdeps
+Checking test 001 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1301.603831
-  0: The maximum resident set size (KB)                   = 952800
+  0: The total amount of wall time                        = 1225.175767
+  0: The maximum resident set size (KB)                   = 952380
 
-Test 096 hafs_regional_datm_cdeps PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_control_cfsr
-Checking test 097 datm_cdeps_control_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 206.362058
- 0: The maximum resident set size (KB)                   = 910680
-
-Test 097 datm_cdeps_control_cfsr PASS
+Test 001 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_restart_cfsr
-Checking test 098 datm_cdeps_restart_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 119.555711
- 0: The maximum resident set size (KB)                   = 898204
-
-Test 098 datm_cdeps_restart_cfsr PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_control_gefs
-Checking test 099 datm_cdeps_control_gefs results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 212.776276
- 0: The maximum resident set size (KB)                   = 809700
-
-Test 099 datm_cdeps_control_gefs PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_iau_gefs
-Checking test 100 datm_cdeps_iau_gefs results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 202.700511
- 0: The maximum resident set size (KB)                   = 811544
-
-Test 100 datm_cdeps_iau_gefs PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_stochy_gefs
-Checking test 101 datm_cdeps_stochy_gefs results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 203.981995
- 0: The maximum resident set size (KB)                   = 818944
-
-Test 101 datm_cdeps_stochy_gefs PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_bulk_cfsr
-Checking test 102 datm_cdeps_bulk_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 201.108804
- 0: The maximum resident set size (KB)                   = 912760
-
-Test 102 datm_cdeps_bulk_cfsr PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_bulk_gefs
-Checking test 103 datm_cdeps_bulk_gefs results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 206.269933
- 0: The maximum resident set size (KB)                   = 814516
-
-Test 103 datm_cdeps_bulk_gefs PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_mx025_cfsr
-Checking test 104 datm_cdeps_mx025_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2011-10-01-43200.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
-
-  0: The total amount of wall time                        = 433.456371
-  0: The maximum resident set size (KB)                   = 755412
-
-Test 104 datm_cdeps_mx025_cfsr PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_mx025_gefs
-Checking test 105 datm_cdeps_mx025_gefs results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2011-10-01-43200.nc .........OK
- Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
-
-  0: The total amount of wall time                        = 440.096469
-  0: The maximum resident set size (KB)                   = 729084
-
-Test 105 datm_cdeps_mx025_gefs PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_multiple_files_cfsr
-Checking test 106 datm_cdeps_multiple_files_cfsr results ....
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 196.937288
- 0: The maximum resident set size (KB)                   = 908960
-
-Test 106 datm_cdeps_multiple_files_cfsr PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_3072x1536_cfsr
-Checking test 107 datm_cdeps_3072x1536_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 275.578236
- 0: The maximum resident set size (KB)                   = 2114212
-
-Test 107 datm_cdeps_3072x1536_cfsr PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_gfs
-Checking test 108 datm_cdeps_gfs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/Jong.Kim/RT_BASELINE/Jong.Kim/FV3_RT/REGRESSION_TEST_INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/hfv3gfs/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_23755/datm_cdeps_gfs
+Checking test 002 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 270.741622
- 0: The maximum resident set size (KB)                   = 2121504
+ 0: The total amount of wall time                        = 263.914043
+ 0: The maximum resident set size (KB)                   = 2112828
 
-Test 108 datm_cdeps_gfs PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/datm_cdeps_debug_cfsr
-Checking test 109 datm_cdeps_debug_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-01-21600.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-
- 0: The total amount of wall time                        = 572.305948
- 0: The maximum resident set size (KB)                   = 887780
-
-Test 109 datm_cdeps_debug_cfsr PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/control_atmwav
-Checking test 110 control_atmwav results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing 20210322.180000.restart.glo_1deg .........OK
-
-  0: The total amount of wall time                        = 133.356279
-  0: The maximum resident set size (KB)                   = 611404
-
-Test 110 control_atmwav PASS
-
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/atmaero_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_57995/atmaero_control_p8
-Checking test 111 atmaero_control_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 457.041056
-  0: The maximum resident set size (KB)                   = 1747900
-
-Test 111 atmaero_control_p8 PASS
+Test 002 datm_cdeps_gfs PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 11 05:38:16 GMT 2022
-Elapsed time: 02h:50m:43s. Have a nice day!
+Tue Jun 14 05:39:00 GMT 2022
+Elapsed time: 00h:58m:19s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,26 +1,26 @@
-Fri Jun 10 21:46:56 CDT 2022
+Mon Jun 13 13:47:49 CDT 2022
 Start Regression test
 
-Compile 001 elapsed time 685 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 221 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 423 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 405 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 445 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 402 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 336 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 239 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 168 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 218 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 715 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 534 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 174 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 141 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 496 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 374 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 666 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 220 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 442 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 393 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 392 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 375 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 352 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 199 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 165 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 178 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 164 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 551 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 553 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 191 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 118 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 545 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 355 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 413.797358
-  0: The maximum resident set size (KB)                   = 4997100
+  0: The total amount of wall time                        = 415.675514
+  0: The maximum resident set size (KB)                   = 5003372
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -145,14 +145,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 253.526768
-  0: The maximum resident set size (KB)                   = 4970568
+  0: The total amount of wall time                        = 252.066430
+  0: The maximum resident set size (KB)                   = 4972280
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -205,14 +205,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 559.104584
-  0: The maximum resident set size (KB)                   = 5482600
+  0: The total amount of wall time                        = 508.948449
+  0: The maximum resident set size (KB)                   = 5474940
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_decomp_p8
 Checking test 004 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -265,14 +265,14 @@ Checking test 004 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 404.548342
-  0: The maximum resident set size (KB)                   = 5173756
+  0: The total amount of wall time                        = 407.416008
+  0: The maximum resident set size (KB)                   = 5176856
 
 Test 004 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_mpi_p8
 Checking test 005 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 338.968279
-  0: The maximum resident set size (KB)                   = 4737100
+  0: The total amount of wall time                        = 342.569986
+  0: The maximum resident set size (KB)                   = 4735076
 
 Test 005 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_control_c192_p8
 Checking test 006 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -385,14 +385,14 @@ Checking test 006 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 801.256193
-  0: The maximum resident set size (KB)                   = 4801400
+  0: The total amount of wall time                        = 789.105561
+  0: The maximum resident set size (KB)                   = 4860316
 
 Test 006 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_restart_c192_p8
 Checking test 007 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -445,14 +445,14 @@ Checking test 007 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 610.751821
-  0: The maximum resident set size (KB)                   = 4832124
+  0: The total amount of wall time                        = 625.603451
+  0: The maximum resident set size (KB)                   = 4883456
 
 Test 007 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_bmark_p8
 Checking test 008 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -498,14 +498,14 @@ Checking test 008 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1320.086820
-  0: The maximum resident set size (KB)                   = 5659640
+  0: The total amount of wall time                        = 1424.041167
+  0: The maximum resident set size (KB)                   = 5595952
 
 Test 008 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_restart_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_restart_bmark_p8
 Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -551,14 +551,14 @@ Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 804.053059
-  0: The maximum resident set size (KB)                   = 5611224
+  0: The total amount of wall time                        = 838.003083
+  0: The maximum resident set size (KB)                   = 5558448
 
 Test 009 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -611,14 +611,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 816.763227
-  0: The maximum resident set size (KB)                   = 5072204
+  0: The total amount of wall time                        = 812.672246
+  0: The maximum resident set size (KB)                   = 5074312
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/cpld_control_noaero_p8_agrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_control_noaero_p8_agrid
 Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -680,14 +680,14 @@ Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 296.397741
-  0: The maximum resident set size (KB)                   = 1181308
+  0: The total amount of wall time                        = 287.500527
+  0: The maximum resident set size (KB)                   = 1256492
 
 Test 011 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control
 Checking test 012 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -734,14 +734,14 @@ Checking test 012 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.611247
-  0: The maximum resident set size (KB)                   = 639996
+  0: The total amount of wall time                        = 126.901613
+  0: The maximum resident set size (KB)                   = 637712
 
 Test 012 control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_decomp
 Checking test 013 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 013 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.788115
-  0: The maximum resident set size (KB)                   = 629968
+  0: The total amount of wall time                        = 133.974460
+  0: The maximum resident set size (KB)                   = 631128
 
 Test 013 control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2dwrtdecomp
 Checking test 014 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -802,14 +802,14 @@ Checking test 014 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.333590
-  0: The maximum resident set size (KB)                   = 640512
+  0: The total amount of wall time                        = 126.169726
+  0: The maximum resident set size (KB)                   = 598916
 
 Test 014 control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2threads
 Checking test 015 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -852,14 +852,14 @@ Checking test 015 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 153.316671
- 0: The maximum resident set size (KB)                   = 691360
+ 0: The total amount of wall time                        = 151.883648
+ 0: The maximum resident set size (KB)                   = 689372
 
 Test 015 control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_restart
 Checking test 016 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -898,14 +898,14 @@ Checking test 016 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 71.570054
-  0: The maximum resident set size (KB)                   = 455688
+  0: The total amount of wall time                        = 69.256566
+  0: The maximum resident set size (KB)                   = 462916
 
 Test 016 control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_fhzero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_fhzero
 Checking test 017 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -948,14 +948,14 @@ Checking test 017 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.391656
-  0: The maximum resident set size (KB)                   = 632848
+  0: The total amount of wall time                        = 120.097401
+  0: The maximum resident set size (KB)                   = 636436
 
 Test 017 control_fhzero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -982,14 +982,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 123.309183
-  0: The maximum resident set size (KB)                   = 644172
+  0: The total amount of wall time                        = 124.436440
+  0: The maximum resident set size (KB)                   = 641920
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1000,32 +1000,32 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 125.662742
-  0: The maximum resident set size (KB)                   = 647100
+  0: The total amount of wall time                        = 126.535898
+  0: The maximum resident set size (KB)                   = 630624
 
 Test 019 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.516721
-  0: The maximum resident set size (KB)                   = 643572
+  0: The total amount of wall time                        = 128.346700
+  0: The maximum resident set size (KB)                   = 640356
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1064,14 +1064,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 329.789338
-0: The maximum resident set size (KB)                   = 802768
+0: The total amount of wall time                        = 328.931599
+0: The maximum resident set size (KB)                   = 819328
 
 Test 021 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 488.831924
-  0: The maximum resident set size (KB)                   = 796832
+  0: The total amount of wall time                        = 491.495372
+  0: The maximum resident set size (KB)                   = 800344
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1100,14 +1100,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 670.969654
-  0: The maximum resident set size (KB)                   = 1081104
+  0: The total amount of wall time                        = 671.263270
+  0: The maximum resident set size (KB)                   = 1075696
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 587.119480
-  0: The maximum resident set size (KB)                   = 1244304
+  0: The total amount of wall time                        = 1546.113993
+  0: The maximum resident set size (KB)                   = 1182908
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384_progsigma
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_c384_progsigma
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c384_progsigma
 Checking test 025 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 025 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 682.843299
-  0: The maximum resident set size (KB)                   = 1076732
+  0: The total amount of wall time                        = 686.803859
+  0: The maximum resident set size (KB)                   = 1080356
 
 Test 025 control_c384_progsigma PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1186,28 +1186,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.901705
-  0: The maximum resident set size (KB)                   = 644428
+  0: The total amount of wall time                        = 81.851254
+  0: The maximum resident set size (KB)                   = 646392
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 47.989108
-  0: The maximum resident set size (KB)                   = 478220
+  0: The total amount of wall time                        = 47.808452
+  0: The maximum resident set size (KB)                   = 477316
 
-Test 027 control_stochy_restart PASS
+Test 027 control_stochy_restart PASS Tries: 2
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.856572
-  0: The maximum resident set size (KB)                   = 639456
+  0: The total amount of wall time                        = 75.616442
+  0: The maximum resident set size (KB)                   = 640060
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.353778
-  0: The maximum resident set size (KB)                   = 590464
+  0: The total amount of wall time                        = 126.385651
+  0: The maximum resident set size (KB)                   = 634708
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.677160
-  0: The maximum resident set size (KB)                   = 635784
+  0: The total amount of wall time                        = 126.888447
+  0: The maximum resident set size (KB)                   = 636220
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1316,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.503429
-  0: The maximum resident set size (KB)                   = 1030692
+  0: The total amount of wall time                        = 167.922293
+  0: The maximum resident set size (KB)                   = 1033156
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_p8_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 320.034619
-  0: The maximum resident set size (KB)                   = 1031880
+  0: The total amount of wall time                        = 319.099425
+  0: The maximum resident set size (KB)                   = 1026336
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1388,14 +1388,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.129798
-  0: The maximum resident set size (KB)                   = 811940
+  0: The total amount of wall time                        = 92.267141
+  0: The maximum resident set size (KB)                   = 869272
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1438,14 +1438,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.480284
-  0: The maximum resident set size (KB)                   = 1017452
+  0: The total amount of wall time                        = 176.415247
+  0: The maximum resident set size (KB)                   = 979960
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 201.773629
- 0: The maximum resident set size (KB)                   = 1109940
+ 0: The total amount of wall time                        = 199.899183
+ 0: The maximum resident set size (KB)                   = 1084728
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_p8_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1542,14 +1542,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.221992
-  0: The maximum resident set size (KB)                   = 1156000
+  0: The total amount of wall time                        = 196.300078
+  0: The maximum resident set size (KB)                   = 1153864
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1560,28 +1560,28 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 333.604706
- 0: The maximum resident set size (KB)                   = 817208
+ 0: The total amount of wall time                        = 334.554595
+ 0: The maximum resident set size (KB)                   = 827388
 
 Test 037 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 186.647428
- 0: The maximum resident set size (KB)                   = 819680
+ 0: The total amount of wall time                        = 188.528201
+ 0: The maximum resident set size (KB)                   = 820688
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 334.733849
- 0: The maximum resident set size (KB)                   = 822680
+ 0: The total amount of wall time                        = 333.755811
+ 0: The maximum resident set size (KB)                   = 828408
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 334.179926
- 0: The maximum resident set size (KB)                   = 806620
+ 0: The total amount of wall time                        = 332.381995
+ 0: The maximum resident set size (KB)                   = 792736
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,28 +1625,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 276.863134
- 0: The maximum resident set size (KB)                   = 824496
+ 0: The total amount of wall time                        = 230.662397
+ 0: The maximum resident set size (KB)                   = 825260
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 332.666687
- 0: The maximum resident set size (KB)                   = 826904
+ 0: The total amount of wall time                        = 331.097930
+ 0: The maximum resident set size (KB)                   = 820048
 
 Test 042 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_3km
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_3km
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 255.795912
-  0: The maximum resident set size (KB)                   = 882016
+  0: The total amount of wall time                        = 254.300695
+  0: The maximum resident set size (KB)                   = 880508
 
 Test 043 regional_3km PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1711,14 +1711,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 436.690172
-  0: The maximum resident set size (KB)                   = 979976
+  0: The total amount of wall time                        = 439.380284
+  0: The maximum resident set size (KB)                   = 1038308
 
 Test 044 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1765,14 +1765,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.712432
-  0: The maximum resident set size (KB)                   = 1190076
+  0: The total amount of wall time                        = 466.875699
+  0: The maximum resident set size (KB)                   = 1190968
 
 Test 045 rap_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_spp_sppt_shum_skeb
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1783,14 +1783,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 312.990241
-  0: The maximum resident set size (KB)                   = 1201292
+  0: The total amount of wall time                        = 299.035776
+  0: The maximum resident set size (KB)                   = 1206624
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1837,14 +1837,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 499.964705
- 0: The maximum resident set size (KB)                   = 1089788
+ 0: The total amount of wall time                        = 500.139544
+ 0: The maximum resident set size (KB)                   = 1086548
 
 Test 047 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1883,14 +1883,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.064146
-  0: The maximum resident set size (KB)                   = 927580
+  0: The total amount of wall time                        = 225.457485
+  0: The maximum resident set size (KB)                   = 932648
 
 Test 048 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1937,14 +1937,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 437.567832
-  0: The maximum resident set size (KB)                   = 1029148
+  0: The total amount of wall time                        = 439.576355
+  0: The maximum resident set size (KB)                   = 992376
 
 Test 049 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1983,14 +1983,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.986691
-  0: The maximum resident set size (KB)                   = 925916
+  0: The total amount of wall time                        = 224.610581
+  0: The maximum resident set size (KB)                   = 955132
 
 Test 050 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 417.989565
-  0: The maximum resident set size (KB)                   = 1033416
+  0: The total amount of wall time                        = 422.116468
+  0: The maximum resident set size (KB)                   = 992108
 
 Test 051 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 426.067024
-  0: The maximum resident set size (KB)                   = 1031200
+  0: The total amount of wall time                        = 427.076783
+  0: The maximum resident set size (KB)                   = 1025660
 
-Test 052 rrfs_v1beta PASS
+Test 052 rrfs_v1beta PASS Tries: 2
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_v1nssl
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2113,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 503.697120
-  0: The maximum resident set size (KB)                   = 696084
+  0: The total amount of wall time                        = 504.100246
+  0: The maximum resident set size (KB)                   = 700748
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_v1nssl_nohailnoccn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2135,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 491.229132
-  0: The maximum resident set size (KB)                   = 723588
+  0: The total amount of wall time                        = 491.319925
+  0: The maximum resident set size (KB)                   = 721812
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2151,14 +2151,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 187.354015
-  0: The maximum resident set size (KB)                   = 874964
+  0: The total amount of wall time                        = 189.652120
+  0: The maximum resident set size (KB)                   = 925620
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 188.109670
-  0: The maximum resident set size (KB)                   = 923280
+  0: The total amount of wall time                        = 192.037959
+  0: The maximum resident set size (KB)                   = 927608
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2183,14 +2183,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 210.846697
-  0: The maximum resident set size (KB)                   = 951244
+  0: The total amount of wall time                        = 211.406905
+  0: The maximum resident set size (KB)                   = 945308
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 346.381050
-  0: The maximum resident set size (KB)                   = 695540
+  0: The total amount of wall time                        = 330.002385
+  0: The maximum resident set size (KB)                   = 753164
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 325.752486
-  0: The maximum resident set size (KB)                   = 755612
+  0: The total amount of wall time                        = 325.350514
+  0: The maximum resident set size (KB)                   = 752916
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_flake
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2237,14 +2237,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 213.701486
-  0: The maximum resident set size (KB)                   = 758880
+  0: The total amount of wall time                        = 211.730661
+  0: The maximum resident set size (KB)                   = 762576
 
 Test 060 control_flake PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2255,14 +2255,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 170.895444
-  0: The maximum resident set size (KB)                   = 719820
+  0: The total amount of wall time                        = 171.281074
+  0: The maximum resident set size (KB)                   = 719144
 
 Test 061 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2273,14 +2273,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 235.075667
-  0: The maximum resident set size (KB)                   = 1077644
+  0: The total amount of wall time                        = 234.104697
+  0: The maximum resident set size (KB)                   = 1080816
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_thompson_no_aero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2291,54 +2291,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 221.159503
-  0: The maximum resident set size (KB)                   = 1060972
+  0: The total amount of wall time                        = 220.240576
+  0: The maximum resident set size (KB)                   = 1061764
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_wam
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 103.473198
-  0: The maximum resident set size (KB)                   = 619564
+  0: The total amount of wall time                        = 105.031252
+  0: The maximum resident set size (KB)                   = 616184
 
 Test 064 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.591266
-  0: The maximum resident set size (KB)                   = 804940
+  0: The total amount of wall time                        = 152.991077
+  0: The maximum resident set size (KB)                   = 804480
 
 Test 065 control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_2threads_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 229.273512
- 0: The maximum resident set size (KB)                   = 865568
+ 0: The total amount of wall time                        = 229.124299
+ 0: The maximum resident set size (KB)                   = 863372
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2365,415 +2365,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.013954
-  0: The maximum resident set size (KB)                   = 804636
+  0: The total amount of wall time                        = 170.132741
+  0: The maximum resident set size (KB)                   = 805320
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 155.174691
-  0: The maximum resident set size (KB)                   = 807764
+  0: The total amount of wall time                        = 154.266701
+  0: The maximum resident set size (KB)                   = 804392
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.319247
-  0: The maximum resident set size (KB)                   = 810712
+  0: The total amount of wall time                        = 172.825744
+  0: The maximum resident set size (KB)                   = 817876
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.134305
-  0: The maximum resident set size (KB)                   = 809476
+  0: The total amount of wall time                        = 157.798746
+  0: The maximum resident set size (KB)                   = 813364
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.040593
-  0: The maximum resident set size (KB)                   = 853620
+  0: The total amount of wall time                        = 230.809006
+  0: The maximum resident set size (KB)                   = 855416
 
 Test 071 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 236.129805
-  0: The maximum resident set size (KB)                   = 861640
+  0: The total amount of wall time                        = 236.974656
+  0: The maximum resident set size (KB)                   = 855676
 
 Test 072 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.533003
-  0: The maximum resident set size (KB)                   = 819204
+  0: The total amount of wall time                        = 159.990333
+  0: The maximum resident set size (KB)                   = 819104
 
 Test 073 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.480983
-  0: The maximum resident set size (KB)                   = 862108
+  0: The total amount of wall time                        = 167.868800
+  0: The maximum resident set size (KB)                   = 861248
 
 Test 074 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.829167
-  0: The maximum resident set size (KB)                   = 1198264
+  0: The total amount of wall time                        = 173.031220
+  0: The maximum resident set size (KB)                   = 1182556
 
 Test 075 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.379193
-  0: The maximum resident set size (KB)                   = 1179264
+  0: The total amount of wall time                        = 181.916234
+  0: The maximum resident set size (KB)                   = 1177216
 
 Test 076 control_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_thompson_no_aero_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.080798
-  0: The maximum resident set size (KB)                   = 1169620
+  0: The total amount of wall time                        = 176.880560
+  0: The maximum resident set size (KB)                   = 1167324
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_thompson_extdiag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.804710
-  0: The maximum resident set size (KB)                   = 1208680
+  0: The total amount of wall time                        = 189.529736
+  0: The maximum resident set size (KB)                   = 1209732
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_thompson_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 182.675270
-  0: The maximum resident set size (KB)                   = 1181272
+  0: The total amount of wall time                        = 178.246501
+  0: The maximum resident set size (KB)                   = 1175364
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 250.423085
- 0: The maximum resident set size (KB)                   = 831516
+ 0: The total amount of wall time                        = 251.175384
+ 0: The maximum resident set size (KB)                   = 848792
 
 Test 080 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.526393
-  0: The maximum resident set size (KB)                   = 1181976
+  0: The total amount of wall time                        = 285.429063
+  0: The maximum resident set size (KB)                   = 1179792
 
 Test 081 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.958864
-  0: The maximum resident set size (KB)                   = 1129116
+  0: The total amount of wall time                        = 272.243479
+  0: The maximum resident set size (KB)                   = 1182972
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.920297
-  0: The maximum resident set size (KB)                   = 1268116
+  0: The total amount of wall time                        = 290.057364
+  0: The maximum resident set size (KB)                   = 1263756
 
 Test 083 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.153950
-  0: The maximum resident set size (KB)                   = 1181016
+  0: The total amount of wall time                        = 289.286730
+  0: The maximum resident set size (KB)                   = 1138076
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.200498
-  0: The maximum resident set size (KB)                   = 1185944
+  0: The total amount of wall time                        = 279.951539
+  0: The maximum resident set size (KB)                   = 1183036
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.115933
-  0: The maximum resident set size (KB)                   = 1189408
+  0: The total amount of wall time                        = 286.284182
+  0: The maximum resident set size (KB)                   = 1151420
 
 Test 086 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.583584
-  0: The maximum resident set size (KB)                   = 1186780
+  0: The total amount of wall time                        = 275.598548
+  0: The maximum resident set size (KB)                   = 1183324
 
 Test 087 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.238222
-  0: The maximum resident set size (KB)                   = 1183740
+  0: The total amount of wall time                        = 269.942733
+  0: The maximum resident set size (KB)                   = 1186940
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.352472
-  0: The maximum resident set size (KB)                   = 1184204
+  0: The total amount of wall time                        = 270.478295
+  0: The maximum resident set size (KB)                   = 1168464
 
 Test 089 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 463.502492
-  0: The maximum resident set size (KB)                   = 1269820
+  0: The total amount of wall time                        = 459.579364
+  0: The maximum resident set size (KB)                   = 1312520
 
 Test 090 rap_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.414988
-  0: The maximum resident set size (KB)                   = 1146172
+  0: The total amount of wall time                        = 280.040268
+  0: The maximum resident set size (KB)                   = 1179356
 
 Test 091 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 447.957998
-  0: The maximum resident set size (KB)                   = 1185144
+  0: The total amount of wall time                        = 452.971123
+  0: The maximum resident set size (KB)                   = 1184536
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.624552
-  0: The maximum resident set size (KB)                   = 1171676
+  0: The total amount of wall time                        = 273.317375
+  0: The maximum resident set size (KB)                   = 1173888
 
 Test 093 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 283.764128
-  0: The maximum resident set size (KB)                   = 511832
+  0: The total amount of wall time                        = 285.084779
+  0: The maximum resident set size (KB)                   = 534288
 
 Test 094 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 309.991025
-  0: The maximum resident set size (KB)                   = 939464
+  0: The total amount of wall time                        = 311.327371
+  0: The maximum resident set size (KB)                   = 979456
 
 Test 095 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 420.488487
-  0: The maximum resident set size (KB)                   = 1352264
+  0: The total amount of wall time                        = 430.733937
+  0: The maximum resident set size (KB)                   = 1336472
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2782,14 +2782,14 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 397.425540
-  0: The maximum resident set size (KB)                   = 1200380
+  0: The total amount of wall time                        = 401.969037
+  0: The maximum resident set size (KB)                   = 1165452
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 098 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 743.865834
-  0: The maximum resident set size (KB)                   = 1234016
+  0: The total amount of wall time                        = 743.772169
+  0: The maximum resident set size (KB)                   = 1201788
 
 Test 098 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2816,28 +2816,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 845.640693
-  0: The maximum resident set size (KB)                   = 1197432
+  0: The total amount of wall time                        = 839.403659
+  0: The maximum resident set size (KB)                   = 1196680
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 447.471391
-  0: The maximum resident set size (KB)                   = 582764
+  0: The total amount of wall time                        = 441.729782
+  0: The maximum resident set size (KB)                   = 573904
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2846,28 +2846,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 509.915652
-  0: The maximum resident set size (KB)                   = 583020
+  0: The total amount of wall time                        = 496.539078
+  0: The maximum resident set size (KB)                   = 585868
 
-Test 101 hafs_regional_telescopic_2nests_atm PASS
+Test 101 hafs_regional_telescopic_2nests_atm PASS Tries: 2
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 205.188472
-  0: The maximum resident set size (KB)                   = 373972
+  0: The total amount of wall time                        = 206.819278
+  0: The maximum resident set size (KB)                   = 377572
 
 Test 102 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2880,42 +2880,42 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 570.040211
-  0: The maximum resident set size (KB)                   = 410584
+  0: The total amount of wall time                        = 574.623999
+  0: The maximum resident set size (KB)                   = 414684
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_specified_moving_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 270.510558
-  0: The maximum resident set size (KB)                   = 585532
+  0: The total amount of wall time                        = 267.476270
+  0: The maximum resident set size (KB)                   = 577056
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 261.560202
-  0: The maximum resident set size (KB)                   = 577444
+  0: The total amount of wall time                        = 258.715150
+  0: The maximum resident set size (KB)                   = 581140
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2924,14 +2924,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 269.301920
-  0: The maximum resident set size (KB)                   = 617672
+  0: The total amount of wall time                        = 266.353014
+  0: The maximum resident set size (KB)                   = 619720
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2942,28 +2942,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 617.497555
-  0: The maximum resident set size (KB)                   = 592644
+  0: The total amount of wall time                        = 616.789463
+  0: The maximum resident set size (KB)                   = 595536
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_global_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 80.156559
-  0: The maximum resident set size (KB)                   = 396488
+  0: The total amount of wall time                        = 79.363142
+  0: The maximum resident set size (KB)                   = 392644
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2971,14 +2971,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 396.605690
-  0: The maximum resident set size (KB)                   = 1213964
+  0: The total amount of wall time                        = 400.673706
+  0: The maximum resident set size (KB)                   = 1211648
 
 Test 109 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2986,118 +2986,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 398.824948
-  0: The maximum resident set size (KB)                   = 1157688
+  0: The total amount of wall time                        = 398.542140
+  0: The maximum resident set size (KB)                   = 1203100
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 918.505349
-  0: The maximum resident set size (KB)                   = 1014456
+  0: The total amount of wall time                        = 927.520689
+  0: The maximum resident set size (KB)                   = 1018076
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.798547
- 0: The maximum resident set size (KB)                   = 1031948
+ 0: The total amount of wall time                        = 142.386555
+ 0: The maximum resident set size (KB)                   = 1018704
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 100.969684
- 0: The maximum resident set size (KB)                   = 994644
+ 0: The total amount of wall time                        = 103.478334
+ 0: The maximum resident set size (KB)                   = 991648
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.740406
- 0: The maximum resident set size (KB)                   = 936268
+ 0: The total amount of wall time                        = 142.281946
+ 0: The maximum resident set size (KB)                   = 939796
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_iau_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.297003
- 0: The maximum resident set size (KB)                   = 927708
+ 0: The total amount of wall time                        = 143.357635
+ 0: The maximum resident set size (KB)                   = 938328
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.639457
- 0: The maximum resident set size (KB)                   = 920640
+ 0: The total amount of wall time                        = 141.940026
+ 0: The maximum resident set size (KB)                   = 934636
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.508417
- 0: The maximum resident set size (KB)                   = 1027584
+ 0: The total amount of wall time                        = 145.702656
+ 0: The maximum resident set size (KB)                   = 1023984
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.464935
- 0: The maximum resident set size (KB)                   = 928200
+ 0: The total amount of wall time                        = 139.585937
+ 0: The maximum resident set size (KB)                   = 928504
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3106,14 +3106,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 298.378537
-  0: The maximum resident set size (KB)                   = 861772
+  0: The total amount of wall time                        = 299.645512
+  0: The maximum resident set size (KB)                   = 853660
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3122,64 +3122,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 296.633055
-  0: The maximum resident set size (KB)                   = 881492
+  0: The total amount of wall time                        = 296.408375
+  0: The maximum resident set size (KB)                   = 883404
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.692668
- 0: The maximum resident set size (KB)                   = 1018964
+ 0: The total amount of wall time                        = 142.003100
+ 0: The maximum resident set size (KB)                   = 1047856
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.295254
- 0: The maximum resident set size (KB)                   = 2245428
+ 0: The total amount of wall time                        = 196.265531
+ 0: The maximum resident set size (KB)                   = 2210924
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_gfs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_gfs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 192.258458
- 0: The maximum resident set size (KB)                   = 2245424
+ 0: The total amount of wall time                        = 194.215730
+ 0: The maximum resident set size (KB)                   = 2251844
 
 Test 123 datm_cdeps_gfs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 451.722011
- 0: The maximum resident set size (KB)                   = 995028
+ 0: The total amount of wall time                        = 441.893327
+ 0: The maximum resident set size (KB)                   = 976820
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3223,14 +3223,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 81.016332
-  0: The maximum resident set size (KB)                   = 709804
+  0: The total amount of wall time                        = 81.246020
+  0: The maximum resident set size (KB)                   = 702148
 
 Test 125 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/INTEL/atmaero_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_424969/atmaero_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/atmaero_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/atmaero_control_p8
 Checking test 126 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3274,12 +3274,12 @@ Checking test 126 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 324.249307
-  0: The maximum resident set size (KB)                   = 5093192
+  0: The total amount of wall time                        = 322.742853
+  0: The maximum resident set size (KB)                   = 5106688
 
 Test 126 atmaero_control_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 10 22:53:52 CDT 2022
-Elapsed time: 01h:06m:57s. Have a nice day!
+Mon Jun 13 14:54:37 CDT 2022
+Elapsed time: 01h:06m:49s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,26 +1,26 @@
-Mon Jun 13 13:47:49 CDT 2022
+Mon Jun 13 16:16:56 CDT 2022
 Start Regression test
 
-Compile 001 elapsed time 666 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 220 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 442 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 393 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 392 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 375 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 352 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 199 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 165 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 178 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 164 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 635 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 211 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 449 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 451 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 407 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 415 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 351 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 208 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 171 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 171 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 167 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 012 elapsed time 551 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 553 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 191 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 118 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 545 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 355 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 586 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 207 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 122 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 538 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 399 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 415.675514
-  0: The maximum resident set size (KB)                   = 5003372
+  0: The total amount of wall time                        = 407.423865
+  0: The maximum resident set size (KB)                   = 5010100
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_restart_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -145,14 +145,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 252.066430
-  0: The maximum resident set size (KB)                   = 4972280
+  0: The total amount of wall time                        = 255.013152
+  0: The maximum resident set size (KB)                   = 4955196
 
 Test 002 cpld_restart_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_2threads_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -205,14 +205,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 508.948449
-  0: The maximum resident set size (KB)                   = 5474940
+  0: The total amount of wall time                        = 506.192668
+  0: The maximum resident set size (KB)                   = 5465416
 
 Test 003 cpld_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_decomp_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_decomp_p8
 Checking test 004 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -265,14 +265,14 @@ Checking test 004 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 407.416008
-  0: The maximum resident set size (KB)                   = 5176856
+  0: The total amount of wall time                        = 409.497168
+  0: The maximum resident set size (KB)                   = 5173020
 
 Test 004 cpld_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_mpi_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_mpi_p8
 Checking test 005 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 342.569986
-  0: The maximum resident set size (KB)                   = 4735076
+  0: The total amount of wall time                        = 337.831075
+  0: The maximum resident set size (KB)                   = 4743140
 
 Test 005 cpld_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_control_c192_p8
 Checking test 006 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -385,14 +385,14 @@ Checking test 006 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 789.105561
-  0: The maximum resident set size (KB)                   = 4860316
+  0: The total amount of wall time                        = 796.611253
+  0: The maximum resident set size (KB)                   = 4847620
 
 Test 006 cpld_control_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_restart_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_restart_c192_p8
 Checking test 007 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -445,14 +445,14 @@ Checking test 007 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 625.603451
-  0: The maximum resident set size (KB)                   = 4883456
+  0: The total amount of wall time                        = 614.669701
+  0: The maximum resident set size (KB)                   = 4914856
 
 Test 007 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_bmark_p8
 Checking test 008 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -498,14 +498,14 @@ Checking test 008 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1424.041167
-  0: The maximum resident set size (KB)                   = 5595952
+  0: The total amount of wall time                        = 1330.669166
+  0: The maximum resident set size (KB)                   = 5641388
 
 Test 008 cpld_bmark_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_restart_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_restart_bmark_p8
 Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -551,14 +551,14 @@ Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 838.003083
-  0: The maximum resident set size (KB)                   = 5558448
+  0: The total amount of wall time                        = 836.735886
+  0: The maximum resident set size (KB)                   = 5609556
 
 Test 009 cpld_restart_bmark_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -611,14 +611,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 812.672246
-  0: The maximum resident set size (KB)                   = 5074312
+  0: The total amount of wall time                        = 844.195816
+  0: The maximum resident set size (KB)                   = 5053428
 
 Test 010 cpld_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/cpld_control_noaero_p8_agrid
 Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -680,14 +680,14 @@ Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 287.500527
-  0: The maximum resident set size (KB)                   = 1256492
+  0: The total amount of wall time                        = 287.982691
+  0: The maximum resident set size (KB)                   = 1254232
 
 Test 011 cpld_control_noaero_p8_agrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control
 Checking test 012 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -734,14 +734,14 @@ Checking test 012 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.901613
-  0: The maximum resident set size (KB)                   = 637712
+  0: The total amount of wall time                        = 127.209521
+  0: The maximum resident set size (KB)                   = 636980
 
 Test 012 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_decomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_decomp
 Checking test 013 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 013 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.974460
-  0: The maximum resident set size (KB)                   = 631128
+  0: The total amount of wall time                        = 134.652601
+  0: The maximum resident set size (KB)                   = 631928
 
 Test 013 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2dwrtdecomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_2dwrtdecomp
 Checking test 014 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -802,14 +802,14 @@ Checking test 014 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.169726
-  0: The maximum resident set size (KB)                   = 598916
+  0: The total amount of wall time                        = 127.813171
+  0: The maximum resident set size (KB)                   = 641412
 
 Test 014 control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_2threads
 Checking test 015 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -852,14 +852,14 @@ Checking test 015 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 151.883648
- 0: The maximum resident set size (KB)                   = 689372
+ 0: The total amount of wall time                        = 150.243133
+ 0: The maximum resident set size (KB)                   = 692164
 
 Test 015 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_restart
 Checking test 016 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -898,14 +898,14 @@ Checking test 016 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 69.256566
-  0: The maximum resident set size (KB)                   = 462916
+  0: The total amount of wall time                        = 68.666132
+  0: The maximum resident set size (KB)                   = 458200
 
 Test 016 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_fhzero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_fhzero
 Checking test 017 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -948,14 +948,14 @@ Checking test 017 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.097401
-  0: The maximum resident set size (KB)                   = 636436
+  0: The total amount of wall time                        = 120.254397
+  0: The maximum resident set size (KB)                   = 635268
 
 Test 017 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -982,14 +982,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 124.436440
-  0: The maximum resident set size (KB)                   = 641920
+  0: The total amount of wall time                        = 123.089794
+  0: The maximum resident set size (KB)                   = 641888
 
-Test 018 control_CubedSphereGrid PASS
+Test 018 control_CubedSphereGrid PASS Tries: 2
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1000,14 +1000,14 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.535898
-  0: The maximum resident set size (KB)                   = 630624
+  0: The total amount of wall time                        = 126.537921
+  0: The maximum resident set size (KB)                   = 645836
 
 Test 019 control_latlon PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1018,14 +1018,14 @@ Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.346700
-  0: The maximum resident set size (KB)                   = 640356
+  0: The total amount of wall time                        = 127.734142
+  0: The maximum resident set size (KB)                   = 643320
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1064,14 +1064,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 328.931599
-0: The maximum resident set size (KB)                   = 819328
+0: The total amount of wall time                        = 330.914300
+0: The maximum resident set size (KB)                   = 815272
 
 Test 021 control_c48 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 491.495372
-  0: The maximum resident set size (KB)                   = 800344
+  0: The total amount of wall time                        = 488.296281
+  0: The maximum resident set size (KB)                   = 805628
 
 Test 022 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1100,14 +1100,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 671.263270
-  0: The maximum resident set size (KB)                   = 1075696
+  0: The total amount of wall time                        = 680.835588
+  0: The maximum resident set size (KB)                   = 1029128
 
 Test 023 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1546.113993
-  0: The maximum resident set size (KB)                   = 1182908
+  0: The total amount of wall time                        = 1546.715981
+  0: The maximum resident set size (KB)                   = 1240024
 
 Test 024 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_c384_progsigma
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_c384_progsigma
 Checking test 025 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 025 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 686.803859
-  0: The maximum resident set size (KB)                   = 1080356
+  0: The total amount of wall time                        = 686.147661
+  0: The maximum resident set size (KB)                   = 1076380
 
 Test 025 control_c384_progsigma PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1186,28 +1186,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.851254
-  0: The maximum resident set size (KB)                   = 646392
+  0: The total amount of wall time                        = 82.145952
+  0: The maximum resident set size (KB)                   = 638616
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_stochy_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 47.808452
-  0: The maximum resident set size (KB)                   = 477316
+  0: The total amount of wall time                        = 47.110939
+  0: The maximum resident set size (KB)                   = 429404
 
-Test 027 control_stochy_restart PASS Tries: 2
+Test 027 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.616442
-  0: The maximum resident set size (KB)                   = 640060
+  0: The total amount of wall time                        = 75.783631
+  0: The maximum resident set size (KB)                   = 637836
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.385651
-  0: The maximum resident set size (KB)                   = 634708
+  0: The total amount of wall time                        = 126.856763
+  0: The maximum resident set size (KB)                   = 605044
 
 Test 029 control_iovr4 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.888447
-  0: The maximum resident set size (KB)                   = 636220
+  0: The total amount of wall time                        = 126.541774
+  0: The maximum resident set size (KB)                   = 640436
 
 Test 030 control_iovr5 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1316,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.922293
-  0: The maximum resident set size (KB)                   = 1033156
+  0: The total amount of wall time                        = 169.565289
+  0: The maximum resident set size (KB)                   = 1021164
 
 Test 031 control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_p8_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 319.099425
-  0: The maximum resident set size (KB)                   = 1026336
+  0: The total amount of wall time                        = 319.503590
+  0: The maximum resident set size (KB)                   = 1024880
 
 Test 032 control_p8_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_restart_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1388,14 +1388,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.267141
-  0: The maximum resident set size (KB)                   = 869272
+  0: The total amount of wall time                        = 94.194518
+  0: The maximum resident set size (KB)                   = 863120
 
 Test 033 control_restart_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_decomp_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1438,14 +1438,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.415247
-  0: The maximum resident set size (KB)                   = 979960
+  0: The total amount of wall time                        = 175.854906
+  0: The maximum resident set size (KB)                   = 1015516
 
 Test 034 control_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2threads_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 199.899183
- 0: The maximum resident set size (KB)                   = 1084728
+ 0: The total amount of wall time                        = 196.818497
+ 0: The maximum resident set size (KB)                   = 1103548
 
 Test 035 control_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_p8_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1542,14 +1542,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.300078
-  0: The maximum resident set size (KB)                   = 1153864
+  0: The total amount of wall time                        = 197.304950
+  0: The maximum resident set size (KB)                   = 1159864
 
 Test 036 control_p8_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1560,28 +1560,28 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 334.554595
- 0: The maximum resident set size (KB)                   = 827388
+ 0: The total amount of wall time                        = 333.133502
+ 0: The maximum resident set size (KB)                   = 826568
 
 Test 037 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 188.528201
- 0: The maximum resident set size (KB)                   = 820688
+ 0: The total amount of wall time                        = 189.779184
+ 0: The maximum resident set size (KB)                   = 820928
 
 Test 038 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_control_2dwrtdecomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 333.755811
- 0: The maximum resident set size (KB)                   = 828408
+ 0: The total amount of wall time                        = 333.940233
+ 0: The maximum resident set size (KB)                   = 827804
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 332.381995
- 0: The maximum resident set size (KB)                   = 792736
+ 0: The total amount of wall time                        = 332.538824
+ 0: The maximum resident set size (KB)                   = 799068
 
 Test 040 regional_noquilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,28 +1625,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 230.662397
- 0: The maximum resident set size (KB)                   = 825260
+ 0: The total amount of wall time                        = 231.452374
+ 0: The maximum resident set size (KB)                   = 827412
 
 Test 041 regional_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 331.097930
- 0: The maximum resident set size (KB)                   = 820048
+ 0: The total amount of wall time                        = 333.233389
+ 0: The maximum resident set size (KB)                   = 814592
 
 Test 042 regional_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_3km
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 254.300695
-  0: The maximum resident set size (KB)                   = 880508
+  0: The total amount of wall time                        = 255.360352
+  0: The maximum resident set size (KB)                   = 880816
 
 Test 043 regional_3km PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1711,14 +1711,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.380284
-  0: The maximum resident set size (KB)                   = 1038308
+  0: The total amount of wall time                        = 438.106552
+  0: The maximum resident set size (KB)                   = 1041792
 
 Test 044 rap_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1765,14 +1765,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 466.875699
-  0: The maximum resident set size (KB)                   = 1190968
+  0: The total amount of wall time                        = 468.797926
+  0: The maximum resident set size (KB)                   = 1190436
 
 Test 045 rap_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1783,14 +1783,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 299.035776
-  0: The maximum resident set size (KB)                   = 1206624
+  0: The total amount of wall time                        = 295.052209
+  0: The maximum resident set size (KB)                   = 1201408
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1837,14 +1837,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 500.139544
- 0: The maximum resident set size (KB)                   = 1086548
+ 0: The total amount of wall time                        = 507.974648
+ 0: The maximum resident set size (KB)                   = 1090444
 
 Test 047 rap_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1883,14 +1883,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 225.457485
-  0: The maximum resident set size (KB)                   = 932648
+  0: The total amount of wall time                        = 224.410057
+  0: The maximum resident set size (KB)                   = 953292
 
 Test 048 rap_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1937,14 +1937,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.576355
-  0: The maximum resident set size (KB)                   = 992376
+  0: The total amount of wall time                        = 440.356994
+  0: The maximum resident set size (KB)                   = 1039544
 
 Test 049 rap_sfcdiff PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_sfcdiff_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1983,14 +1983,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 224.610581
-  0: The maximum resident set size (KB)                   = 955132
+  0: The total amount of wall time                        = 224.534567
+  0: The maximum resident set size (KB)                   = 936196
 
 Test 050 rap_sfcdiff_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 422.116468
-  0: The maximum resident set size (KB)                   = 992108
+  0: The total amount of wall time                        = 420.901285
+  0: The maximum resident set size (KB)                   = 1033624
 
 Test 051 hrrr_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 427.076783
-  0: The maximum resident set size (KB)                   = 1025660
+  0: The total amount of wall time                        = 431.286936
+  0: The maximum resident set size (KB)                   = 1016480
 
-Test 052 rrfs_v1beta PASS Tries: 2
+Test 052 rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1nssl
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2113,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 504.100246
-  0: The maximum resident set size (KB)                   = 700748
+  0: The total amount of wall time                        = 501.613211
+  0: The maximum resident set size (KB)                   = 700096
 
 Test 053 rrfs_v1nssl PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2135,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 491.319925
-  0: The maximum resident set size (KB)                   = 721812
+  0: The total amount of wall time                        = 491.410353
+  0: The maximum resident set size (KB)                   = 739280
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2151,14 +2151,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 189.652120
-  0: The maximum resident set size (KB)                   = 925620
+  0: The total amount of wall time                        = 189.249240
+  0: The maximum resident set size (KB)                   = 923696
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 192.037959
-  0: The maximum resident set size (KB)                   = 927608
+  0: The total amount of wall time                        = 188.385075
+  0: The maximum resident set size (KB)                   = 886488
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2183,14 +2183,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 211.406905
-  0: The maximum resident set size (KB)                   = 945308
+  0: The total amount of wall time                        = 213.322333
+  0: The maximum resident set size (KB)                   = 954400
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 330.002385
-  0: The maximum resident set size (KB)                   = 753164
+  0: The total amount of wall time                        = 327.870467
+  0: The maximum resident set size (KB)                   = 751108
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 325.350514
-  0: The maximum resident set size (KB)                   = 752916
+  0: The total amount of wall time                        = 323.741245
+  0: The maximum resident set size (KB)                   = 757916
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2237,14 +2237,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 211.730661
-  0: The maximum resident set size (KB)                   = 762576
+  0: The total amount of wall time                        = 211.621659
+  0: The maximum resident set size (KB)                   = 758936
 
 Test 060 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2255,14 +2255,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 171.281074
-  0: The maximum resident set size (KB)                   = 719144
+  0: The total amount of wall time                        = 171.010454
+  0: The maximum resident set size (KB)                   = 722412
 
 Test 061 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2273,14 +2273,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 234.104697
-  0: The maximum resident set size (KB)                   = 1080816
+  0: The total amount of wall time                        = 234.347632
+  0: The maximum resident set size (KB)                   = 1079188
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2291,54 +2291,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 220.240576
-  0: The maximum resident set size (KB)                   = 1061764
+  0: The total amount of wall time                        = 220.184678
+  0: The maximum resident set size (KB)                   = 1059404
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wam
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 105.031252
-  0: The maximum resident set size (KB)                   = 616184
+  0: The total amount of wall time                        = 103.483263
+  0: The maximum resident set size (KB)                   = 620212
 
 Test 064 control_wam PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.991077
-  0: The maximum resident set size (KB)                   = 804480
+  0: The total amount of wall time                        = 153.858812
+  0: The maximum resident set size (KB)                   = 813496
 
 Test 065 control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_2threads_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 229.124299
- 0: The maximum resident set size (KB)                   = 863372
+ 0: The total amount of wall time                        = 227.958380
+ 0: The maximum resident set size (KB)                   = 862716
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2365,415 +2365,415 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.132741
-  0: The maximum resident set size (KB)                   = 805320
+  0: The total amount of wall time                        = 165.918709
+  0: The maximum resident set size (KB)                   = 804528
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.266701
-  0: The maximum resident set size (KB)                   = 804392
+  0: The total amount of wall time                        = 160.462294
+  0: The maximum resident set size (KB)                   = 814144
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.825744
-  0: The maximum resident set size (KB)                   = 817876
+  0: The total amount of wall time                        = 169.463020
+  0: The maximum resident set size (KB)                   = 815132
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.798746
-  0: The maximum resident set size (KB)                   = 813364
+  0: The total amount of wall time                        = 160.539936
+  0: The maximum resident set size (KB)                   = 809436
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 230.809006
-  0: The maximum resident set size (KB)                   = 855416
+  0: The total amount of wall time                        = 234.385602
+  0: The maximum resident set size (KB)                   = 855248
 
 Test 071 control_csawmg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 236.974656
-  0: The maximum resident set size (KB)                   = 855676
+  0: The total amount of wall time                        = 235.771216
+  0: The maximum resident set size (KB)                   = 856268
 
 Test 072 control_csawmgt_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.990333
-  0: The maximum resident set size (KB)                   = 819104
+  0: The total amount of wall time                        = 158.177234
+  0: The maximum resident set size (KB)                   = 817860
 
 Test 073 control_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.868800
-  0: The maximum resident set size (KB)                   = 861248
+  0: The total amount of wall time                        = 164.222028
+  0: The maximum resident set size (KB)                   = 862264
 
 Test 074 control_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.031220
-  0: The maximum resident set size (KB)                   = 1182556
+  0: The total amount of wall time                        = 173.274325
+  0: The maximum resident set size (KB)                   = 1202084
 
 Test 075 control_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.916234
-  0: The maximum resident set size (KB)                   = 1177216
+  0: The total amount of wall time                        = 185.435365
+  0: The maximum resident set size (KB)                   = 1176980
 
 Test 076 control_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.880560
-  0: The maximum resident set size (KB)                   = 1167324
+  0: The total amount of wall time                        = 177.492223
+  0: The maximum resident set size (KB)                   = 1164152
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_extdiag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.529736
-  0: The maximum resident set size (KB)                   = 1209732
+  0: The total amount of wall time                        = 190.318270
+  0: The maximum resident set size (KB)                   = 1209412
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.246501
-  0: The maximum resident set size (KB)                   = 1175364
+  0: The total amount of wall time                        = 178.606309
+  0: The maximum resident set size (KB)                   = 1178008
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 251.175384
- 0: The maximum resident set size (KB)                   = 848792
+ 0: The total amount of wall time                        = 250.295790
+ 0: The maximum resident set size (KB)                   = 849396
 
 Test 080 regional_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.429063
-  0: The maximum resident set size (KB)                   = 1179792
+  0: The total amount of wall time                        = 283.362723
+  0: The maximum resident set size (KB)                   = 1182888
 
 Test 081 rap_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_unified_drag_suite_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.243479
-  0: The maximum resident set size (KB)                   = 1182972
+  0: The total amount of wall time                        = 277.923959
+  0: The maximum resident set size (KB)                   = 1187036
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.057364
-  0: The maximum resident set size (KB)                   = 1263756
+  0: The total amount of wall time                        = 294.520446
+  0: The maximum resident set size (KB)                   = 1272688
 
 Test 083 rap_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.286730
-  0: The maximum resident set size (KB)                   = 1138076
+  0: The total amount of wall time                        = 275.819261
+  0: The maximum resident set size (KB)                   = 1184832
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_unified_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.951539
-  0: The maximum resident set size (KB)                   = 1183036
+  0: The total amount of wall time                        = 828.038826
+  0: The maximum resident set size (KB)                   = 1182016
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.284182
-  0: The maximum resident set size (KB)                   = 1151420
+  0: The total amount of wall time                        = 277.096784
+  0: The maximum resident set size (KB)                   = 1180852
 
 Test 086 rap_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.598548
-  0: The maximum resident set size (KB)                   = 1183324
+  0: The total amount of wall time                        = 282.535493
+  0: The maximum resident set size (KB)                   = 1184856
 
 Test 087 rap_flake_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.942733
-  0: The maximum resident set size (KB)                   = 1186940
+  0: The total amount of wall time                        = 271.075223
+  0: The maximum resident set size (KB)                   = 1186548
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.478295
-  0: The maximum resident set size (KB)                   = 1168464
+  0: The total amount of wall time                        = 271.672816
+  0: The maximum resident set size (KB)                   = 1180704
 
 Test 089 rap_noah_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 459.579364
-  0: The maximum resident set size (KB)                   = 1312520
+  0: The total amount of wall time                        = 454.962600
+  0: The maximum resident set size (KB)                   = 1312620
 
 Test 090 rap_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.040268
-  0: The maximum resident set size (KB)                   = 1179356
+  0: The total amount of wall time                        = 279.694933
+  0: The maximum resident set size (KB)                   = 1184004
 
 Test 091 rap_sfcdiff_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 452.971123
-  0: The maximum resident set size (KB)                   = 1184536
+  0: The total amount of wall time                        = 454.173795
+  0: The maximum resident set size (KB)                   = 1175808
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.317375
-  0: The maximum resident set size (KB)                   = 1173888
+  0: The total amount of wall time                        = 270.533977
+  0: The maximum resident set size (KB)                   = 1175472
 
 Test 093 rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 285.084779
-  0: The maximum resident set size (KB)                   = 534288
+  0: The total amount of wall time                        = 289.481534
+  0: The maximum resident set size (KB)                   = 510404
 
 Test 094 control_wam_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 311.327371
-  0: The maximum resident set size (KB)                   = 979456
+  0: The total amount of wall time                        = 315.291057
+  0: The maximum resident set size (KB)                   = 980832
 
 Test 095 hafs_regional_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 430.733937
-  0: The maximum resident set size (KB)                   = 1336472
+  0: The total amount of wall time                        = 409.109350
+  0: The maximum resident set size (KB)                   = 1340440
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2782,14 +2782,14 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 401.969037
-  0: The maximum resident set size (KB)                   = 1165452
+  0: The total amount of wall time                        = 399.211126
+  0: The maximum resident set size (KB)                   = 1204028
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 098 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 743.772169
-  0: The maximum resident set size (KB)                   = 1201788
+  0: The total amount of wall time                        = 755.731506
+  0: The maximum resident set size (KB)                   = 1226948
 
 Test 098 hafs_regional_atm_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2816,28 +2816,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 839.403659
-  0: The maximum resident set size (KB)                   = 1196680
+  0: The total amount of wall time                        = 844.776690
+  0: The maximum resident set size (KB)                   = 1162228
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 441.729782
-  0: The maximum resident set size (KB)                   = 573904
+  0: The total amount of wall time                        = 446.890979
+  0: The maximum resident set size (KB)                   = 575232
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2846,28 +2846,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 496.539078
-  0: The maximum resident set size (KB)                   = 585868
+  0: The total amount of wall time                        = 498.346404
+  0: The maximum resident set size (KB)                   = 586864
 
-Test 101 hafs_regional_telescopic_2nests_atm PASS Tries: 2
+Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 206.819278
-  0: The maximum resident set size (KB)                   = 377572
+  0: The total amount of wall time                        = 205.258352
+  0: The maximum resident set size (KB)                   = 378236
 
 Test 102 hafs_global_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2880,42 +2880,42 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 574.623999
-  0: The maximum resident set size (KB)                   = 414684
+  0: The total amount of wall time                        = 562.239356
+  0: The maximum resident set size (KB)                   = 390492
 
-Test 103 hafs_global_multiple_4nests_atm PASS
+Test 103 hafs_global_multiple_4nests_atm PASS Tries: 2
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 267.476270
-  0: The maximum resident set size (KB)                   = 577056
+  0: The total amount of wall time                        = 271.982094
+  0: The maximum resident set size (KB)                   = 528500
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 258.715150
-  0: The maximum resident set size (KB)                   = 581140
+  0: The total amount of wall time                        = 258.764105
+  0: The maximum resident set size (KB)                   = 581460
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2924,14 +2924,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 266.353014
-  0: The maximum resident set size (KB)                   = 619720
+  0: The total amount of wall time                        = 264.982858
+  0: The maximum resident set size (KB)                   = 622308
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2942,28 +2942,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 616.789463
-  0: The maximum resident set size (KB)                   = 595536
+  0: The total amount of wall time                        = 611.038619
+  0: The maximum resident set size (KB)                   = 597472
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 79.363142
-  0: The maximum resident set size (KB)                   = 392644
+  0: The total amount of wall time                        = 78.518670
+  0: The maximum resident set size (KB)                   = 396312
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2971,14 +2971,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 400.673706
-  0: The maximum resident set size (KB)                   = 1211648
+  0: The total amount of wall time                        = 394.915439
+  0: The maximum resident set size (KB)                   = 1158044
 
 Test 109 hafs_regional_docn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2986,118 +2986,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 398.542140
-  0: The maximum resident set size (KB)                   = 1203100
+  0: The total amount of wall time                        = 399.580306
+  0: The maximum resident set size (KB)                   = 1203716
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 927.520689
-  0: The maximum resident set size (KB)                   = 1018076
+  0: The total amount of wall time                        = 921.043359
+  0: The maximum resident set size (KB)                   = 1014820
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.386555
- 0: The maximum resident set size (KB)                   = 1018704
+ 0: The total amount of wall time                        = 143.445164
+ 0: The maximum resident set size (KB)                   = 1024192
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 103.478334
- 0: The maximum resident set size (KB)                   = 991648
+ 0: The total amount of wall time                        = 97.909982
+ 0: The maximum resident set size (KB)                   = 992896
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.281946
- 0: The maximum resident set size (KB)                   = 939796
+ 0: The total amount of wall time                        = 141.558103
+ 0: The maximum resident set size (KB)                   = 932684
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.357635
- 0: The maximum resident set size (KB)                   = 938328
+ 0: The total amount of wall time                        = 142.674616
+ 0: The maximum resident set size (KB)                   = 929564
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.940026
- 0: The maximum resident set size (KB)                   = 934636
+ 0: The total amount of wall time                        = 140.978888
+ 0: The maximum resident set size (KB)                   = 935676
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.702656
- 0: The maximum resident set size (KB)                   = 1023984
+ 0: The total amount of wall time                        = 142.476294
+ 0: The maximum resident set size (KB)                   = 1013664
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.585937
- 0: The maximum resident set size (KB)                   = 928504
+ 0: The total amount of wall time                        = 137.098447
+ 0: The maximum resident set size (KB)                   = 936296
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3106,14 +3106,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 299.645512
-  0: The maximum resident set size (KB)                   = 853660
+  0: The total amount of wall time                        = 296.254321
+  0: The maximum resident set size (KB)                   = 862316
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3122,64 +3122,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 296.408375
-  0: The maximum resident set size (KB)                   = 883404
+  0: The total amount of wall time                        = 291.841327
+  0: The maximum resident set size (KB)                   = 878548
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.003100
- 0: The maximum resident set size (KB)                   = 1047856
+ 0: The total amount of wall time                        = 145.936365
+ 0: The maximum resident set size (KB)                   = 1026636
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 196.265531
- 0: The maximum resident set size (KB)                   = 2210924
+ 0: The total amount of wall time                        = 188.720716
+ 0: The maximum resident set size (KB)                   = 2251492
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_gfs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 194.215730
- 0: The maximum resident set size (KB)                   = 2251844
+ 0: The total amount of wall time                        = 193.277288
+ 0: The maximum resident set size (KB)                   = 2239504
 
 Test 123 datm_cdeps_gfs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 441.893327
- 0: The maximum resident set size (KB)                   = 976820
+ 0: The total amount of wall time                        = 435.136429
+ 0: The maximum resident set size (KB)                   = 974212
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3223,14 +3223,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 81.246020
-  0: The maximum resident set size (KB)                   = 702148
+  0: The total amount of wall time                        = 80.935214
+  0: The maximum resident set size (KB)                   = 703620
 
 Test 125 control_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/INTEL/atmaero_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_194647/atmaero_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_291190/atmaero_control_p8
 Checking test 126 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3274,12 +3274,12 @@ Checking test 126 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 322.742853
-  0: The maximum resident set size (KB)                   = 5106688
+  0: The total amount of wall time                        = 326.345160
+  0: The maximum resident set size (KB)                   = 5111284
 
 Test 126 atmaero_control_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jun 13 14:54:37 CDT 2022
-Elapsed time: 01h:06m:49s. Have a nice day!
+Mon Jun 13 17:22:10 CDT 2022
+Elapsed time: 01h:05m:15s. Have a nice day!

--- a/tests/RegressionTests_wcoss2.intel.log
+++ b/tests/RegressionTests_wcoss2.intel.log
@@ -1,20 +1,20 @@
-Mon Jun 13 01:44:42 UTC 2022
+Mon Jun 13 19:06:21 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 772 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 579 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 338 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 651 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 496 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 323 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 391 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 149 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 145 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 465 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 601 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 464 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 974 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 582 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 487 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 282 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 837 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 513 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 542 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 413 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 457 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 585 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/cpld_control_noaero_p8_agrid
 Checking test 001 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -76,14 +76,14 @@ Checking test 001 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 321.129485
-The maximum resident set size (KB)                   = 1056800
+The total amount of wall time                        = 324.087345
+The maximum resident set size (KB)                   = 1052024
 
 Test 001 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control
 Checking test 002 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -130,14 +130,14 @@ Checking test 002 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 125.123718
-The maximum resident set size (KB)                   = 517428
+The total amount of wall time                        = 126.754301
+The maximum resident set size (KB)                   = 518876
 
 Test 002 control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_decomp
 Checking test 003 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -180,14 +180,14 @@ Checking test 003 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 130.904592
-The maximum resident set size (KB)                   = 515276
+The total amount of wall time                        = 133.362650
+The maximum resident set size (KB)                   = 515008
 
 Test 003 control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_2dwrtdecomp
 Checking test 004 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 123.397104
-The maximum resident set size (KB)                   = 517732
+The total amount of wall time                        = 126.691623
+The maximum resident set size (KB)                   = 517252
 
 Test 004 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_2threads
 Checking test 005 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -248,14 +248,14 @@ Checking test 005 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 370.928672
-The maximum resident set size (KB)                   = 567668
+The total amount of wall time                        = 374.807190
+The maximum resident set size (KB)                   = 572336
 
 Test 005 control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_restart
 Checking test 006 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -294,14 +294,14 @@ Checking test 006 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 66.402754
-The maximum resident set size (KB)                   = 258024
+The total amount of wall time                        = 66.557247
+The maximum resident set size (KB)                   = 256192
 
 Test 006 control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_fhzero
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_fhzero
 Checking test 007 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -344,14 +344,14 @@ Checking test 007 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 121.930218
-The maximum resident set size (KB)                   = 517948
+The total amount of wall time                        = 122.492513
+The maximum resident set size (KB)                   = 517712
 
 Test 007 control_fhzero PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_CubedSphereGrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_CubedSphereGrid
 Checking test 008 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -378,14 +378,14 @@ Checking test 008 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 120.604212
-The maximum resident set size (KB)                   = 515792
+The total amount of wall time                        = 123.567528
+The maximum resident set size (KB)                   = 519944
 
 Test 008 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_latlon
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_latlon
 Checking test 009 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -396,14 +396,14 @@ Checking test 009 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 122.159968
-The maximum resident set size (KB)                   = 519136
+The total amount of wall time                        = 125.580570
+The maximum resident set size (KB)                   = 516940
 
 Test 009 control_latlon PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_wrtGauss_netcdf_parallel
 Checking test 010 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -414,14 +414,14 @@ Checking test 010 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 123.997573
-The maximum resident set size (KB)                   = 516736
+The total amount of wall time                        = 127.452930
+The maximum resident set size (KB)                   = 517100
 
 Test 010 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_c48
 Checking test 011 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -460,14 +460,14 @@ Checking test 011 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 310.340062
-The maximum resident set size (KB)                   = 671384
+The total amount of wall time                        = 311.339818
+The maximum resident set size (KB)                   = 668816
 
 Test 011 control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_c192
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_c192
 Checking test 012 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -478,14 +478,14 @@ Checking test 012 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 499.065009
-The maximum resident set size (KB)                   = 619944
+The total amount of wall time                        = 501.462265
+The maximum resident set size (KB)                   = 624940
 
 Test 012 control_c192 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_c384
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_c384
 Checking test 013 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -496,14 +496,14 @@ Checking test 013 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1519.754714
-The maximum resident set size (KB)                   = 890984
+The total amount of wall time                        = 1524.916164
+The maximum resident set size (KB)                   = 890776
 
 Test 013 control_c384 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_c384gdas
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_c384gdas
 Checking test 014 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -546,14 +546,14 @@ Checking test 014 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1401.808637
-The maximum resident set size (KB)                   = 1013764
+The total amount of wall time                        = 1396.524720
+The maximum resident set size (KB)                   = 1014044
 
 Test 014 control_c384gdas PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_c384_progsigma
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_c384_progsigma
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_c384_progsigma
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_c384_progsigma
 Checking test 015 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -564,14 +564,14 @@ Checking test 015 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1545.093827
-The maximum resident set size (KB)                   = 908844
+The total amount of wall time                        = 1543.767260
+The maximum resident set size (KB)                   = 912916
 
 Test 015 control_c384_progsigma PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_stochy
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_stochy
 Checking test 016 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -582,28 +582,28 @@ Checking test 016 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 83.783198
-The maximum resident set size (KB)                   = 520768
+The total amount of wall time                        = 84.559186
+The maximum resident set size (KB)                   = 522724
 
 Test 016 control_stochy PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_stochy_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_stochy_restart
 Checking test 017 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 44.855103
-The maximum resident set size (KB)                   = 288752
+The total amount of wall time                        = 45.532804
+The maximum resident set size (KB)                   = 286828
 
 Test 017 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_lndp
 Checking test 018 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -614,14 +614,14 @@ Checking test 018 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 75.756819
-The maximum resident set size (KB)                   = 520484
+The total amount of wall time                        = 76.381686
+The maximum resident set size (KB)                   = 520184
 
 Test 018 control_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_iovr4
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_iovr4
 Checking test 019 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -636,14 +636,14 @@ Checking test 019 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 125.296953
-The maximum resident set size (KB)                   = 516672
+The total amount of wall time                        = 127.432152
+The maximum resident set size (KB)                   = 517704
 
 Test 019 control_iovr4 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_iovr5
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_iovr5
 Checking test 020 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -658,14 +658,14 @@ Checking test 020 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 125.142897
-The maximum resident set size (KB)                   = 516372
+The total amount of wall time                        = 127.448664
+The maximum resident set size (KB)                   = 517032
 
 Test 020 control_iovr5 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_p8
 Checking test 021 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -712,14 +712,14 @@ Checking test 021 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 175.252377
-The maximum resident set size (KB)                   = 909904
+The total amount of wall time                        = 178.643788
+The maximum resident set size (KB)                   = 909344
 
 Test 021 control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_p8_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_p8_lndp
 Checking test 022 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -738,14 +738,14 @@ Checking test 022 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 320.338030
-The maximum resident set size (KB)                   = 909172
+The total amount of wall time                        = 321.737189
+The maximum resident set size (KB)                   = 906432
 
 Test 022 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_restart_p8
 Checking test 023 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 023 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.963710
-The maximum resident set size (KB)                   = 647272
+The total amount of wall time                        = 100.430389
+The maximum resident set size (KB)                   = 646752
 
 Test 023 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_decomp_p8
 Checking test 024 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -834,14 +834,14 @@ Checking test 024 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 177.467424
-The maximum resident set size (KB)                   = 911120
+The total amount of wall time                        = 180.887443
+The maximum resident set size (KB)                   = 904488
 
 Test 024 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_2threads_p8
 Checking test 025 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -884,14 +884,14 @@ Checking test 025 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 492.710489
-The maximum resident set size (KB)                   = 986240
+The total amount of wall time                        = 489.265936
+The maximum resident set size (KB)                   = 985012
 
 Test 025 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_p8_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_p8_rrtmgp
 Checking test 026 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -938,14 +938,14 @@ Checking test 026 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 245.030899
-The maximum resident set size (KB)                   = 1026048
+The total amount of wall time                        = 251.059434
+The maximum resident set size (KB)                   = 1023984
 
 Test 026 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_control
 Checking test 027 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -956,28 +956,28 @@ Checking test 027 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 299.444508
-The maximum resident set size (KB)                   = 597436
+The total amount of wall time                        = 298.114486
+The maximum resident set size (KB)                   = 597000
 
 Test 027 regional_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_restart
 Checking test 028 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 163.776150
-The maximum resident set size (KB)                   = 601280
+The total amount of wall time                        = 165.492641
+The maximum resident set size (KB)                   = 594608
 
 Test 028 regional_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_control_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_control_2dwrtdecomp
 Checking test 029 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -988,14 +988,14 @@ Checking test 029 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 298.796437
-The maximum resident set size (KB)                   = 601132
+The total amount of wall time                        = 299.542779
+The maximum resident set size (KB)                   = 598804
 
 Test 029 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_noquilt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_noquilt
 Checking test 030 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1003,14 +1003,14 @@ Checking test 030 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 314.373474
-The maximum resident set size (KB)                   = 592236
+The total amount of wall time                        = 316.114682
+The maximum resident set size (KB)                   = 589944
 
 Test 030 regional_noquilt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_2threads
 Checking test 031 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1021,28 +1021,28 @@ Checking test 031 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 595.662015
-The maximum resident set size (KB)                   = 649412
+The total amount of wall time                        = 596.331562
+The maximum resident set size (KB)                   = 650496
 
 Test 031 regional_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_netcdf_parallel
 Checking test 032 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 298.144999
-The maximum resident set size (KB)                   = 594944
+The total amount of wall time                        = 295.032670
+The maximum resident set size (KB)                   = 597380
 
 Test 032 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_3km
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_3km
 Checking test 033 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1053,14 +1053,14 @@ Checking test 033 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 248.592527
-The maximum resident set size (KB)                   = 650332
+The total amount of wall time                        = 256.026862
+The maximum resident set size (KB)                   = 646312
 
 Test 033 regional_3km PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_control
 Checking test 034 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1107,14 +1107,14 @@ Checking test 034 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 396.056969
-The maximum resident set size (KB)                   = 889428
+The total amount of wall time                        = 403.197745
+The maximum resident set size (KB)                   = 888724
 
 Test 034 rap_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_rrtmgp
 Checking test 035 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1161,14 +1161,14 @@ Checking test 035 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 469.127637
-The maximum resident set size (KB)                   = 1012212
+The total amount of wall time                        = 476.212543
+The maximum resident set size (KB)                   = 1011672
 
 Test 035 rap_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_spp_sppt_shum_skeb
 Checking test 036 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1179,14 +1179,14 @@ Checking test 036 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 719.055456
-The maximum resident set size (KB)                   = 977652
+The total amount of wall time                        = 725.963927
+The maximum resident set size (KB)                   = 980332
 
 Test 036 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_2threads
 Checking test 037 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1233,14 +1233,14 @@ Checking test 037 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1246.651528
-The maximum resident set size (KB)                   = 956548
+The total amount of wall time                        = 1245.803038
+The maximum resident set size (KB)                   = 951232
 
 Test 037 rap_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_restart
 Checking test 038 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1279,14 +1279,14 @@ Checking test 038 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.390568
-The maximum resident set size (KB)                   = 631208
+The total amount of wall time                        = 203.303800
+The maximum resident set size (KB)                   = 631444
 
 Test 038 rap_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_sfcdiff
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_sfcdiff
 Checking test 039 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1333,14 +1333,14 @@ Checking test 039 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 401.213312
-The maximum resident set size (KB)                   = 891556
+The total amount of wall time                        = 400.946844
+The maximum resident set size (KB)                   = 888516
 
 Test 039 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_sfcdiff_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_sfcdiff_restart
 Checking test 040 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1379,14 +1379,14 @@ Checking test 040 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 201.663897
-The maximum resident set size (KB)                   = 633572
+The total amount of wall time                        = 202.504832
+The maximum resident set size (KB)                   = 630984
 
 Test 040 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hrrr_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hrrr_control
 Checking test 041 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1433,14 +1433,14 @@ Checking test 041 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 379.199255
-The maximum resident set size (KB)                   = 891932
+The total amount of wall time                        = 386.772491
+The maximum resident set size (KB)                   = 892716
 
 Test 041 hrrr_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_v1beta
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_v1beta
 Checking test 042 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1487,14 +1487,14 @@ Checking test 042 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 382.864997
-The maximum resident set size (KB)                   = 890700
+The total amount of wall time                        = 387.936100
+The maximum resident set size (KB)                   = 887984
 
 Test 042 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_v1nssl
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_v1nssl
 Checking test 043 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1509,14 +1509,14 @@ Checking test 043 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 445.508094
-The maximum resident set size (KB)                   = 574752
+The total amount of wall time                        = 448.153427
+The maximum resident set size (KB)                   = 574140
 
 Test 043 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_v1nssl_nohailnoccn
 Checking test 044 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1531,14 +1531,14 @@ Checking test 044 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 439.166712
-The maximum resident set size (KB)                   = 566932
+The total amount of wall time                        = 435.212458
+The maximum resident set size (KB)                   = 569168
 
 Test 044 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_conus13km_hrrr_warm
 Checking test 045 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,14 +1547,14 @@ Checking test 045 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 167.327794
-The maximum resident set size (KB)                   = 762324
+The total amount of wall time                        = 172.296402
+The maximum resident set size (KB)                   = 764328
 
 Test 045 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_conus13km_radar_tten_warm
 Checking test 046 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1563,14 +1563,14 @@ Checking test 046 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 168.047577
-The maximum resident set size (KB)                   = 764868
+The total amount of wall time                        = 169.796942
+The maximum resident set size (KB)                   = 764256
 
 Test 046 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_smoke_conus13km_hrrr_warm
 Checking test 047 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1579,14 +1579,14 @@ Checking test 047 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 183.062075
-The maximum resident set size (KB)                   = 779440
+The total amount of wall time                        = 191.917903
+The maximum resident set size (KB)                   = 778160
 
 Test 047 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_csawmg
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_csawmg
 Checking test 048 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1597,14 +1597,14 @@ Checking test 048 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 337.688360
-The maximum resident set size (KB)                   = 591840
+The total amount of wall time                        = 338.902540
+The maximum resident set size (KB)                   = 589616
 
 Test 048 control_csawmg PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_csawmgt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_csawmgt
 Checking test 049 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1615,14 +1615,14 @@ Checking test 049 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 334.918065
-The maximum resident set size (KB)                   = 591508
+The total amount of wall time                        = 338.633316
+The maximum resident set size (KB)                   = 585900
 
 Test 049 control_csawmgt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_flake
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_flake
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_flake
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_flake
 Checking test 050 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1633,14 +1633,14 @@ Checking test 050 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 244.699031
-The maximum resident set size (KB)                   = 589264
+The total amount of wall time                        = 242.041965
+The maximum resident set size (KB)                   = 587280
 
 Test 050 control_flake PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_ras
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_ras
 Checking test 051 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1651,14 +1651,14 @@ Checking test 051 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 172.224705
-The maximum resident set size (KB)                   = 547092
+The total amount of wall time                        = 172.247541
+The maximum resident set size (KB)                   = 547672
 
 Test 051 control_ras PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_thompson
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_thompson
 Checking test 052 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1669,14 +1669,14 @@ Checking test 052 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 231.657984
-The maximum resident set size (KB)                   = 906724
+The total amount of wall time                        = 233.177812
+The maximum resident set size (KB)                   = 905340
 
 Test 052 control_thompson PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_thompson_no_aero
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_thompson_no_aero
 Checking test 053 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1687,54 +1687,54 @@ Checking test 053 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 217.004032
-The maximum resident set size (KB)                   = 899972
+The total amount of wall time                        = 220.485939
+The maximum resident set size (KB)                   = 899864
 
 Test 053 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_wam
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_wam
 Checking test 054 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 109.622168
-The maximum resident set size (KB)                   = 278828
+The total amount of wall time                        = 110.403348
+The maximum resident set size (KB)                   = 265064
 
 Test 054 control_wam PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_debug
 Checking test 055 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 152.234853
-The maximum resident set size (KB)                   = 673996
+The total amount of wall time                        = 152.604053
+The maximum resident set size (KB)                   = 677444
 
 Test 055 control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_2threads_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_2threads_debug
 Checking test 056 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 442.215436
-The maximum resident set size (KB)                   = 733168
+The total amount of wall time                        = 443.695056
+The maximum resident set size (KB)                   = 728440
 
 Test 056 control_2threads_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_CubedSphereGrid_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_CubedSphereGrid_debug
 Checking test 057 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1761,415 +1761,415 @@ Checking test 057 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 152.843225
-The maximum resident set size (KB)                   = 670344
+The total amount of wall time                        = 154.640848
+The maximum resident set size (KB)                   = 673416
 
 Test 057 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_wrtGauss_netcdf_parallel_debug
 Checking test 058 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 153.563148
-The maximum resident set size (KB)                   = 675808
+The total amount of wall time                        = 152.945282
+The maximum resident set size (KB)                   = 672844
 
 Test 058 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_stochy_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_stochy_debug
 Checking test 059 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 173.924814
-The maximum resident set size (KB)                   = 679800
+The total amount of wall time                        = 175.070064
+The maximum resident set size (KB)                   = 677020
 
 Test 059 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_lndp_debug
 Checking test 060 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 156.650167
-The maximum resident set size (KB)                   = 675688
+The total amount of wall time                        = 156.045795
+The maximum resident set size (KB)                   = 677288
 
 Test 060 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_csawmg_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_csawmg_debug
 Checking test 061 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 251.500234
-The maximum resident set size (KB)                   = 717688
+The total amount of wall time                        = 249.396097
+The maximum resident set size (KB)                   = 720692
 
 Test 061 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_csawmgt_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_csawmgt_debug
 Checking test 062 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 250.144312
-The maximum resident set size (KB)                   = 719872
+The total amount of wall time                        = 245.698338
+The maximum resident set size (KB)                   = 721252
 
 Test 062 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_ras_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_ras_debug
 Checking test 063 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 157.671685
-The maximum resident set size (KB)                   = 687680
+The total amount of wall time                        = 157.416705
+The maximum resident set size (KB)                   = 685292
 
 Test 063 control_ras_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_diag_debug
 Checking test 064 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 158.883617
-The maximum resident set size (KB)                   = 733048
+The total amount of wall time                        = 158.101885
+The maximum resident set size (KB)                   = 729360
 
 Test 064 control_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_debug_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_debug_p8
 Checking test 065 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 178.030836
-The maximum resident set size (KB)                   = 1070976
+The total amount of wall time                        = 180.175256
+The maximum resident set size (KB)                   = 1070380
 
 Test 065 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_thompson_debug
 Checking test 066 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 182.392251
-The maximum resident set size (KB)                   = 1040836
+The total amount of wall time                        = 184.349040
+The maximum resident set size (KB)                   = 1039292
 
 Test 066 control_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_thompson_no_aero_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_thompson_no_aero_debug
 Checking test 067 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 175.036733
-The maximum resident set size (KB)                   = 1035228
+The total amount of wall time                        = 176.538203
+The maximum resident set size (KB)                   = 1034956
 
 Test 067 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_thompson_extdiag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_thompson_extdiag_debug
 Checking test 068 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 188.902406
-The maximum resident set size (KB)                   = 1068088
+The total amount of wall time                        = 189.662965
+The maximum resident set size (KB)                   = 1070928
 
 Test 068 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_thompson_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_thompson_progcld_thompson_debug
 Checking test 069 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 183.200043
-The maximum resident set size (KB)                   = 1040860
+The total amount of wall time                        = 184.509157
+The maximum resident set size (KB)                   = 1039280
 
 Test 069 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/fv3_regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/regional_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/fv3_regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/regional_debug
 Checking test 070 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 256.255761
-The maximum resident set size (KB)                   = 620180
+The total amount of wall time                        = 257.148637
+The maximum resident set size (KB)                   = 620272
 
 Test 070 regional_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_control_debug
 Checking test 071 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.282413
-The maximum resident set size (KB)                   = 1049304
+The total amount of wall time                        = 293.099897
+The maximum resident set size (KB)                   = 1046500
 
 Test 071 rap_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_unified_drag_suite_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_unified_drag_suite_debug
 Checking test 072 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.105166
-The maximum resident set size (KB)                   = 1050636
+The total amount of wall time                        = 294.609723
+The maximum resident set size (KB)                   = 1047872
 
 Test 072 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_diag_debug
 Checking test 073 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.138871
-The maximum resident set size (KB)                   = 1133284
+The total amount of wall time                        = 303.457333
+The maximum resident set size (KB)                   = 1132880
 
 Test 073 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_cires_ugwp_debug
 Checking test 074 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.672171
-The maximum resident set size (KB)                   = 1046308
+The total amount of wall time                        = 297.633562
+The maximum resident set size (KB)                   = 1044228
 
 Test 074 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_unified_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_unified_ugwp_debug
 Checking test 075 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.818218
-The maximum resident set size (KB)                   = 1052600
+The total amount of wall time                        = 298.660351
+The maximum resident set size (KB)                   = 1052100
 
 Test 075 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_lndp_debug
 Checking test 076 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.680163
-The maximum resident set size (KB)                   = 1049752
+The total amount of wall time                        = 292.650987
+The maximum resident set size (KB)                   = 1047932
 
 Test 076 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_flake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_flake_debug
 Checking test 077 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.526190
-The maximum resident set size (KB)                   = 1052524
+The total amount of wall time                        = 291.930322
+The maximum resident set size (KB)                   = 1052060
 
 Test 077 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_progcld_thompson_debug
 Checking test 078 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.189314
-The maximum resident set size (KB)                   = 1051704
+The total amount of wall time                        = 292.677897
+The maximum resident set size (KB)                   = 1046740
 
 Test 078 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_noah_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_noah_debug
 Checking test 079 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 284.620837
-The maximum resident set size (KB)                   = 1051744
+The total amount of wall time                        = 291.195584
+The maximum resident set size (KB)                   = 1047384
 
 Test 079 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_rrtmgp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_rrtmgp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_rrtmgp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_rrtmgp_debug
 Checking test 080 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 488.972410
-The maximum resident set size (KB)                   = 1169100
+The total amount of wall time                        = 495.384539
+The maximum resident set size (KB)                   = 1173600
 
 Test 080 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_sfcdiff_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_sfcdiff_debug
 Checking test 081 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.854963
-The maximum resident set size (KB)                   = 1052244
+The total amount of wall time                        = 294.333092
+The maximum resident set size (KB)                   = 1051872
 
 Test 081 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 082 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 479.347363
-The maximum resident set size (KB)                   = 1045748
+The total amount of wall time                        = 484.477764
+The maximum resident set size (KB)                   = 1046236
 
 Test 082 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/rrfs_v1beta_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/rrfs_v1beta_debug
 Checking test 083 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.848851
-The maximum resident set size (KB)                   = 1042908
+The total amount of wall time                        = 290.462997
+The maximum resident set size (KB)                   = 1047816
 
 Test 083 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/control_wam_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/control_wam_debug
 Checking test 084 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 299.885157
-The maximum resident set size (KB)                   = 291092
+The total amount of wall time                        = 300.439337
+The maximum resident set size (KB)                   = 291416
 
 Test 084 control_wam_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_atm
 Checking test 085 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 690.540595
-The maximum resident set size (KB)                   = 788780
+The total amount of wall time                        = 691.175075
+The maximum resident set size (KB)                   = 789692
 
 Test 085 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_atm_thompson_gfdlsf
 Checking test 086 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 804.465672
-The maximum resident set size (KB)                   = 1149036
+The total amount of wall time                        = 804.029419
+The maximum resident set size (KB)                   = 1149532
 
 Test 086 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_atm_ocn
 Checking test 087 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 087 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 440.298836
-The maximum resident set size (KB)                   = 827392
+The total amount of wall time                        = 437.654860
+The maximum resident set size (KB)                   = 828348
 
 Test 087 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_atm_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_atm_wav
 Checking test 088 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 088 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 708.639892
-The maximum resident set size (KB)                   = 864768
+The total amount of wall time                        = 709.073967
+The maximum resident set size (KB)                   = 864036
 
 Test 088 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_atm_ocn_wav
 Checking test 089 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2212,28 +2212,28 @@ Checking test 089 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 867.645958
-The maximum resident set size (KB)                   = 872052
+The total amount of wall time                        = 864.498323
+The maximum resident set size (KB)                   = 871240
 
 Test 089 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_1nest_atm
 Checking test 090 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 1056.784462
-The maximum resident set size (KB)                   = 378940
+The total amount of wall time                        = 1058.750976
+The maximum resident set size (KB)                   = 379336
 
 Test 090 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_telescopic_2nests_atm
 Checking test 091 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2242,28 +2242,28 @@ Checking test 091 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 1209.848420
-The maximum resident set size (KB)                   = 386016
+The total amount of wall time                        = 1210.660194
+The maximum resident set size (KB)                   = 390676
 
 Test 091 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_global_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_global_1nest_atm
 Checking test 092 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 507.419361
-The maximum resident set size (KB)                   = 246312
+The total amount of wall time                        = 514.012792
+The maximum resident set size (KB)                   = 244592
 
 Test 092 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_global_multiple_4nests_atm
 Checking test 093 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2276,42 +2276,42 @@ Checking test 093 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-The total amount of wall time                        = 1350.884628
-The maximum resident set size (KB)                   = 309292
+The total amount of wall time                        = 1349.337595
+The maximum resident set size (KB)                   = 310492
 
 Test 093 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_specified_moving_1nest_atm
 Checking test 094 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 631.818546
-The maximum resident set size (KB)                   = 381120
+The total amount of wall time                        = 634.453077
+The maximum resident set size (KB)                   = 386184
 
 Test 094 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_storm_following_1nest_atm
 Checking test 095 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 608.993357
-The maximum resident set size (KB)                   = 381300
+The total amount of wall time                        = 615.306454
+The maximum resident set size (KB)                   = 383240
 
 Test 095 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 096 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2320,14 +2320,14 @@ Checking test 096 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 632.496947
-The maximum resident set size (KB)                   = 409692
+The total amount of wall time                        = 635.526664
+The maximum resident set size (KB)                   = 411268
 
 Test 096 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 097 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2338,28 +2338,28 @@ Checking test 097 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 1297.669149
-The maximum resident set size (KB)                   = 463668
+The total amount of wall time                        = 1299.185501
+The maximum resident set size (KB)                   = 468468
 
 Test 097 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_global_storm_following_1nest_atm
 Checking test 098 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 205.765891
-The maximum resident set size (KB)                   = 278972
+The total amount of wall time                        = 207.403322
+The maximum resident set size (KB)                   = 267496
 
 Test 098 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_docn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_docn
 Checking test 099 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2367,14 +2367,14 @@ Checking test 099 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 389.571163
-The maximum resident set size (KB)                   = 833920
+The total amount of wall time                        = 390.786592
+The maximum resident set size (KB)                   = 835212
 
 Test 099 hafs_regional_docn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_docn_oisst
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_docn_oisst
 Checking test 100 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2382,25 +2382,25 @@ Checking test 100 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 391.654129
-The maximum resident set size (KB)                   = 818228
+The total amount of wall time                        = 394.195646
+The maximum resident set size (KB)                   = 822504
 
 Test 100 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220601/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_8960/hafs_regional_datm_cdeps
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220613/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_113682/hafs_regional_datm_cdeps
 Checking test 101 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 1181.268099
-The maximum resident set size (KB)                   = 847556
+The total amount of wall time                        = 1181.230655
+The maximum resident set size (KB)                   = 840972
 
 Test 101 hafs_regional_datm_cdeps PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jun 13 02:30:17 UTC 2022
-Elapsed time: 00h:45m:36s. Have a nice day!
+Mon Jun 13 19:58:18 UTC 2022
+Elapsed time: 00h:51m:58s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,18 +1,18 @@
-Sun Jun 12 14:35:38 UTC 2022
+Mon Jun 13 22:12:16 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 799 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 834 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 794 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 720 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 613 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 591 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 556 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 583 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 936 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 735 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 757 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 811 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 702 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 584 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 542 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 563 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 534 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 951 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -59,14 +59,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 147.109232
-The maximum resident set size (KB)                   = 421112
+The total amount of wall time                        = 147.357173
+The maximum resident set size (KB)                   = 421160
 
 Test 001 control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_decomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -109,14 +109,14 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 148.405007
-The maximum resident set size (KB)                   = 420184
+The total amount of wall time                        = 150.733207
+The maximum resident set size (KB)                   = 420404
 
 Test 002 control_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_2dwrtdecomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_2dwrtdecomp
 Checking test 003 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -127,14 +127,14 @@ Checking test 003 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 142.736999
-The maximum resident set size (KB)                   = 421040
+The total amount of wall time                        = 145.015682
+The maximum resident set size (KB)                   = 421308
 
 Test 003 control_2dwrtdecomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_restart
 Checking test 004 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -173,14 +173,14 @@ Checking test 004 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 87.202912
-The maximum resident set size (KB)                   = 158876
+The total amount of wall time                        = 80.549691
+The maximum resident set size (KB)                   = 158456
 
 Test 004 control_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_fhzero
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_fhzero
 Checking test 005 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -223,14 +223,14 @@ Checking test 005 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 140.148537
-The maximum resident set size (KB)                   = 421148
+The total amount of wall time                        = 138.617569
+The maximum resident set size (KB)                   = 421156
 
 Test 005 control_fhzero PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_CubedSphereGrid
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_CubedSphereGrid
 Checking test 006 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -257,14 +257,14 @@ Checking test 006 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 142.434780
-The maximum resident set size (KB)                   = 423796
+The total amount of wall time                        = 140.724288
+The maximum resident set size (KB)                   = 423812
 
 Test 006 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_latlon
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_latlon
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_latlon
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_latlon
 Checking test 007 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -275,14 +275,14 @@ Checking test 007 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 144.507881
-The maximum resident set size (KB)                   = 421204
+The total amount of wall time                        = 141.846517
+The maximum resident set size (KB)                   = 421180
 
 Test 007 control_latlon PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_wrtGauss_netcdf_parallel
 Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -293,14 +293,14 @@ Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 146.510484
-The maximum resident set size (KB)                   = 421196
+The total amount of wall time                        = 150.704491
+The maximum resident set size (KB)                   = 421216
 
 Test 008 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c48
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_c48
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c48
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_c48
 Checking test 009 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -339,14 +339,14 @@ Checking test 009 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 454.257387
-The maximum resident set size (KB)                   = 632676
+The total amount of wall time                        = 452.599917
+The maximum resident set size (KB)                   = 632644
 
 Test 009 control_c48 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c192
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c192
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_c192
 Checking test 010 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -357,14 +357,14 @@ Checking test 010 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 553.986577
-The maximum resident set size (KB)                   = 522412
+The total amount of wall time                        = 559.966558
+The maximum resident set size (KB)                   = 522460
 
 Test 010 control_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_stochy
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_stochy
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_stochy
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_stochy
 Checking test 011 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -375,28 +375,28 @@ Checking test 011 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 100.829630
-The maximum resident set size (KB)                   = 422876
+The total amount of wall time                        = 98.124400
+The maximum resident set size (KB)                   = 422972
 
 Test 011 control_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_stochy
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_stochy_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_stochy
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_stochy_restart
 Checking test 012 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 57.707290
-The maximum resident set size (KB)                   = 175476
+The total amount of wall time                        = 56.849885
+The maximum resident set size (KB)                   = 175852
 
 Test 012 control_stochy_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_lndp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_lndp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_lndp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_lndp
 Checking test 013 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -407,14 +407,14 @@ Checking test 013 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 91.832262
-The maximum resident set size (KB)                   = 424956
+The total amount of wall time                        = 89.089454
+The maximum resident set size (KB)                   = 424948
 
 Test 013 control_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_iovr4
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_iovr4
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_iovr4
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_iovr4
 Checking test 014 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -429,14 +429,14 @@ Checking test 014 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 146.924305
-The maximum resident set size (KB)                   = 421052
+The total amount of wall time                        = 146.872293
+The maximum resident set size (KB)                   = 421236
 
 Test 014 control_iovr4 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_iovr5
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_iovr5
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_iovr5
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_iovr5
 Checking test 015 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -451,14 +451,14 @@ Checking test 015 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 147.873744
-The maximum resident set size (KB)                   = 421092
+The total amount of wall time                        = 149.171790
+The maximum resident set size (KB)                   = 421144
 
 Test 015 control_iovr5 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_p8
 Checking test 016 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -505,14 +505,14 @@ Checking test 016 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 196.875526
-The maximum resident set size (KB)                   = 810268
+The total amount of wall time                        = 192.670334
+The maximum resident set size (KB)                   = 810272
 
 Test 016 control_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8_lndp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_p8_lndp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8_lndp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_p8_lndp
 Checking test 017 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -531,14 +531,14 @@ Checking test 017 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 364.298206
-The maximum resident set size (KB)                   = 810416
+The total amount of wall time                        = 362.883749
+The maximum resident set size (KB)                   = 810412
 
 Test 017 control_p8_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_restart_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_restart_p8
 Checking test 018 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -577,14 +577,14 @@ Checking test 018 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 119.645739
-The maximum resident set size (KB)                   = 547180
+The total amount of wall time                        = 109.212463
+The maximum resident set size (KB)                   = 547344
 
 Test 018 control_restart_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_decomp_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_decomp_p8
 Checking test 019 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -627,14 +627,14 @@ Checking test 019 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 203.744770
-The maximum resident set size (KB)                   = 804200
+The total amount of wall time                        = 201.846006
+The maximum resident set size (KB)                   = 804068
 
 Test 019 control_decomp_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8_rrtmgp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_p8_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8_rrtmgp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_p8_rrtmgp
 Checking test 020 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -681,14 +681,14 @@ Checking test 020 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 240.311432
-The maximum resident set size (KB)                   = 926868
+The total amount of wall time                        = 233.196166
+The maximum resident set size (KB)                   = 926928
 
 Test 020 control_p8_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_control
 Checking test 021 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -699,28 +699,28 @@ Checking test 021 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 370.256190
-The maximum resident set size (KB)                   = 534440
+The total amount of wall time                        = 369.603212
+The maximum resident set size (KB)                   = 534472
 
 Test 021 regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_restart
 Checking test 022 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 230.375792
-The maximum resident set size (KB)                   = 529416
+The total amount of wall time                        = 229.458297
+The maximum resident set size (KB)                   = 529472
 
 Test 022 regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_control_2dwrtdecomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_control_2dwrtdecomp
 Checking test 023 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -731,14 +731,14 @@ Checking test 023 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 369.341493
-The maximum resident set size (KB)                   = 534456
+The total amount of wall time                        = 373.385326
+The maximum resident set size (KB)                   = 534540
 
 Test 023 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_noquilt
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_noquilt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_noquilt
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_noquilt
 Checking test 024 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -746,28 +746,28 @@ Checking test 024 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 408.795725
-The maximum resident set size (KB)                   = 536536
+The total amount of wall time                        = 408.399211
+The maximum resident set size (KB)                   = 536600
 
 Test 024 regional_noquilt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_netcdf_parallel
 Checking test 025 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 384.383752
-The maximum resident set size (KB)                   = 527756
+The total amount of wall time                        = 364.916852
+The maximum resident set size (KB)                   = 527808
 
 Test 025 regional_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_3km
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_3km
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_3km
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_3km
 Checking test 026 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -778,14 +778,14 @@ Checking test 026 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 321.997564
-The maximum resident set size (KB)                   = 557960
+The total amount of wall time                        = 307.515360
+The maximum resident set size (KB)                   = 557996
 
 Test 026 regional_3km PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_control
 Checking test 027 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -832,14 +832,14 @@ Checking test 027 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 478.757675
-The maximum resident set size (KB)                   = 793496
+The total amount of wall time                        = 460.965723
+The maximum resident set size (KB)                   = 793376
 
 Test 027 rap_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_rrtmgp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_rrtmgp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_rrtmgp
 Checking test 028 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -886,14 +886,14 @@ Checking test 028 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 508.713294
-The maximum resident set size (KB)                   = 908836
+The total amount of wall time                        = 505.838238
+The maximum resident set size (KB)                   = 908712
 
 Test 028 rap_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/regional_spp_sppt_shum_skeb
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_spp_sppt_shum_skeb
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/regional_spp_sppt_shum_skeb
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_spp_sppt_shum_skeb
 Checking test 029 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -904,14 +904,14 @@ Checking test 029 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 369.103009
-The maximum resident set size (KB)                   = 876744
+The total amount of wall time                        = 355.540454
+The maximum resident set size (KB)                   = 859444
 
 Test 029 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_restart
 Checking test 030 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -950,14 +950,14 @@ Checking test 030 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.951458
-The maximum resident set size (KB)                   = 532552
+The total amount of wall time                        = 252.731803
+The maximum resident set size (KB)                   = 532600
 
 Test 030 rap_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_sfcdiff
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_sfcdiff
 Checking test 031 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1004,14 +1004,14 @@ Checking test 031 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 480.769629
-The maximum resident set size (KB)                   = 790592
+The total amount of wall time                        = 469.420477
+The maximum resident set size (KB)                   = 790552
 
 Test 031 rap_sfcdiff PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_sfcdiff_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_sfcdiff_restart
 Checking test 032 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1050,14 +1050,14 @@ Checking test 032 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.562870
-The maximum resident set size (KB)                   = 532556
+The total amount of wall time                        = 244.926004
+The maximum resident set size (KB)                   = 532540
 
 Test 032 rap_sfcdiff_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hrrr_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hrrr_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hrrr_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hrrr_control
 Checking test 033 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1104,14 +1104,14 @@ Checking test 033 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 450.413117
-The maximum resident set size (KB)                   = 788212
+The total amount of wall time                        = 448.893526
+The maximum resident set size (KB)                   = 788208
 
 Test 033 hrrr_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_v1beta
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_v1beta
 Checking test 034 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1158,14 +1158,14 @@ Checking test 034 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 449.176625
-The maximum resident set size (KB)                   = 784400
+The total amount of wall time                        = 453.571327
+The maximum resident set size (KB)                   = 784312
 
 Test 034 rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1nssl
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_v1nssl
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1nssl
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_v1nssl
 Checking test 035 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1180,14 +1180,14 @@ Checking test 035 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 507.228213
-The maximum resident set size (KB)                   = 475096
+The total amount of wall time                        = 504.246499
+The maximum resident set size (KB)                   = 475044
 
 Test 035 rrfs_v1nssl PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1nssl_nohailnoccn
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_v1nssl_nohailnoccn
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1nssl_nohailnoccn
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_v1nssl_nohailnoccn
 Checking test 036 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1202,14 +1202,14 @@ Checking test 036 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 490.985418
-The maximum resident set size (KB)                   = 468116
+The total amount of wall time                        = 493.944070
+The maximum resident set size (KB)                   = 468136
 
 Test 036 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_conus13km_hrrr_warm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_conus13km_hrrr_warm
 Checking test 037 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 037 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 273.540976
-The maximum resident set size (KB)                   = 602184
+The total amount of wall time                        = 274.506713
+The maximum resident set size (KB)                   = 602108
 
 Test 037 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_conus13km_radar_tten_warm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_conus13km_radar_tten_warm
 Checking test 038 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1234,14 +1234,14 @@ Checking test 038 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 296.024802
-The maximum resident set size (KB)                   = 604264
+The total amount of wall time                        = 281.923286
+The maximum resident set size (KB)                   = 603996
 
 Test 038 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_smoke_conus13km_hrrr_warm
 Checking test 039 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1250,14 +1250,14 @@ Checking test 039 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 294.731612
-The maximum resident set size (KB)                   = 613928
+The total amount of wall time                        = 284.699469
+The maximum resident set size (KB)                   = 613852
 
 Test 039 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmg
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_csawmg
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmg
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_csawmg
 Checking test 040 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1268,14 +1268,14 @@ Checking test 040 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 370.671466
-The maximum resident set size (KB)                   = 488964
+The total amount of wall time                        = 372.224174
+The maximum resident set size (KB)                   = 489524
 
 Test 040 control_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_csawmgt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_csawmgt
 Checking test 041 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1286,14 +1286,14 @@ Checking test 041 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 366.389714
-The maximum resident set size (KB)                   = 488388
+The total amount of wall time                        = 359.603601
+The maximum resident set size (KB)                   = 488540
 
 Test 041 control_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_flake
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_flake
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_flake
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_flake
 Checking test 042 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1304,14 +1304,14 @@ Checking test 042 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 237.312149
-The maximum resident set size (KB)                   = 491812
+The total amount of wall time                        = 236.796055
+The maximum resident set size (KB)                   = 492044
 
 Test 042 control_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_ras
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_ras
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_ras
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_ras
 Checking test 043 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1322,40 +1322,40 @@ Checking test 043 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 196.453289
-The maximum resident set size (KB)                   = 454876
+The total amount of wall time                        = 199.135157
+The maximum resident set size (KB)                   = 454984
 
 Test 043 control_ras PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wam
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_wam
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wam
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_wam
 Checking test 044 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 115.193361
-The maximum resident set size (KB)                   = 169768
+The total amount of wall time                        = 114.923584
+The maximum resident set size (KB)                   = 169820
 
 Test 044 control_wam PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_debug
 Checking test 045 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 146.272253
-The maximum resident set size (KB)                   = 585400
+The total amount of wall time                        = 145.247504
+The maximum resident set size (KB)                   = 585396
 
 Test 045 control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_CubedSphereGrid_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_CubedSphereGrid_debug
 Checking test 046 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1382,415 +1382,415 @@ Checking test 046 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 156.344187
-The maximum resident set size (KB)                   = 584944
+The total amount of wall time                        = 154.504318
+The maximum resident set size (KB)                   = 584956
 
 Test 046 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_wrtGauss_netcdf_parallel_debug
 Checking test 047 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 146.223602
-The maximum resident set size (KB)                   = 585464
+The total amount of wall time                        = 147.793591
+The maximum resident set size (KB)                   = 585404
 
 Test 047 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_stochy_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_stochy_debug
 Checking test 048 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.411999
-The maximum resident set size (KB)                   = 591012
+The total amount of wall time                        = 165.731130
+The maximum resident set size (KB)                   = 591908
 
 Test 048 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_lndp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_lndp_debug
 Checking test 049 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 149.797667
-The maximum resident set size (KB)                   = 588740
+The total amount of wall time                        = 149.185689
+The maximum resident set size (KB)                   = 588800
 
 Test 049 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_csawmg_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_csawmg_debug
 Checking test 050 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 233.376243
-The maximum resident set size (KB)                   = 628124
+The total amount of wall time                        = 235.211196
+The maximum resident set size (KB)                   = 628152
 
 Test 050 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_csawmgt_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_csawmgt_debug
 Checking test 051 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 235.049591
-The maximum resident set size (KB)                   = 625660
+The total amount of wall time                        = 230.500687
+The maximum resident set size (KB)                   = 625560
 
 Test 051 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_ras_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_ras_debug
 Checking test 052 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 151.997182
-The maximum resident set size (KB)                   = 597140
+The total amount of wall time                        = 151.693550
+The maximum resident set size (KB)                   = 597164
 
 Test 052 control_ras_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_diag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_diag_debug
 Checking test 053 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 155.307549
-The maximum resident set size (KB)                   = 644432
+The total amount of wall time                        = 156.378185
+The maximum resident set size (KB)                   = 644160
 
 Test 053 control_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_debug_p8
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_debug_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_debug_p8
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_debug_p8
 Checking test 054 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.752885
-The maximum resident set size (KB)                   = 974052
+The total amount of wall time                        = 167.417109
+The maximum resident set size (KB)                   = 974036
 
 Test 054 control_debug_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_thompson_debug
 Checking test 055 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.720548
-The maximum resident set size (KB)                   = 944736
+The total amount of wall time                        = 177.528224
+The maximum resident set size (KB)                   = 946528
 
 Test 055 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_thompson_no_aero_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_thompson_no_aero_debug
 Checking test 056 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.801066
-The maximum resident set size (KB)                   = 941136
+The total amount of wall time                        = 167.110759
+The maximum resident set size (KB)                   = 941060
 
 Test 056 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_thompson_extdiag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_debug_extdiag
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_thompson_extdiag_debug
 Checking test 057 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 191.927829
-The maximum resident set size (KB)                   = 973212
+The total amount of wall time                        = 185.484231
+The maximum resident set size (KB)                   = 973028
 
 Test 057 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_thompson_progcld_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_thompson_progcld_thompson_debug
 Checking test 058 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 191.201633
-The maximum resident set size (KB)                   = 946596
+The total amount of wall time                        = 178.858291
+The maximum resident set size (KB)                   = 946508
 
 Test 058 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/regional_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/regional_debug
 Checking test 059 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 259.116540
-The maximum resident set size (KB)                   = 556852
+The total amount of wall time                        = 252.209037
+The maximum resident set size (KB)                   = 556824
 
 Test 059 regional_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_control_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_control_debug
 Checking test 060 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 274.484249
-The maximum resident set size (KB)                   = 953120
+The total amount of wall time                        = 273.080535
+The maximum resident set size (KB)                   = 952972
 
 Test 060 rap_control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_unified_drag_suite_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_unified_drag_suite_debug
 Checking test 061 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 281.216274
-The maximum resident set size (KB)                   = 953040
+The total amount of wall time                        = 273.267151
+The maximum resident set size (KB)                   = 953144
 
 Test 061 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_diag_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_diag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_diag_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_diag_debug
 Checking test 062 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.420912
-The maximum resident set size (KB)                   = 1035624
+The total amount of wall time                        = 295.499900
+The maximum resident set size (KB)                   = 1035496
 
 Test 062 rap_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_cires_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_cires_ugwp_debug
 Checking test 063 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 282.429200
-The maximum resident set size (KB)                   = 954912
+The total amount of wall time                        = 284.369173
+The maximum resident set size (KB)                   = 954844
 
 Test 063 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_unified_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_unified_ugwp_debug
 Checking test 064 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 280.743786
-The maximum resident set size (KB)                   = 953160
+The total amount of wall time                        = 280.473529
+The maximum resident set size (KB)                   = 953112
 
 Test 064 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_lndp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_lndp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_lndp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_lndp_debug
 Checking test 065 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 280.093415
-The maximum resident set size (KB)                   = 954120
+The total amount of wall time                        = 275.305067
+The maximum resident set size (KB)                   = 953996
 
 Test 065 rap_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_flake_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_flake_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_flake_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_flake_debug
 Checking test 066 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 274.179845
-The maximum resident set size (KB)                   = 953136
+The total amount of wall time                        = 272.265257
+The maximum resident set size (KB)                   = 953084
 
 Test 066 rap_flake_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_progcld_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_progcld_thompson_debug
 Checking test 067 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 276.960859
-The maximum resident set size (KB)                   = 953116
+The total amount of wall time                        = 272.530079
+The maximum resident set size (KB)                   = 953084
 
 Test 067 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_noah_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_noah_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_noah_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_noah_debug
 Checking test 068 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 269.432012
-The maximum resident set size (KB)                   = 951384
+The total amount of wall time                        = 267.276216
+The maximum resident set size (KB)                   = 951380
 
 Test 068 rap_noah_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_rrtmgp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_rrtmgp_debug
 Checking test 069 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 457.811718
-The maximum resident set size (KB)                   = 1074204
+The total amount of wall time                        = 452.409736
+The maximum resident set size (KB)                   = 1074200
 
 Test 069 rap_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_sfcdiff_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_sfcdiff_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_sfcdiff_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_sfcdiff_debug
 Checking test 070 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 274.487782
-The maximum resident set size (KB)                   = 953180
+The total amount of wall time                        = 275.977598
+The maximum resident set size (KB)                   = 953224
 
 Test 070 rap_sfcdiff_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 071 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 446.800644
-The maximum resident set size (KB)                   = 956352
+The total amount of wall time                        = 444.132505
+The maximum resident set size (KB)                   = 956444
 
 Test 071 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/rrfs_v1beta_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/rrfs_v1beta_debug
 Checking test 072 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 269.000960
-The maximum resident set size (KB)                   = 950356
+The total amount of wall time                        = 267.596624
+The maximum resident set size (KB)                   = 950428
 
 Test 072 rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wam_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/control_wam_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wam_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/control_wam_debug
 Checking test 073 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 278.482205
-The maximum resident set size (KB)                   = 199612
+The total amount of wall time                        = 276.508811
+The maximum resident set size (KB)                   = 199532
 
 Test 073 control_wam_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_atm
 Checking test 074 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 420.720203
-The maximum resident set size (KB)                   = 650612
+The total amount of wall time                        = 405.420074
+The maximum resident set size (KB)                   = 647592
 
 Test 074 hafs_regional_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_atm_thompson_gfdlsf
 Checking test 075 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 487.963164
-The maximum resident set size (KB)                   = 1001268
+The total amount of wall time                        = 485.675791
+The maximum resident set size (KB)                   = 1001116
 
 Test 075 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_ocn
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_atm_ocn
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_ocn
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_atm_ocn
 Checking test 076 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 076 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 604.734026
-The maximum resident set size (KB)                   = 670448
+The total amount of wall time                        = 602.675551
+The maximum resident set size (KB)                   = 670516
 
 Test 076 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_wav
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_atm_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_wav
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_atm_wav
 Checking test 077 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1815,14 +1815,14 @@ Checking test 077 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 1049.882636
-The maximum resident set size (KB)                   = 697712
+The total amount of wall time                        = 1001.647146
+The maximum resident set size (KB)                   = 698064
 
 Test 077 hafs_regional_atm_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_atm_ocn_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_atm_ocn_wav
 Checking test 078 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1833,28 +1833,28 @@ Checking test 078 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 1082.535071
-The maximum resident set size (KB)                   = 707508
+The total amount of wall time                        = 1134.910198
+The maximum resident set size (KB)                   = 708060
 
 Test 078 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_1nest_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_1nest_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_1nest_atm
 Checking test 079 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 409.141030
-The maximum resident set size (KB)                   = 247036
+The total amount of wall time                        = 403.463132
+The maximum resident set size (KB)                   = 247336
 
 Test 079 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_telescopic_2nests_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_telescopic_2nests_atm
 Checking test 080 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1863,56 +1863,56 @@ Checking test 080 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 466.369021
-The maximum resident set size (KB)                   = 251196
+The total amount of wall time                        = 458.202563
+The maximum resident set size (KB)                   = 250580
 
 Test 080 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_global_1nest_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_global_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_global_1nest_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_global_1nest_atm
 Checking test 081 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 181.031040
-The maximum resident set size (KB)                   = 148296
+The total amount of wall time                        = 177.901006
+The maximum resident set size (KB)                   = 148132
 
 Test 081 hafs_global_1nest_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_specified_moving_1nest_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_specified_moving_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_specified_moving_1nest_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_specified_moving_1nest_atm
 Checking test 082 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 256.852697
-The maximum resident set size (KB)                   = 254640
+The total amount of wall time                        = 252.902321
+The maximum resident set size (KB)                   = 254328
 
 Test 082 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_storm_following_1nest_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_storm_following_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_storm_following_1nest_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_storm_following_1nest_atm
 Checking test 083 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 245.282252
-The maximum resident set size (KB)                   = 252736
+The total amount of wall time                        = 240.717945
+The maximum resident set size (KB)                   = 254344
 
 Test 083 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 084 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1921,14 +1921,14 @@ Checking test 084 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 289.569896
-The maximum resident set size (KB)                   = 280220
+The total amount of wall time                        = 298.767901
+The maximum resident set size (KB)                   = 280756
 
 Test 084 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 085 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1939,26 +1939,26 @@ Checking test 085 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 597.027461
-The maximum resident set size (KB)                   = 336876
+The total amount of wall time                        = 616.405571
+The maximum resident set size (KB)                   = 336064
 
 Test 085 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_global_storm_following_1nest_atm
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_46132/hafs_global_storm_following_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_global_storm_following_1nest_atm
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_21912/hafs_global_storm_following_1nest_atm
 Checking test 086 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 70.962953
-The maximum resident set size (KB)                   = 166600
+The total amount of wall time                        = 69.580473
+The maximum resident set size (KB)                   = 166584
 
 Test 086 hafs_global_storm_following_1nest_atm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Jun 12 15:23:25 UTC 2022
-Elapsed time: 00h:47m:47s. Have a nice day!
+Mon Jun 13 23:27:34 UTC 2022
+Elapsed time: 01h:15m:18s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,26 +1,26 @@
-Sun Jun 12 14:35:20 UTC 2022
+Mon Jun 13 22:21:08 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 2312 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 665 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1642 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 1163 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1332 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1244 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 919 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 450 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 353 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 372 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 282 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 1798 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1777 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 819 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 293 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 1520 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 1071 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 2406 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 678 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1667 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 1156 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1363 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1238 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 907 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 448 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 362 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 375 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 298 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 1802 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 1783 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 813 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 325 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 1545 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 1060 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_control_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -85,14 +85,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 448.412658
-[0] The maximum resident set size (KB)                   = 1471080
+[0] The total amount of wall time                        = 444.789524
+[0] The maximum resident set size (KB)                   = 1470936
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_restart_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -145,14 +145,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 270.925715
-[0] The maximum resident set size (KB)                   = 1434816
+[0] The total amount of wall time                        = 266.588848
+[0] The maximum resident set size (KB)                   = 1437056
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_2threads_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -205,14 +205,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 491.790003
-[0] The maximum resident set size (KB)                   = 2207964
+[0] The total amount of wall time                        = 493.447623
+[0] The maximum resident set size (KB)                   = 2210764
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_decomp_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_decomp_p8
 Checking test 004 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -265,14 +265,14 @@ Checking test 004 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 446.333457
-[0] The maximum resident set size (KB)                   = 1634992
+[0] The total amount of wall time                        = 443.902604
+[0] The maximum resident set size (KB)                   = 1633728
 
 Test 004 cpld_decomp_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_mpi_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_mpi_p8
 Checking test 005 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 372.105362
-[0] The maximum resident set size (KB)                   = 1277820
+[0] The total amount of wall time                        = 374.536708
+[0] The maximum resident set size (KB)                   = 1273688
 
 Test 005 cpld_mpi_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_control_c192_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_c192_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_control_c192_p8
 Checking test 006 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -385,14 +385,14 @@ Checking test 006 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 774.997440
-[0] The maximum resident set size (KB)                   = 1750456
+[0] The total amount of wall time                        = 782.424136
+[0] The maximum resident set size (KB)                   = 1750256
 
 Test 006 cpld_control_c192_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_restart_c192_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_c192_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_restart_c192_p8
 Checking test 007 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -445,14 +445,14 @@ Checking test 007 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 461.163091
-[0] The maximum resident set size (KB)                   = 1705716
+[0] The total amount of wall time                        = 464.523238
+[0] The maximum resident set size (KB)                   = 1714064
 
 Test 007 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_bmark_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_bmark_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_bmark_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_bmark_p8
 Checking test 008 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -498,14 +498,14 @@ Checking test 008 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 1359.797957
-[0] The maximum resident set size (KB)                   = 2578036
+[0] The total amount of wall time                        = 1329.143801
+[0] The maximum resident set size (KB)                   = 2582320
 
 Test 008 cpld_bmark_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_bmark_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_restart_bmark_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_bmark_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_restart_bmark_p8
 Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -551,14 +551,14 @@ Checking test 009 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 868.283438
-[0] The maximum resident set size (KB)                   = 2575288
+[0] The total amount of wall time                        = 893.866844
+[0] The maximum resident set size (KB)                   = 2576096
 
 Test 009 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_debug_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_debug_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_debug_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -611,14 +611,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-[0] The total amount of wall time                        = 871.875357
-[0] The maximum resident set size (KB)                   = 1536876
+[0] The total amount of wall time                        = 873.184891
+[0] The maximum resident set size (KB)                   = 1536628
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/cpld_control_noaero_p8_agrid
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/cpld_control_noaero_p8_agrid
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/cpld_control_noaero_p8_agrid
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/cpld_control_noaero_p8_agrid
 Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -680,14 +680,14 @@ Checking test 011 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 326.073173
-[0] The maximum resident set size (KB)                   = 986612
+[0] The total amount of wall time                        = 328.364715
+[0] The maximum resident set size (KB)                   = 985592
 
 Test 011 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control
 Checking test 012 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -734,14 +734,14 @@ Checking test 012 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 151.734685
-[0] The maximum resident set size (KB)                   = 463700
+[0] The total amount of wall time                        = 150.751472
+[0] The maximum resident set size (KB)                   = 469288
 
 Test 012 control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_decomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_decomp
 Checking test 013 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -784,14 +784,14 @@ Checking test 013 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 155.947392
-[0] The maximum resident set size (KB)                   = 466080
+[0] The total amount of wall time                        = 157.087164
+[0] The maximum resident set size (KB)                   = 464800
 
 Test 013 control_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_2dwrtdecomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_2dwrtdecomp
 Checking test 014 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -802,14 +802,14 @@ Checking test 014 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 143.543859
-[0] The maximum resident set size (KB)                   = 463236
+[0] The total amount of wall time                        = 146.471340
+[0] The maximum resident set size (KB)                   = 467828
 
 Test 014 control_2dwrtdecomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_2threads
 Checking test 015 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -852,14 +852,14 @@ Checking test 015 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 136.942297
-[0] The maximum resident set size (KB)                   = 520236
+[0] The total amount of wall time                        = 136.812153
+[0] The maximum resident set size (KB)                   = 518288
 
 Test 015 control_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_restart
 Checking test 016 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -898,14 +898,14 @@ Checking test 016 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 76.400472
-[0] The maximum resident set size (KB)                   = 212852
+[0] The total amount of wall time                        = 80.883824
+[0] The maximum resident set size (KB)                   = 208376
 
 Test 016 control_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_fhzero
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_fhzero
 Checking test 017 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -948,14 +948,14 @@ Checking test 017 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 144.744136
-[0] The maximum resident set size (KB)                   = 466536
+[0] The total amount of wall time                        = 142.388224
+[0] The maximum resident set size (KB)                   = 467924
 
 Test 017 control_fhzero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_CubedSphereGrid
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -982,14 +982,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 144.603906
-[0] The maximum resident set size (KB)                   = 460760
+[0] The total amount of wall time                        = 144.948328
+[0] The maximum resident set size (KB)                   = 466620
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_latlon
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_latlon
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_latlon
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1000,14 +1000,14 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 144.422405
-[0] The maximum resident set size (KB)                   = 466068
+[0] The total amount of wall time                        = 143.695431
+[0] The maximum resident set size (KB)                   = 464964
 
 Test 019 control_latlon PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1018,14 +1018,14 @@ Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 151.862741
-[0] The maximum resident set size (KB)                   = 466464
+[0] The total amount of wall time                        = 151.216682
+[0] The maximum resident set size (KB)                   = 465712
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c48
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_c48
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c48
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1064,14 +1064,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 448.895600
-[0] The maximum resident set size (KB)                   = 669352
+[0] The total amount of wall time                        = 451.081855
+[0] The maximum resident set size (KB)                   = 664992
 
 Test 021 control_c48 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c192
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c192
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 574.742156
-[0] The maximum resident set size (KB)                   = 564288
+[0] The total amount of wall time                        = 570.858749
+[0] The maximum resident set size (KB)                   = 567376
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c384
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c384
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1100,14 +1100,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 561.711513
-[0] The maximum resident set size (KB)                   = 838580
+[0] The total amount of wall time                        = 570.676276
+[0] The maximum resident set size (KB)                   = 839472
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_c384gdas
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 567.306493
-[0] The maximum resident set size (KB)                   = 986496
+[0] The total amount of wall time                        = 571.311098
+[0] The maximum resident set size (KB)                   = 985268
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_c384_progsigma
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_c384_progsigma
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_c384_progsigma
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_c384_progsigma
 Checking test 025 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 025 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 573.559428
-[0] The maximum resident set size (KB)                   = 859612
+[0] The total amount of wall time                        = 591.821221
+[0] The maximum resident set size (KB)                   = 859284
 
 Test 025 control_c384_progsigma PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_stochy
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_stochy
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_stochy
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1186,28 +1186,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 98.191831
-[0] The maximum resident set size (KB)                   = 466672
+[0] The total amount of wall time                        = 96.144459
+[0] The maximum resident set size (KB)                   = 471540
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_stochy
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_stochy_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_stochy
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 52.993939
-[0] The maximum resident set size (KB)                   = 262964
+[0] The total amount of wall time                        = 54.742127
+[0] The maximum resident set size (KB)                   = 260388
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_lndp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_lndp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_lndp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,14 +1218,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 86.952755
-[0] The maximum resident set size (KB)                   = 473320
+[0] The total amount of wall time                        = 88.454106
+[0] The maximum resident set size (KB)                   = 469996
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_iovr4
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_iovr4
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_iovr4
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 151.985297
-[0] The maximum resident set size (KB)                   = 470164
+[0] The total amount of wall time                        = 147.037304
+[0] The maximum resident set size (KB)                   = 469612
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_iovr5
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_iovr5
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_iovr5
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 146.410340
-[0] The maximum resident set size (KB)                   = 465080
+[0] The total amount of wall time                        = 150.540023
+[0] The maximum resident set size (KB)                   = 463296
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1316,14 +1316,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 188.713509
-[0] The maximum resident set size (KB)                   = 845756
+[0] The total amount of wall time                        = 198.964547
+[0] The maximum resident set size (KB)                   = 846952
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8_lndp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_p8_lndp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8_lndp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-[0] The total amount of wall time                        = 364.768228
-[0] The maximum resident set size (KB)                   = 853504
+[0] The total amount of wall time                        = 370.804642
+[0] The maximum resident set size (KB)                   = 852800
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_restart_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1388,14 +1388,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 100.224743
-[0] The maximum resident set size (KB)                   = 600180
+[0] The total amount of wall time                        = 99.213058
+[0] The maximum resident set size (KB)                   = 598828
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_decomp_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1438,14 +1438,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 195.406466
-[0] The maximum resident set size (KB)                   = 841392
+[0] The total amount of wall time                        = 201.386430
+[0] The maximum resident set size (KB)                   = 842816
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_2threads_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 177.108445
-[0] The maximum resident set size (KB)                   = 922720
+[0] The total amount of wall time                        = 181.970096
+[0] The maximum resident set size (KB)                   = 920132
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_p8_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_p8_rrtmgp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_p8_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1542,14 +1542,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 229.139816
-[0] The maximum resident set size (KB)                   = 965196
+[0] The total amount of wall time                        = 240.692891
+[0] The maximum resident set size (KB)                   = 965728
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1560,28 +1560,28 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 380.266951
-[0] The maximum resident set size (KB)                   = 582060
+[0] The total amount of wall time                        = 382.151231
+[0] The maximum resident set size (KB)                   = 582992
 
 Test 037 regional_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 207.484811
-[0] The maximum resident set size (KB)                   = 585324
+[0] The total amount of wall time                        = 203.282815
+[0] The maximum resident set size (KB)                   = 584880
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_control_2dwrtdecomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 378.858197
-[0] The maximum resident set size (KB)                   = 584660
+[0] The total amount of wall time                        = 382.748606
+[0] The maximum resident set size (KB)                   = 583928
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_noquilt
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_noquilt
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_noquilt
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 400.615650
-[0] The maximum resident set size (KB)                   = 613628
+[0] The total amount of wall time                        = 409.233074
+[0] The maximum resident set size (KB)                   = 614240
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,28 +1625,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 221.675013
-[0] The maximum resident set size (KB)                   = 584648
+[0] The total amount of wall time                        = 229.074301
+[0] The maximum resident set size (KB)                   = 583444
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 370.172553
-[0] The maximum resident set size (KB)                   = 583236
+[0] The total amount of wall time                        = 382.780295
+[0] The maximum resident set size (KB)                   = 581220
 
 Test 042 regional_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_3km
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_3km
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_3km
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-[0] The total amount of wall time                        = 313.011800
-[0] The maximum resident set size (KB)                   = 612688
+[0] The total amount of wall time                        = 321.210432
+[0] The maximum resident set size (KB)                   = 612664
 
 Test 043 regional_3km PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1711,14 +1711,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 465.649055
-[0] The maximum resident set size (KB)                   = 840844
+[0] The total amount of wall time                        = 476.430180
+[0] The maximum resident set size (KB)                   = 844132
 
 Test 044 rap_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_rrtmgp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1765,14 +1765,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 521.944757
-[0] The maximum resident set size (KB)                   = 951500
+[0] The total amount of wall time                        = 528.198928
+[0] The maximum resident set size (KB)                   = 953284
 
 Test 045 rap_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/regional_spp_sppt_shum_skeb
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_spp_sppt_shum_skeb
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/regional_spp_sppt_shum_skeb
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1783,14 +1783,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-[0] The total amount of wall time                        = 268.125140
-[0] The maximum resident set size (KB)                   = 941188
+[0] The total amount of wall time                        = 272.381875
+[0] The maximum resident set size (KB)                   = 935068
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_2threads
 Checking test 047 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1837,14 +1837,14 @@ Checking test 047 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 442.684394
-[0] The maximum resident set size (KB)                   = 906616
+[0] The total amount of wall time                        = 452.629467
+[0] The maximum resident set size (KB)                   = 908252
 
 Test 047 rap_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_restart
 Checking test 048 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1883,14 +1883,14 @@ Checking test 048 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 243.173650
-[0] The maximum resident set size (KB)                   = 588304
+[0] The total amount of wall time                        = 239.957503
+[0] The maximum resident set size (KB)                   = 591624
 
 Test 048 rap_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_sfcdiff
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_sfcdiff
 Checking test 049 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1937,14 +1937,14 @@ Checking test 049 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 469.173962
-[0] The maximum resident set size (KB)                   = 841276
+[0] The total amount of wall time                        = 469.337130
+[0] The maximum resident set size (KB)                   = 842144
 
 Test 049 rap_sfcdiff PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_sfcdiff_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1983,14 +1983,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 243.717170
-[0] The maximum resident set size (KB)                   = 592708
+[0] The total amount of wall time                        = 236.301939
+[0] The maximum resident set size (KB)                   = 593932
 
 Test 050 rap_sfcdiff_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hrrr_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hrrr_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hrrr_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 448.000795
-[0] The maximum resident set size (KB)                   = 843760
+[0] The total amount of wall time                        = 463.239778
+[0] The maximum resident set size (KB)                   = 839520
 
 Test 051 hrrr_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_v1beta
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 464.645283
-[0] The maximum resident set size (KB)                   = 833684
+[0] The total amount of wall time                        = 466.654089
+[0] The maximum resident set size (KB)                   = 829936
 
 Test 052 rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1nssl
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_v1nssl
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1nssl
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2113,14 +2113,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 537.324007
-[0] The maximum resident set size (KB)                   = 527564
+[0] The total amount of wall time                        = 542.360799
+[0] The maximum resident set size (KB)                   = 526172
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1nssl_nohailnoccn
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_v1nssl_nohailnoccn
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1nssl_nohailnoccn
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2135,14 +2135,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 517.430795
-[0] The maximum resident set size (KB)                   = 516232
+[0] The total amount of wall time                        = 518.499017
+[0] The maximum resident set size (KB)                   = 518184
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_conus13km_hrrr_warm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2151,14 +2151,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 202.272932
-[0] The maximum resident set size (KB)                   = 666484
+[0] The total amount of wall time                        = 203.047755
+[0] The maximum resident set size (KB)                   = 664284
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_conus13km_radar_tten_warm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 200.460691
-[0] The maximum resident set size (KB)                   = 668940
+[0] The total amount of wall time                        = 206.223867
+[0] The maximum resident set size (KB)                   = 669488
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2183,14 +2183,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 216.189965
-[0] The maximum resident set size (KB)                   = 684312
+[0] The total amount of wall time                        = 221.980691
+[0] The maximum resident set size (KB)                   = 688312
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_csawmg
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 382.887821
-[0] The maximum resident set size (KB)                   = 526812
+[0] The total amount of wall time                        = 369.836426
+[0] The maximum resident set size (KB)                   = 528412
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_csawmgt
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 378.875011
-[0] The maximum resident set size (KB)                   = 523716
+[0] The total amount of wall time                        = 376.495200
+[0] The maximum resident set size (KB)                   = 526700
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_flake
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_flake
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_flake
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2237,14 +2237,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 259.140191
-[0] The maximum resident set size (KB)                   = 536244
+[0] The total amount of wall time                        = 259.382018
+[0] The maximum resident set size (KB)                   = 538700
 
 Test 060 control_flake PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_ras
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_ras
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_ras
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2255,14 +2255,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 200.968778
-[0] The maximum resident set size (KB)                   = 497912
+[0] The total amount of wall time                        = 196.300132
+[0] The maximum resident set size (KB)                   = 495408
 
 Test 061 control_ras PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2273,14 +2273,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 265.154929
-[0] The maximum resident set size (KB)                   = 853180
+[0] The total amount of wall time                        = 262.225361
+[0] The maximum resident set size (KB)                   = 852160
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_thompson_no_aero
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2291,42 +2291,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 256.727541
-[0] The maximum resident set size (KB)                   = 846028
+[0] The total amount of wall time                        = 253.837087
+[0] The maximum resident set size (KB)                   = 842264
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wam
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_wam
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wam
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_wam
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-[0] The total amount of wall time                        = 122.701713
-[0] The maximum resident set size (KB)                   = 234620
+[0] The total amount of wall time                        = 124.320948
+[0] The maximum resident set size (KB)                   = 231084
 
 Test 064 control_wam PASS
 
-Test 065 control_debug FAIL
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_debug
+Checking test 065 control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 166.908158
+[0] The maximum resident set size (KB)                   = 626200
+
+Test 065 control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_2threads_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 155.845461
-[0] The maximum resident set size (KB)                   = 681036
+[0] The total amount of wall time                        = 156.296893
+[0] The maximum resident set size (KB)                   = 684744
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_CubedSphereGrid_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2353,403 +2365,410 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 181.323154
-[0] The maximum resident set size (KB)                   = 630820
+[0] The total amount of wall time                        = 181.273947
+[0] The maximum resident set size (KB)                   = 627468
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 169.889879
-[0] The maximum resident set size (KB)                   = 632256
+[0] The total amount of wall time                        = 170.457564
+[0] The maximum resident set size (KB)                   = 629764
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_stochy_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.286953
-[0] The maximum resident set size (KB)                   = 635132
+[0] The total amount of wall time                        = 191.114555
+[0] The maximum resident set size (KB)                   = 635472
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_lndp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 170.683504
-[0] The maximum resident set size (KB)                   = 634264
+[0] The total amount of wall time                        = 171.652048
+[0] The maximum resident set size (KB)                   = 633368
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_csawmg_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 268.217377
-[0] The maximum resident set size (KB)                   = 666720
+[0] The total amount of wall time                        = 268.090726
+[0] The maximum resident set size (KB)                   = 664124
 
 Test 071 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_csawmgt_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 263.664600
-[0] The maximum resident set size (KB)                   = 664152
+[0] The total amount of wall time                        = 264.497972
+[0] The maximum resident set size (KB)                   = 669684
 
 Test 072 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_ras_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 174.738696
-[0] The maximum resident set size (KB)                   = 639044
+[0] The total amount of wall time                        = 173.341521
+[0] The maximum resident set size (KB)                   = 640668
 
 Test 073 control_ras_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_diag_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 176.159499
-[0] The maximum resident set size (KB)                   = 684416
+[0] The total amount of wall time                        = 175.480594
+[0] The maximum resident set size (KB)                   = 689844
 
 Test 074 control_diag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_debug_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_debug_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_debug_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 190.446714
-[0] The maximum resident set size (KB)                   = 1011008
+[0] The total amount of wall time                        = 190.463786
+[0] The maximum resident set size (KB)                   = 1007312
 
 Test 075 control_debug_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 197.150826
-[0] The maximum resident set size (KB)                   = 991252
+[0] The total amount of wall time                        = 197.439576
+[0] The maximum resident set size (KB)                   = 992100
 
 Test 076 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_thompson_no_aero_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 190.609963
-[0] The maximum resident set size (KB)                   = 983488
-
-Test 077 control_thompson_no_aero_debug PASS
+ Comparing sfcf000.nc ............MISSING file
+ Comparing sfcf001.nc ............MISSING file
+ Comparing atmf000.nc ............MISSING file
+ Comparing atmf001.nc ............MISSING file
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_thompson_extdiag_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_debug_extdiag
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 207.078230
-[0] The maximum resident set size (KB)                   = 1019256
+[0] The total amount of wall time                        = 207.812970
+[0] The maximum resident set size (KB)                   = 1017448
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_thompson_progcld_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 197.659339
-[0] The maximum resident set size (KB)                   = 991464
+[0] The total amount of wall time                        = 197.003232
+[0] The maximum resident set size (KB)                   = 991080
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/fv3_regional_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/regional_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/fv3_regional_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-[0] The total amount of wall time                        = 282.585395
-[0] The maximum resident set size (KB)                   = 608652
+[0] The total amount of wall time                        = 283.154722
+[0] The maximum resident set size (KB)                   = 605504
 
 Test 080 regional_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_control_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 306.050199
-[0] The maximum resident set size (KB)                   = 1001592
+[0] The total amount of wall time                        = 306.467760
+[0] The maximum resident set size (KB)                   = 995692
 
 Test 081 rap_control_debug PASS
 
-Test 082 rap_unified_drag_suite_debug FAIL
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_unified_drag_suite_debug
+Checking test 082 rap_unified_drag_suite_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 306.854960
+[0] The maximum resident set size (KB)                   = 1000848
+
+Test 082 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_diag_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_diag_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_diag_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 321.392703
-[0] The maximum resident set size (KB)                   = 1084100
+[0] The total amount of wall time                        = 321.815848
+[0] The maximum resident set size (KB)                   = 1080532
 
 Test 083 rap_diag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_cires_ugwp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 312.454686
-[0] The maximum resident set size (KB)                   = 997772
+[0] The total amount of wall time                        = 312.666083
+[0] The maximum resident set size (KB)                   = 1000332
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_unified_ugwp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 313.157944
-[0] The maximum resident set size (KB)                   = 999692
+[0] The total amount of wall time                        = 313.312480
+[0] The maximum resident set size (KB)                   = 996300
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_lndp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 308.207162
-[0] The maximum resident set size (KB)                   = 1005760
+[0] The total amount of wall time                        = 309.484015
+[0] The maximum resident set size (KB)                   = 1003996
 
 Test 086 rap_lndp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_flake_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_flake_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_flake_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_flake_debug
 Checking test 087 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 305.437895
-[0] The maximum resident set size (KB)                   = 1000416
+[0] The total amount of wall time                        = 306.945592
+[0] The maximum resident set size (KB)                   = 1001464
 
 Test 087 rap_flake_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_progcld_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_progcld_thompson_debug
 Checking test 088 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 306.252141
-[0] The maximum resident set size (KB)                   = 999060
+[0] The total amount of wall time                        = 307.164554
+[0] The maximum resident set size (KB)                   = 1001324
 
 Test 088 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_noah_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_noah_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_noah_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_noah_debug
 Checking test 089 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 302.164224
-[0] The maximum resident set size (KB)                   = 999192
+[0] The total amount of wall time                        = 303.018703
+[0] The maximum resident set size (KB)                   = 998880
 
 Test 089 rap_noah_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_rrtmgp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_rrtmgp_debug
 Checking test 090 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 519.438619
-[0] The maximum resident set size (KB)                   = 1117700
+[0] The total amount of wall time                        = 519.728909
+[0] The maximum resident set size (KB)                   = 1116256
 
 Test 090 rap_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_sfcdiff_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_sfcdiff_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_sfcdiff_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 306.455734
-[0] The maximum resident set size (KB)                   = 999280
+[0] The total amount of wall time                        = 306.558541
+[0] The maximum resident set size (KB)                   = 999200
 
 Test 091 rap_sfcdiff_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 509.382073
-[0] The maximum resident set size (KB)                   = 999676
+[0] The total amount of wall time                        = 508.375135
+[0] The maximum resident set size (KB)                   = 998428
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/rrfs_v1beta_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 304.454389
-[0] The maximum resident set size (KB)                   = 999284
+[0] The total amount of wall time                        = 305.774236
+[0] The maximum resident set size (KB)                   = 999576
 
 Test 093 rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_wam_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_wam_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_wam_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-[0] The total amount of wall time                        = 322.996911
-[0] The maximum resident set size (KB)                   = 252208
+[0] The total amount of wall time                        = 323.417402
+[0] The maximum resident set size (KB)                   = 255984
 
 Test 094 control_wam_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-[0] The total amount of wall time                        = 281.650724
-[0] The maximum resident set size (KB)                   = 706396
+[0] The total amount of wall time                        = 280.499745
+[0] The maximum resident set size (KB)                   = 708624
 
 Test 095 hafs_regional_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-[0] The total amount of wall time                        = 379.776498
-[0] The maximum resident set size (KB)                   = 1068276
+[0] The total amount of wall time                        = 377.831884
+[0] The maximum resident set size (KB)                   = 1069276
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_atm_ocn
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2758,14 +2777,14 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 434.471415
-[0] The maximum resident set size (KB)                   = 746248
+[0] The total amount of wall time                        = 433.268818
+[0] The maximum resident set size (KB)                   = 743592
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_wav
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_atm_wav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_wav
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2774,14 +2793,14 @@ Checking test 098 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 987.865361
-[0] The maximum resident set size (KB)                   = 779956
+[0] The total amount of wall time                        = 989.861853
+[0] The maximum resident set size (KB)                   = 777564
 
 Test 098 hafs_regional_atm_wav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_atm_ocn_wav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2792,16 +2811,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1095.827960
-[0] The maximum resident set size (KB)                   = 796148
+[0] The total amount of wall time                        = 1096.862004
+[0] The maximum resident set size (KB)                   = 790968
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
-Test 100 hafs_regional_1nest_atm FAIL
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_1nest_atm
+Checking test 100 hafs_regional_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+
+[0] The total amount of wall time                        = 416.018388
+[0] The maximum resident set size (KB)                   = 318256
+
+Test 100 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_telescopic_2nests_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2810,28 +2841,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-[0] The total amount of wall time                        = 467.379791
-[0] The maximum resident set size (KB)                   = 325188
+[0] The total amount of wall time                        = 464.593076
+[0] The maximum resident set size (KB)                   = 324572
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_global_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_global_1nest_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_global_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-[0] The total amount of wall time                        = 193.845454
-[0] The maximum resident set size (KB)                   = 207312
+[0] The total amount of wall time                        = 190.995046
+[0] The maximum resident set size (KB)                   = 207260
 
 Test 102 hafs_global_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_global_multiple_4nests_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_global_multiple_4nests_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_global_multiple_4nests_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2844,42 +2875,42 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-[0] The total amount of wall time                        = 570.117878
-[0] The maximum resident set size (KB)                   = 254184
+[0] The total amount of wall time                        = 568.131833
+[0] The maximum resident set size (KB)                   = 255392
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_specified_moving_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_specified_moving_1nest_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_specified_moving_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_specified_moving_1nest_atm
 Checking test 104 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-[0] The total amount of wall time                        = 253.549242
-[0] The maximum resident set size (KB)                   = 319976
+[0] The total amount of wall time                        = 252.905444
+[0] The maximum resident set size (KB)                   = 319140
 
 Test 104 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_storm_following_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_storm_following_1nest_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_storm_following_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_storm_following_1nest_atm
 Checking test 105 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-[0] The total amount of wall time                        = 240.208060
-[0] The maximum resident set size (KB)                   = 318268
+[0] The total amount of wall time                        = 239.186928
+[0] The maximum resident set size (KB)                   = 323844
 
 Test 105 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2888,14 +2919,14 @@ Checking test 106 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-[0] The total amount of wall time                        = 272.098612
-[0] The maximum resident set size (KB)                   = 348804
+[0] The total amount of wall time                        = 270.822514
+[0] The maximum resident set size (KB)                   = 343096
 
 Test 106 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2906,28 +2937,28 @@ Checking test 107 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 695.842555
-[0] The maximum resident set size (KB)                   = 411500
+[0] The total amount of wall time                        = 689.562882
+[0] The maximum resident set size (KB)                   = 413716
 
 Test 107 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_global_storm_following_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_global_storm_following_1nest_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_global_storm_following_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_global_storm_following_1nest_atm
 Checking test 108 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-[0] The total amount of wall time                        = 75.950336
-[0] The maximum resident set size (KB)                   = 223256
+[0] The total amount of wall time                        = 75.117155
+[0] The maximum resident set size (KB)                   = 223156
 
 Test 108 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_docn
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_docn
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_docn
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_docn
 Checking test 109 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2935,14 +2966,14 @@ Checking test 109 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 426.756567
-[0] The maximum resident set size (KB)                   = 768020
+[0] The total amount of wall time                        = 423.605498
+[0] The maximum resident set size (KB)                   = 766004
 
 Test 109 hafs_regional_docn PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_docn_oisst
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_docn_oisst
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_docn_oisst
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_docn_oisst
 Checking test 110 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2950,118 +2981,118 @@ Checking test 110 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 426.250821
-[0] The maximum resident set size (KB)                   = 741208
+[0] The total amount of wall time                        = 433.485556
+[0] The maximum resident set size (KB)                   = 745336
 
 Test 110 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_datm_cdeps
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/hafs_regional_datm_cdeps
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/hafs_regional_datm_cdeps
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/hafs_regional_datm_cdeps
 Checking test 111 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1089.071912
-[0] The maximum resident set size (KB)                   = 890960
+[0] The total amount of wall time                        = 1089.814382
+[0] The maximum resident set size (KB)                   = 889420
 
 Test 111 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_control_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_control_cfsr
 Checking test 112 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 176.214571
-[0] The maximum resident set size (KB)                   = 728144
+[0] The total amount of wall time                        = 174.444199
+[0] The maximum resident set size (KB)                   = 726660
 
 Test 112 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_restart_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_restart_cfsr
 Checking test 113 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 119.978835
-[0] The maximum resident set size (KB)                   = 746360
+[0] The total amount of wall time                        = 117.379745
+[0] The maximum resident set size (KB)                   = 747588
 
 Test 113 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_control_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_control_gefs
 Checking test 114 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.874500
-[0] The maximum resident set size (KB)                   = 629856
+[0] The total amount of wall time                        = 170.895287
+[0] The maximum resident set size (KB)                   = 628496
 
 Test 114 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_iau_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_iau_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_iau_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_iau_gefs
 Checking test 115 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 170.522763
-[0] The maximum resident set size (KB)                   = 631792
+[0] The total amount of wall time                        = 171.099599
+[0] The maximum resident set size (KB)                   = 629356
 
 Test 115 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_stochy_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_stochy_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_stochy_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_stochy_gefs
 Checking test 116 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.621483
-[0] The maximum resident set size (KB)                   = 628232
+[0] The total amount of wall time                        = 173.304864
+[0] The maximum resident set size (KB)                   = 626952
 
 Test 116 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_bulk_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_bulk_cfsr
 Checking test 117 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 175.003759
-[0] The maximum resident set size (KB)                   = 724868
+[0] The total amount of wall time                        = 173.580336
+[0] The maximum resident set size (KB)                   = 727912
 
 Test 117 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_bulk_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_bulk_gefs
 Checking test 118 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 168.311422
-[0] The maximum resident set size (KB)                   = 629872
+[0] The total amount of wall time                        = 167.511666
+[0] The maximum resident set size (KB)                   = 628420
 
 Test 118 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_mx025_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_mx025_cfsr
 Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3070,14 +3101,14 @@ Checking test 119 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 357.918364
-[0] The maximum resident set size (KB)                   = 558856
+[0] The total amount of wall time                        = 355.786067
+[0] The maximum resident set size (KB)                   = 557120
 
 Test 119 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_mx025_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_mx025_gefs
 Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3086,64 +3117,64 @@ Checking test 120 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 348.089738
-[0] The maximum resident set size (KB)                   = 545776
+[0] The total amount of wall time                        = 359.706873
+[0] The maximum resident set size (KB)                   = 545488
 
 Test 120 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_multiple_files_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_multiple_files_cfsr
 Checking test 121 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 174.163830
-[0] The maximum resident set size (KB)                   = 728036
+[0] The total amount of wall time                        = 174.182480
+[0] The maximum resident set size (KB)                   = 724432
 
 Test 121 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_3072x1536_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_3072x1536_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_3072x1536_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_3072x1536_cfsr
 Checking test 122 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 252.309140
-[0] The maximum resident set size (KB)                   = 1839512
+[0] The total amount of wall time                        = 252.964626
+[0] The maximum resident set size (KB)                   = 1839860
 
 Test 122 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_gfs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_gfs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_gfs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_gfs
 Checking test 123 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 252.852316
-[0] The maximum resident set size (KB)                   = 1837860
+[0] The total amount of wall time                        = 255.422861
+[0] The maximum resident set size (KB)                   = 1840100
 
 Test 123 datm_cdeps_gfs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/datm_cdeps_debug_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/datm_cdeps_debug_cfsr
 Checking test 124 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 504.438936
-[0] The maximum resident set size (KB)                   = 731968
+[0] The total amount of wall time                        = 501.704618
+[0] The maximum resident set size (KB)                   = 730272
 
 Test 124 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/control_atmwav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/control_atmwav
 Checking test 125 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3187,14 +3218,14 @@ Checking test 125 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 95.745158
-[0] The maximum resident set size (KB)                   = 477536
+[0] The total amount of wall time                        = 91.795123
+[0] The maximum resident set size (KB)                   = 477160
 
 Test 125 control_atmwav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/atmaero_control_p8
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_29371/atmaero_control_p8
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/atmaero_control_p8
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_25633/atmaero_control_p8
 Checking test 126 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3238,71 +3269,39 @@ Checking test 126 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 363.617902
-[0] The maximum resident set size (KB)                   = 1371100
+[0] The total amount of wall time                        = 358.555093
+[0] The maximum resident set size (KB)                   = 1372640
 
 Test 126 atmaero_control_p8 PASS
 
 FAILED TESTS: 
-Test control_debug 065 failed in run_test failed 
-Test rap_unified_drag_suite_debug 082 failed in run_test failed 
-Test hafs_regional_1nest_atm 100 failed in run_test failed 
+Test control_thompson_no_aero_debug 077 failed in run_test failed 
 
 REGRESSION TEST FAILED
-Sun Jun 12 17:16:52 UTC 2022
-Elapsed time: 02h:41m:34s. Have a nice day!
+Tue Jun 14 00:31:43 UTC 2022
+Elapsed time: 02h:10m:37s. Have a nice day!
 
 
 
-Sun Jun 12 18:05:08 UTC 2022
+Tue Jun 14 00:33:10 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 443 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 002 elapsed time 340 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 003 elapsed time 1794 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 450 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_12705/control_debug
-Checking test 001 control_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220613/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_6728/control_thompson_no_aero_debug
+Checking test 001 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 166.515896
-[0] The maximum resident set size (KB)                   = 630612
+[0] The total amount of wall time                        = 189.457479
+[0] The maximum resident set size (KB)                   = 987020
 
-Test 001 control_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_12705/rap_unified_drag_suite_debug
-Checking test 002 rap_unified_drag_suite_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 305.825922
-[0] The maximum resident set size (KB)                   = 1001920
-
-Test 002 rap_unified_drag_suite_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220601/hafs_regional_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_12705/hafs_regional_1nest_atm
-Checking test 003 hafs_regional_1nest_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
- Comparing sfc.nest02.f006.nc .........OK
-
-[0] The total amount of wall time                        = 415.112710
-[0] The maximum resident set size (KB)                   = 323228
-
-Test 003 hafs_regional_1nest_atm PASS
+Test 001 control_thompson_no_aero_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Jun 12 19:04:59 UTC 2022
-Elapsed time: 00h:59m:52s. Have a nice day!
+Tue Jun 14 00:46:54 UTC 2022
+Elapsed time: 00h:13m:49s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -485,7 +485,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20220601
+BL_DATE=20220613
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]] || [[ $MACHINE_ID = s4.* ]] || [[ $MACHINE_ID = wcoss2.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 else


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR are specified below.

- [x] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] ~~New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.~~

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsibility to keep the PR up-to-date with the develop branch of ufs-weather-model. 

## Description

Emergency bugfix for the MYNN surface layer scheme:

```
 TH1D(I)=T1D(I)**(100000./P1D(I))**ROVCP !(Theta, K)
```

The first `**` should be a `*`

```
 TH1D(I)=T1D(I)*(100000./P1D(I))**ROVCP !(Theta, K)
```

This will change the results of any configuration that uses the MYNN surface layer. @joeolson42 found and fixed this bug yesterday (June 9). His preliminary results show it will decrease the 2m temperature bias seen in some RRFS runs. He also expects it to fix the GFS parallel issues discussed in #1260.

### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/issues/941
https://github.com/ufs-community/ufs-weather-model/issues/1260

## Testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

Full regression test suite and more in NOAA-GSL fork with hera.intel, hera.gnu, and jet.intel.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss2.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

https://github.com/NOAA-EMC/fv3atm/pull/552
https://github.com/NCAR/ccpp-physics/pull/940

