### PR TITLE
Address ccpp-physics issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/dustinswales/fv3atm
+  branch = accumulated_cleanup
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/tests/control_rrtmgp
+++ b/tests/tests/control_rrtmgp
@@ -1,21 +1,57 @@
 ###############################################################################
 #
-#  Global control w/ RRTMGP test
+#  global control test: GFSv16 atmosphere only at C96L127 with RRTMGP radiation
 #
 ###############################################################################
 
-export TEST_DESCR="Compare global control w/ RRTMGP results with previous trunk version"
+export TEST_DESCR="Compare global control results with previous trunk version"
 
 export CNTL_DIR=control_rrtmgp
 
 export LIST_FILES="sfcf000.nc \
+                   sfcf021.nc \
                    sfcf024.nc \
                    atmf000.nc \
+                   atmf021.nc \
                    atmf024.nc \
                    GFSFLX.GrbF00 \
+                   GFSFLX.GrbF21 \
                    GFSFLX.GrbF24 \
                    GFSPRS.GrbF00 \
-                   GFSPRS.GrbF24"
+                   GFSPRS.GrbF21 \
+                   GFSPRS.GrbF24 \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
 
 export_fv3
 export NPZ=127
@@ -25,16 +61,20 @@ export SYEAR=2021
 export SMONTH=03
 export SDAY=22
 export SHOUR=06
+export RESTART_INTERVAL="12 -1"
 export OUTPUT_GRID='gaussian_grid'
 export NSTF_NAME='2,0,0,0,0'
 export WRITE_DOPOST=.true.
 export IAER=5111
+export IOVR=3
+export OUTPUT_FH='0 21 24'
+
 
 export FV3_RUN=control_run.IN
+export CCPP_SUITE=FV3_GFS_v16_RRTMGP
 export INPUT_NML=control.nml.IN
 
 # RRTMGP
-export CCPP_SUITE=FV3_GFS_v16_RRTMGP
 export DO_RRTMGP=.true.
 export DOGP_CLDOPTICS_LUT=.true.
 export DOGP_LWSCAT=.true.


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR
are specified below.

- [ ] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsibility to keep the PR up-to-date with the develop branch of ufs-weather-model.

## Description

This PR contains changes to GFS_typedefs.* to accommodate changes in [ccpp-physics:956](https://github.com/NCAR/ccpp-physics/pull/956). There are no changes to the results.

### Issue(s) addressed
- Remove all instances of physparam.f. [448](https://github.com/NCAR/ccpp-physics/issues/488)
- Bug in gcycle.F90. [672](https://github.com/NCAR/ccpp-physics/issues/672)
- Missing metadata hooks in gsl drag suite. [764](https://github.com/NCAR/ccpp-physics/issues/764)
- Fix file extension for pre-processor directives. (.f90->.F90). [886](https://github.com/NCAR/ccpp-physics/issues/886)
- Replace "stop" statements with CCPP error handling. [913](https://github.com/NCAR/ccpp-physics/issues/913)
Along with the physparam.f cleanup in #488, instances of physcons.f were removed for the touched subroutines, mostly the rrtmg radiation.

## Testing

Testes on Cheyenne with Intel. All RT's passed.
No changes to baselines.

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [x] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] acorn.intel
- [ ] opnReqTest for newly added/changed feature
- [ ] CI
