### PR TITLE
removed dell/cray requirement due to decommission

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,8 +38,6 @@ How were these changes tested? What compilers / HPCs was it tested with? Are the
 - [ ] gaea.intel 
 - [ ] jet.intel
 - [ ] wcoss2.intel
-- [ ] wcoss_cray
-- [ ] wcoss_dell_p3
 - [ ] opnReqTest for newly added/changed feature
 - [ ] CI
 


### PR DESCRIPTION
# PR Checklist

- [*] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

## Description

Cleaning up PR template to remove dell and cray options due to decommission

### Issue(s) addressed

dell and cray is being decommissioned this week. so no need to run RTs and test requirement on dell and cray anymore

## Testing

N/A


## Dependencies

N/A