### PR TITLE
Bug fix for #1309: false reports of test failures

### DIFF
--- a/tests/run_compile.sh
+++ b/tests/run_compile.sh
@@ -26,9 +26,9 @@ write_fail_test() {
 remove_fail_test() {
     echo "Removing test failure flag file for compile_${COMPILE_NR}"
     if [[ ${OPNREQ_TEST} == true ]] ; then
-        rm -f $PATHRT/fail_opnreq_test_${COMPILE_NR}
+        rm -f $PATHRT/fail_opnreq_compile_${COMPILE_NR}
     else
-        rm -f $PATHRT/fail_test_${COMPILE_NR}
+        rm -f $PATHRT/fail_compile_${COMPILE_NR}
     fi
 }
 

--- a/tests/run_compile.sh
+++ b/tests/run_compile.sh
@@ -23,6 +23,15 @@ write_fail_test() {
   exit 1
 }
 
+remove_fail_test() {
+    echo "Removing test failure flag file for compile_${COMPILE_NR}"
+    if [[ ${OPNREQ_TEST} == true ]] ; then
+        rm -f $PATHRT/fail_opnreq_test_${COMPILE_NR}
+    else
+        rm -f $PATHRT/fail_test_${COMPILE_NR}
+    fi
+}
+
 if [[ $# != 4 ]]; then
   echo "Usage: $0 PATHRT RUNDIR_ROOT MAKE_OPT COMPILE_NR"
   exit 1
@@ -35,11 +44,7 @@ export COMPILE_NR=$4
 
 cd ${PATHRT}
 OPNREQ_TEST=${OPNREQ_TEST:-false}
-if [[ ${OPNREQ_TEST} == true ]]; then
-  rm -f fail_opnreq_compile_${COMPILE_NR}
-else
-  rm -f fail_compile_${COMPILE_NR}
-fi
+remove_fail_test
 
 [[ -e ${RUNDIR_ROOT}/compile_${COMPILE_NR}.env ]] && source ${RUNDIR_ROOT}/compile_${COMPILE_NR}.env
 source default_vars.sh
@@ -85,6 +90,9 @@ ls -l ${PATHTR}/tests/fv3_${COMPILE_NR}.exe
 
 cp ${RUNDIR}/compile_*_time.log ${LOG_DIR}
 cat ${RUNDIR}/job_timestamp.txt >> ${LOG_DIR}/job_${JOB_NR}_timestamp.txt
+
+remove_fail_test
+
 ################################################################################
 # End compile job
 ################################################################################

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -23,6 +23,15 @@ write_fail_test() {
   exit 1
 }
 
+remove_fail_test() {
+    echo "Removing test failure flag file for ${TEST_NAME} ${TEST_NR}"
+    if [[ ${OPNREQ_TEST} == true ]] ; then
+        rm -f $PATHRT/fail_opnreq_test_${TEST_NR}
+    else
+        rm -f $PATHRT/fail_test_${TEST_NR}
+    fi
+}
+
 function compute_petbounds() {
 
   # each test MUST define ${COMPONENT}_tasks variable for all components it is using
@@ -90,11 +99,7 @@ export COMPILE_NR=$5
 
 cd ${PATHRT}
 OPNREQ_TEST=${OPNREQ_TEST:-false}
-if [[ ${OPNREQ_TEST} == true ]]; then
-  rm -f fail_opnreq_test_${TEST_NR}
-else
-  rm -f fail_test_${TEST_NR}
-fi
+remove_fail_test
 
 [[ -e ${RUNDIR_ROOT}/run_test_${TEST_NR}.env ]] && source ${RUNDIR_ROOT}/run_test_${TEST_NR}.env
 source default_vars.sh
@@ -356,6 +361,9 @@ fi
 if [[ $SCHEDULER != 'none' ]]; then
   cat ${RUNDIR}/job_timestamp.txt >> ${LOG_DIR}/job_${JOB_NR}_timestamp.txt
 fi
+
+remove_fail_test
+
 ################################################################################
 # End test
 ################################################################################


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

## Description

Fixes a known issue in the regression test system which can cause successful tests to be reported as failing.

### Issue(s) addressed

fixes #1309

## Testing

Ran tests on Hera, causing jobs to fail in various ways and then succeed. The fix *seems* to work. I want to test on Jet once it's back since that system has had the most trouble.

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

None.
