### PR TITLE
NCAR/main PR #66 (Bugfix and optimization of prognostic closure for the P8 physics suite)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/dustinswales/fv3atm
+  branch = ncar-main-PR967
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/dustinswales/fv3atm
-  branch = ncar-main-PR967
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,21 +1,21 @@
-Wed Oct  5 18:28:13 MDT 2022
+Mon Oct 10 08:53:28 MDT 2022
 Start Regression test
 
-Compile 001 elapsed time 406 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 855 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 213 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 390 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1086 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 851 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 855 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 684 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 578 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 372 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 309 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 391 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 403 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 825 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 199 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 370 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1046 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 839 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 836 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 651 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 570 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 379 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 306 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -62,14 +62,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 276.930708
-0:The maximum resident set size (KB)                   = 435352
+0:The total amount of wall time                        = 280.435452
+0:The maximum resident set size (KB)                   = 435452
 
 Test 001 control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -108,14 +108,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 138.044876
-0:The maximum resident set size (KB)                   = 185156
+0:The total amount of wall time                        = 141.160207
+0:The maximum resident set size (KB)                   = 185200
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_c48
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_c48
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -154,14 +154,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 816.496085
-0:The maximum resident set size (KB)                   = 676568
+0:The total amount of wall time                        = 816.246570
+0:The maximum resident set size (KB)                   = 676560
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -172,14 +172,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 180.779541
-0:The maximum resident set size (KB)                   = 430708
+0:The total amount of wall time                        = 175.738282
+0:The maximum resident set size (KB)                   = 429684
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_ras
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_ras
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_ras
 Checking test 005 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -190,14 +190,14 @@ Checking test 005 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 294.196129
-0:The maximum resident set size (KB)                   = 448116
+0:The total amount of wall time                        = 291.726096
+0:The maximum resident set size (KB)                   = 447996
 
 Test 005 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_p8
 Checking test 006 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -244,14 +244,14 @@ Checking test 006 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 311.359775
-0:The maximum resident set size (KB)                   = 1222408
+0:The total amount of wall time                        = 301.694332
+0:The maximum resident set size (KB)                   = 1222388
 
 Test 006 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_control
 Checking test 007 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -298,14 +298,14 @@ Checking test 007 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 705.860134
-0:The maximum resident set size (KB)                   = 776064
+0:The total amount of wall time                        = 714.583721
+0:The maximum resident set size (KB)                   = 776044
 
 Test 007 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_decomp
 Checking test 008 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 716.863115
+0:The total amount of wall time                        = 719.638872
 0:The maximum resident set size (KB)                   = 775464
 
 Test 008 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_2threads
 Checking test 009 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1248.643272
-0:The maximum resident set size (KB)                   = 842972
+0:The total amount of wall time                        = 1240.100426
+0:The maximum resident set size (KB)                   = 842936
 
 Test 009 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_restart
 Checking test 010 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -452,14 +452,14 @@ Checking test 010 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 353.310513
-0:The maximum resident set size (KB)                   = 523856
+0:The total amount of wall time                        = 354.149926
+0:The maximum resident set size (KB)                   = 523820
 
 Test 010 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_sfcdiff
 Checking test 011 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 703.229096
-0:The maximum resident set size (KB)                   = 776020
+0:The total amount of wall time                        = 714.153056
+0:The maximum resident set size (KB)                   = 775932
 
 Test 011 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_sfcdiff_decomp
 Checking test 012 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 718.979269
-0:The maximum resident set size (KB)                   = 775468
+0:The total amount of wall time                        = 740.684278
+0:The maximum resident set size (KB)                   = 775456
 
 Test 012 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_sfcdiff_restart
 Checking test 013 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -606,14 +606,14 @@ Checking test 013 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 524.875902
-0:The maximum resident set size (KB)                   = 523472
+0:The total amount of wall time                        = 528.009850
+0:The maximum resident set size (KB)                   = 523488
 
 Test 013 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control
 Checking test 014 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -660,14 +660,14 @@ Checking test 014 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 680.055650
-0:The maximum resident set size (KB)                   = 773516
+0:The total amount of wall time                        = 678.806057
+0:The maximum resident set size (KB)                   = 773472
 
 Test 014 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_2threads
 Checking test 015 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1189.141718
-0:The maximum resident set size (KB)                   = 838388
+0:The total amount of wall time                        = 1193.064230
+0:The maximum resident set size (KB)                   = 838416
 
 Test 015 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_decomp
 Checking test 016 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 681.324814
-0:The maximum resident set size (KB)                   = 772944
+0:The total amount of wall time                        = 687.604576
+0:The maximum resident set size (KB)                   = 772916
 
 Test 016 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_restart
 Checking test 017 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -814,14 +814,14 @@ Checking test 017 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 508.652559
-0:The maximum resident set size (KB)                   = 519392
+0:The total amount of wall time                        = 508.165498
+0:The maximum resident set size (KB)                   = 519492
 
 Test 017 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rrfs_v1beta
 Checking test 018 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -868,14 +868,14 @@ Checking test 018 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 694.774605
-0:The maximum resident set size (KB)                   = 773176
+0:The total amount of wall time                        = 696.148637
+0:The maximum resident set size (KB)                   = 773108
 
 Test 018 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rrfs_conus13km_hrrr_warm
 Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -884,14 +884,14 @@ Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 318.503484
-0:The maximum resident set size (KB)                   = 593580
+0:The total amount of wall time                        = 320.136166
+0:The maximum resident set size (KB)                   = 594452
 
 Test 019 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rrfs_conus13km_radar_tten_warm
 Checking test 020 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -900,14 +900,14 @@ Checking test 020 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 320.671823
-0:The maximum resident set size (KB)                   = 596400
+0:The total amount of wall time                        = 320.651671
+0:The maximum resident set size (KB)                   = 596480
 
 Test 020 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rrfs_smoke_conus13km_hrrr_warm
 Checking test 021 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -916,194 +916,194 @@ Checking test 021 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 343.100730
-0:The maximum resident set size (KB)                   = 607804
+0:The total amount of wall time                        = 355.311497
+0:The maximum resident set size (KB)                   = 607792
 
 Test 021 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_debug
 Checking test 022 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 81.384984
-0:The maximum resident set size (KB)                   = 426372
+0:The total amount of wall time                        = 80.262628
+0:The maximum resident set size (KB)                   = 426220
 
 Test 022 control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_diag_debug
 Checking test 023 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.678496
-0:The maximum resident set size (KB)                   = 483424
+0:The total amount of wall time                        = 98.482331
+0:The maximum resident set size (KB)                   = 483612
 
 Test 023 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/fv3_regional_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/fv3_regional_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/regional_debug
 Checking test 024 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 131.248719
-0:The maximum resident set size (KB)                   = 538240
+0:The total amount of wall time                        = 132.602438
+0:The maximum resident set size (KB)                   = 538124
 
 Test 024 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_control_debug
 Checking test 025 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 149.372664
-0:The maximum resident set size (KB)                   = 798364
+0:The total amount of wall time                        = 150.882261
+0:The maximum resident set size (KB)                   = 798288
 
 Test 025 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_debug
 Checking test 026 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.546162
-0:The maximum resident set size (KB)                   = 793104
+0:The total amount of wall time                        = 147.940983
+0:The maximum resident set size (KB)                   = 793044
 
 Test 026 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_diag_debug
 Checking test 027 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 156.869457
-0:The maximum resident set size (KB)                   = 881852
+0:The total amount of wall time                        = 157.660589
+0:The maximum resident set size (KB)                   = 881812
 
 Test 027 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 028 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 236.532291
-0:The maximum resident set size (KB)                   = 796912
+0:The total amount of wall time                        = 248.216292
+0:The maximum resident set size (KB)                   = 796884
 
 Test 028 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_progcld_thompson_debug
 Checking test 029 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 150.550588
-0:The maximum resident set size (KB)                   = 798380
+0:The total amount of wall time                        = 159.278449
+0:The maximum resident set size (KB)                   = 798312
 
-Test 029 rap_progcld_thompson_debug PASS Tries: 2
+Test 029 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rrfs_v1beta_debug
 Checking test 030 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.911428
-0:The maximum resident set size (KB)                   = 793424
+0:The total amount of wall time                        = 148.887056
+0:The maximum resident set size (KB)                   = 792796
 
 Test 030 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_ras_debug
 Checking test 031 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 84.337767
-0:The maximum resident set size (KB)                   = 436184
+0:The total amount of wall time                        = 83.606112
+0:The maximum resident set size (KB)                   = 436076
 
 Test 031 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_stochy_debug
 Checking test 032 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.732600
-0:The maximum resident set size (KB)                   = 430240
+0:The total amount of wall time                        = 91.386440
+0:The maximum resident set size (KB)                   = 430116
 
 Test 032 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_debug_p8
 Checking test 033 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 94.890298
-0:The maximum resident set size (KB)                   = 1213576
+0:The total amount of wall time                        = 105.329123
+0:The maximum resident set size (KB)                   = 1213548
 
 Test 033 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/control_wam_debug
 Checking test 034 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 148.250052
-0:The maximum resident set size (KB)                   = 172140
+0:The total amount of wall time                        = 146.153761
+0:The maximum resident set size (KB)                   = 172304
 
 Test 034 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_control_dyn32_phy32
 Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 684.756701
+0:The total amount of wall time                        = 681.620550
 0:The maximum resident set size (KB)                   = 661564
 
 Test 035 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_dyn32_phy32
 Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1204,14 +1204,14 @@ Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 346.187716
-0:The maximum resident set size (KB)                   = 659940
+0:The total amount of wall time                        = 348.438890
+0:The maximum resident set size (KB)                   = 659916
 
 Test 036 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_2threads_dyn32_phy32
 Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1258,14 +1258,14 @@ Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1202.605022
-0:The maximum resident set size (KB)                   = 702548
+0:The total amount of wall time                        = 1198.744868
+0:The maximum resident set size (KB)                   = 698028
 
 Test 037 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_2threads_dyn32_phy32
 Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1312,14 +1312,14 @@ Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 594.946031
-0:The maximum resident set size (KB)                   = 699708
+0:The total amount of wall time                        = 590.919215
+0:The maximum resident set size (KB)                   = 699544
 
 Test 038 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_decomp_dyn32_phy32
 Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1366,14 +1366,14 @@ Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 345.257873
-0:The maximum resident set size (KB)                   = 659428
+0:The total amount of wall time                        = 344.578999
+0:The maximum resident set size (KB)                   = 659340
 
 Test 039 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_restart_dyn32_phy32
 Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1412,14 +1412,14 @@ Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 510.492799
-0:The maximum resident set size (KB)                   = 499332
+0:The total amount of wall time                        = 509.566337
+0:The maximum resident set size (KB)                   = 499212
 
 Test 040 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_restart_dyn32_phy32
 Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1458,14 +1458,14 @@ Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 175.980673
-0:The maximum resident set size (KB)                   = 497232
+0:The total amount of wall time                        = 175.755908
+0:The maximum resident set size (KB)                   = 497004
 
 Test 041 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_control_dyn64_phy32
 Checking test 042 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1512,56 +1512,56 @@ Checking test 042 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 405.967523
-0:The maximum resident set size (KB)                   = 681508
+0:The total amount of wall time                        = 438.579976
+0:The maximum resident set size (KB)                   = 681560
 
 Test 042 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_control_debug_dyn32_phy32
 Checking test 043 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 146.175399
-0:The maximum resident set size (KB)                   = 678888
+0:The total amount of wall time                        = 147.540866
+0:The maximum resident set size (KB)                   = 678944
 
 Test 043 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/hrrr_control_debug_dyn32_phy32
 Checking test 044 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.097603
-0:The maximum resident set size (KB)                   = 675916
+0:The total amount of wall time                        = 142.931007
+0:The maximum resident set size (KB)                   = 675968
 
 Test 044 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/rap_control_dyn64_phy32_debug
 Checking test 045 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 153.700677
-0:The maximum resident set size (KB)                   = 697948
+0:The total amount of wall time                        = 149.547963
+0:The maximum resident set size (KB)                   = 698712
 
 Test 045 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/cpld_control_p8
 Checking test 046 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1626,14 +1626,14 @@ Checking test 046 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 502.895809
-0:The maximum resident set size (KB)                   = 3145448
+0:The total amount of wall time                        = 494.339139
+0:The maximum resident set size (KB)                   = 3141696
 
 Test 046 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/cpld_control_nowave_noaero_p8
 Checking test 047 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1695,14 +1695,14 @@ Checking test 047 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 243.366858
-0:The maximum resident set size (KB)                   = 1223892
+0:The total amount of wall time                        = 241.364939
+0:The maximum resident set size (KB)                   = 1224076
 
 Test 047 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/cpld_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/cpld_debug_p8
 Checking test 048 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1755,25 +1755,25 @@ Checking test 048 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 280.772625
-0:The maximum resident set size (KB)                   = 3159492
+0:The total amount of wall time                        = 287.076650
+0:The maximum resident set size (KB)                   = 3159736
 
 Test 048 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-gnu/jongkim/FV3_RT/rt_13626/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/GNU/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-gnu/jongkim/FV3_RT/rt_64016/datm_cdeps_control_cfsr
 Checking test 049 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 179.455912
-0:The maximum resident set size (KB)                   = 686484
+0:The total amount of wall time                        = 188.519907
+0:The maximum resident set size (KB)                   = 679104
 
 Test 049 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct  5 19:01:47 MDT 2022
-Elapsed time: 00h:33m:34s. Have a nice day!
+Mon Oct 10 09:30:07 MDT 2022
+Elapsed time: 00h:36m:39s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,32 +1,32 @@
-Wed Oct  5 18:27:29 MDT 2022
+Sun Oct  9 09:48:07 MDT 2022
 Start Regression test
 
-Compile 001 elapsed time 1303 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1159 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 468 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 420 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 1246 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1118 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 430 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 401 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 Compile 005 elapsed time 854 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 867 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 710 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 794 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 703 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 597 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1321 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 259 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 576 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 588 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 260 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 253 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 921 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 884 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 450 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 215 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 803 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 661 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 641 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 851 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 688 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 780 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 696 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 577 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 1319 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 238 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 568 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 561 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 245 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 251 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 912 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 875 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 437 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 204 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 802 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 662 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 628 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -91,14 +91,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 327.643494
-0:The maximum resident set size (KB)                   = 2719076
+0:The total amount of wall time                        = 313.158862
+0:The maximum resident set size (KB)                   = 2719180
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -151,14 +151,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 194.711112
-0:The maximum resident set size (KB)                   = 2581004
+0:The total amount of wall time                        = 187.037684
+0:The maximum resident set size (KB)                   = 2580912
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -211,14 +211,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 544.484396
-0:The maximum resident set size (KB)                   = 3164760
+0:The total amount of wall time                        = 542.639589
+0:The maximum resident set size (KB)                   = 3165072
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_esmfthreads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -271,14 +271,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 266.174244
-0:The maximum resident set size (KB)                   = 2887516
+0:The total amount of wall time                        = 258.316602
+0:The maximum resident set size (KB)                   = 2886952
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -331,14 +331,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 325.639282
-0:The maximum resident set size (KB)                   = 2724024
+0:The total amount of wall time                        = 320.654838
+0:The maximum resident set size (KB)                   = 2723644
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_mpi_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 283.354375
-0:The maximum resident set size (KB)                   = 2686956
+0:The total amount of wall time                        = 270.858094
+0:The maximum resident set size (KB)                   = 2686872
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_ciceC_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_ciceC_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_ciceC_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -463,14 +463,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 330.642574
-0:The maximum resident set size (KB)                   = 2719352
+0:The total amount of wall time                        = 322.467498
+0:The maximum resident set size (KB)                   = 2719088
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -523,14 +523,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1425.002158
-0:The maximum resident set size (KB)                   = 3024084
+0:The total amount of wall time                        = 1271.344475
+0:The maximum resident set size (KB)                   = 3024300
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_restart_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -583,14 +583,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 711.495631
-0:The maximum resident set size (KB)                   = 2951152
+0:The total amount of wall time                        = 726.445704
+0:The maximum resident set size (KB)                   = 2951500
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_noaero_p8
 Checking test 010 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -654,14 +654,14 @@ Checking test 010 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 275.596695
-0:The maximum resident set size (KB)                   = 1440920
+0:The total amount of wall time                        = 262.237259
+0:The maximum resident set size (KB)                   = 1440888
 
 Test 010 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_nowave_noaero_p8
 Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -723,14 +723,14 @@ Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 193.622141
-0:The maximum resident set size (KB)                   = 1453760
+0:The total amount of wall time                        = 193.839240
+0:The maximum resident set size (KB)                   = 1453780
 
 Test 011 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -783,14 +783,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 475.228187
-0:The maximum resident set size (KB)                   = 2790568
+0:The total amount of wall time                        = 476.661792
+0:The maximum resident set size (KB)                   = 2790540
 
 Test 012 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_debug_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_debug_noaero_p8
 Checking test 013 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -842,14 +842,14 @@ Checking test 013 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 352.453002
-0:The maximum resident set size (KB)                   = 1464884
+0:The total amount of wall time                        = 347.006360
+0:The maximum resident set size (KB)                   = 1464816
 
 Test 013 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_noaero_p8_agrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_noaero_p8_agrid
 Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -911,14 +911,14 @@ Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 257.458535
-0:The maximum resident set size (KB)                   = 1458048
+0:The total amount of wall time                        = 259.461645
+0:The maximum resident set size (KB)                   = 1457980
 
 Test 014 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c48
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c48
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_control_c48
 Checking test 015 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -968,14 +968,14 @@ Checking test 015 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 604.337475
-0:The maximum resident set size (KB)                   = 2582888
+0:The total amount of wall time                        = 599.985049
+0:The maximum resident set size (KB)                   = 2582944
 
 Test 015 cpld_control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_warmstart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_warmstart_c48
 Checking test 016 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1025,14 +1025,14 @@ Checking test 016 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 162.350736
-0:The maximum resident set size (KB)                   = 2599036
+0:The total amount of wall time                        = 160.592670
+0:The maximum resident set size (KB)                   = 2598912
 
 Test 016 cpld_warmstart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/cpld_restart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/cpld_restart_c48
 Checking test 017 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 017 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 84.805646
-0:The maximum resident set size (KB)                   = 2016216
+0:The total amount of wall time                        = 83.591677
+0:The maximum resident set size (KB)                   = 2016292
 
 Test 017 cpld_restart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control
 Checking test 018 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1136,14 +1136,14 @@ Checking test 018 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 147.513393
-0:The maximum resident set size (KB)                   = 455868
+0:The total amount of wall time                        = 146.166879
+0:The maximum resident set size (KB)                   = 455884
 
 Test 018 control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_decomp
 Checking test 019 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1186,14 +1186,14 @@ Checking test 019 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 154.197914
-0:The maximum resident set size (KB)                   = 454408
+0:The total amount of wall time                        = 153.889253
+0:The maximum resident set size (KB)                   = 454476
 
 Test 019 control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_2dwrtdecomp
 Checking test 020 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1204,14 +1204,14 @@ Checking test 020 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 149.179731
-0:The maximum resident set size (KB)                   = 456036
+0:The total amount of wall time                        = 146.352916
+0:The maximum resident set size (KB)                   = 456068
 
 Test 020 control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_2threads
 Checking test 021 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1254,14 +1254,14 @@ Checking test 021 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 375.724283
-0:The maximum resident set size (KB)                   = 499344
+0:The total amount of wall time                        = 379.551021
+0:The maximum resident set size (KB)                   = 499360
 
 Test 021 control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_restart
 Checking test 022 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1300,14 +1300,14 @@ Checking test 022 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 78.847676
-0:The maximum resident set size (KB)                   = 195932
+0:The total amount of wall time                        = 76.209918
+0:The maximum resident set size (KB)                   = 195968
 
 Test 022 control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_fhzero
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_fhzero
 Checking test 023 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1350,14 +1350,14 @@ Checking test 023 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 138.272526
-0:The maximum resident set size (KB)                   = 455436
+0:The total amount of wall time                        = 135.175535
+0:The maximum resident set size (KB)                   = 455516
 
 Test 023 control_fhzero PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_CubedSphereGrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_CubedSphereGrid
 Checking test 024 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1384,28 +1384,28 @@ Checking test 024 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.376484
-0:The maximum resident set size (KB)                   = 455412
+0:The total amount of wall time                        = 140.403791
+0:The maximum resident set size (KB)                   = 455420
 
 Test 024 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_parallel
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_CubedSphereGrid_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_parallel
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_CubedSphereGrid_parallel
 Checking test 025 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 141.092779
-0:The maximum resident set size (KB)                   = 455888
+0:The total amount of wall time                        = 139.257151
+0:The maximum resident set size (KB)                   = 455832
 
 Test 025 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_latlon
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_latlon
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_latlon
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_latlon
 Checking test 026 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1416,16 +1416,16 @@ Checking test 026 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.778713
-0:The maximum resident set size (KB)                   = 455548
+0:The total amount of wall time                        = 148.107166
+0:The maximum resident set size (KB)                   = 455688
 
 Test 026 control_latlon PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_wrtGauss_netcdf_parallel
 Checking test 027 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1434,14 +1434,14 @@ Checking test 027 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.595293
-0:The maximum resident set size (KB)                   = 455888
+0:The total amount of wall time                        = 147.043950
+0:The maximum resident set size (KB)                   = 455908
 
 Test 027 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c48
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c48
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_c48
 Checking test 028 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1480,14 +1480,14 @@ Checking test 028 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 446.149013
+0:The total amount of wall time                        = 439.809275
 0:The maximum resident set size (KB)                   = 627832
 
 Test 028 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c192
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_c192
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c192
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_c192
 Checking test 029 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1498,14 +1498,14 @@ Checking test 029 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 593.728522
-0:The maximum resident set size (KB)                   = 561148
+0:The total amount of wall time                        = 590.202646
+0:The maximum resident set size (KB)                   = 560620
 
 Test 029 control_c192 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_c384
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_c384
 Checking test 030 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1516,14 +1516,14 @@ Checking test 030 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1305.269805
-0:The maximum resident set size (KB)                   = 835944
+0:The total amount of wall time                        = 1303.534944
+0:The maximum resident set size (KB)                   = 836072
 
 Test 030 control_c384 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384gdas
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_c384gdas
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384gdas
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_c384gdas
 Checking test 031 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1566,14 +1566,14 @@ Checking test 031 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1332.271348
-0:The maximum resident set size (KB)                   = 970144
+0:The total amount of wall time                        = 1328.916396
+0:The maximum resident set size (KB)                   = 970812
 
 Test 031 control_c384gdas PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384_progsigma
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_c384_progsigma
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384_progsigma
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_c384_progsigma
 Checking test 032 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1584,14 +1584,14 @@ Checking test 032 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1332.904945
-0:The maximum resident set size (KB)                   = 854380
+0:The total amount of wall time                        = 1317.262731
+0:The maximum resident set size (KB)                   = 854308
 
 Test 032 control_c384_progsigma PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_stochy
 Checking test 033 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1602,28 +1602,28 @@ Checking test 033 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 98.205801
-0:The maximum resident set size (KB)                   = 459636
+0:The total amount of wall time                        = 97.632873
+0:The maximum resident set size (KB)                   = 459724
 
 Test 033 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_stochy_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_stochy_restart
 Checking test 034 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 51.275603
-0:The maximum resident set size (KB)                   = 225908
+0:The total amount of wall time                        = 52.589401
+0:The maximum resident set size (KB)                   = 225872
 
 Test 034 control_stochy_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_lndp
 Checking test 035 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1634,14 +1634,14 @@ Checking test 035 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 89.531214
-0:The maximum resident set size (KB)                   = 459276
+0:The total amount of wall time                        = 90.086388
+0:The maximum resident set size (KB)                   = 459296
 
 Test 035 control_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr4
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_iovr4
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr4
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_iovr4
 Checking test 036 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1656,14 +1656,14 @@ Checking test 036 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.228050
-0:The maximum resident set size (KB)                   = 455508
+0:The total amount of wall time                        = 147.874495
+0:The maximum resident set size (KB)                   = 455588
 
 Test 036 control_iovr4 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr5
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_iovr5
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr5
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_iovr5
 Checking test 037 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1678,14 +1678,14 @@ Checking test 037 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.018493
-0:The maximum resident set size (KB)                   = 455484
+0:The total amount of wall time                        = 143.973992
+0:The maximum resident set size (KB)                   = 455428
 
 Test 037 control_iovr5 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_p8
 Checking test 038 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1732,14 +1732,14 @@ Checking test 038 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 183.560284
-0:The maximum resident set size (KB)                   = 1426144
+0:The total amount of wall time                        = 180.117432
+0:The maximum resident set size (KB)                   = 1426232
 
 Test 038 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_lndp
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_p8_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_lndp
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_p8_lndp
 Checking test 039 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1758,14 +1758,14 @@ Checking test 039 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 331.503953
-0:The maximum resident set size (KB)                   = 1426368
+0:The total amount of wall time                        = 333.243118
+0:The maximum resident set size (KB)                   = 1426700
 
 Test 039 control_p8_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_restart_p8
 Checking test 040 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1804,14 +1804,14 @@ Checking test 040 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 94.293491
-0:The maximum resident set size (KB)                   = 583004
+0:The total amount of wall time                        = 91.655245
+0:The maximum resident set size (KB)                   = 582668
 
 Test 040 control_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_decomp_p8
 Checking test 041 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1854,14 +1854,14 @@ Checking test 041 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 185.581465
-0:The maximum resident set size (KB)                   = 1420480
+0:The total amount of wall time                        = 179.546342
+0:The maximum resident set size (KB)                   = 1420500
 
 Test 041 control_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_2threads_p8
 Checking test 042 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1904,14 +1904,14 @@ Checking test 042 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 495.653754
-0:The maximum resident set size (KB)                   = 1502080
+0:The total amount of wall time                        = 497.918292
+0:The maximum resident set size (KB)                   = 1501984
 
 Test 042 control_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_p8_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_p8_rrtmgp
 Checking test 043 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1958,14 +1958,14 @@ Checking test 043 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 246.376044
-0:The maximum resident set size (KB)                   = 1541764
+0:The total amount of wall time                        = 239.886643
+0:The maximum resident set size (KB)                   = 1541840
 
 Test 043 control_p8_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/merra2_thompson
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/merra2_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/merra2_thompson
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/merra2_thompson
 Checking test 044 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2012,14 +2012,14 @@ Checking test 044 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 184.607132
-0:The maximum resident set size (KB)                   = 1432472
+0:The total amount of wall time                        = 180.423874
+0:The maximum resident set size (KB)                   = 1432516
 
 Test 044 merra2_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_control
 Checking test 045 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2030,28 +2030,28 @@ Checking test 045 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 372.898206
-0:The maximum resident set size (KB)                   = 565472
+0:The total amount of wall time                        = 368.900777
+0:The maximum resident set size (KB)                   = 565536
 
 Test 045 regional_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_restart
 Checking test 046 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 207.360744
-0:The maximum resident set size (KB)                   = 556680
+0:The total amount of wall time                        = 199.867456
+0:The maximum resident set size (KB)                   = 556760
 
 Test 046 regional_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_control_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_control_2dwrtdecomp
 Checking test 047 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2062,14 +2062,14 @@ Checking test 047 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 380.391621
-0:The maximum resident set size (KB)                   = 564596
+0:The total amount of wall time                        = 372.157098
+0:The maximum resident set size (KB)                   = 564780
 
 Test 047 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_noquilt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_noquilt
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_noquilt
 Checking test 048 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2077,14 +2077,14 @@ Checking test 048 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 391.047369
-0:The maximum resident set size (KB)                   = 558928
+0:The total amount of wall time                        = 390.694514
+0:The maximum resident set size (KB)                   = 559028
 
 Test 048 regional_noquilt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_2threads
 Checking test 049 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2095,28 +2095,28 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 1111.352871
-0:The maximum resident set size (KB)                   = 558392
+0:The total amount of wall time                        = 1108.518176
+0:The maximum resident set size (KB)                   = 558500
 
 Test 049 regional_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_netcdf_parallel
 Checking test 050 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 366.503414
-0:The maximum resident set size (KB)                   = 555812
+0:The total amount of wall time                        = 375.326841
+0:The maximum resident set size (KB)                   = 555656
 
 Test 050 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_3km
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_3km
 Checking test 051 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2127,14 +2127,14 @@ Checking test 051 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 297.323083
-0:The maximum resident set size (KB)                   = 592784
+0:The total amount of wall time                        = 297.188781
+0:The maximum resident set size (KB)                   = 592880
 
 Test 051 regional_3km PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_3km_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_3km_decomp
 Checking test 052 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2145,14 +2145,14 @@ Checking test 052 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 314.098862
-0:The maximum resident set size (KB)                   = 600608
+0:The total amount of wall time                        = 315.471012
+0:The maximum resident set size (KB)                   = 600704
 
 Test 052 regional_3km_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_control
 Checking test 053 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2199,14 +2199,14 @@ Checking test 053 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 465.905841
-0:The maximum resident set size (KB)                   = 825728
+0:The total amount of wall time                        = 460.393137
+0:The maximum resident set size (KB)                   = 825748
 
 Test 053 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_rrtmgp
 Checking test 054 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2253,14 +2253,14 @@ Checking test 054 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 523.842273
-0:The maximum resident set size (KB)                   = 951280
+0:The total amount of wall time                        = 503.135510
+0:The maximum resident set size (KB)                   = 951412
 
 Test 054 rap_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_spp_sppt_shum_skeb
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_spp_sppt_shum_skeb
 Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2271,14 +2271,14 @@ Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 702.957042
-0:The maximum resident set size (KB)                   = 933068
+0:The total amount of wall time                        = 700.732479
+0:The maximum resident set size (KB)                   = 932572
 
 Test 055 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_decomp
 Checking test 056 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2325,14 +2325,14 @@ Checking test 056 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 485.458179
-0:The maximum resident set size (KB)                   = 824772
+0:The total amount of wall time                        = 482.484552
+0:The maximum resident set size (KB)                   = 824936
 
 Test 056 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_2threads
 Checking test 057 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2379,14 +2379,14 @@ Checking test 057 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1107.303925
-0:The maximum resident set size (KB)                   = 884604
+0:The total amount of wall time                        = 1112.711507
+0:The maximum resident set size (KB)                   = 884508
 
 Test 057 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_restart
 Checking test 058 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2425,14 +2425,14 @@ Checking test 058 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 234.867412
-0:The maximum resident set size (KB)                   = 570972
+0:The total amount of wall time                        = 232.485393
+0:The maximum resident set size (KB)                   = 570928
 
 Test 058 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_sfcdiff
 Checking test 059 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2479,14 +2479,14 @@ Checking test 059 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 460.363143
-0:The maximum resident set size (KB)                   = 825716
+0:The total amount of wall time                        = 454.490367
+0:The maximum resident set size (KB)                   = 825868
 
 Test 059 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_sfcdiff_decomp
 Checking test 060 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2533,14 +2533,14 @@ Checking test 060 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 484.819357
-0:The maximum resident set size (KB)                   = 824264
+0:The total amount of wall time                        = 478.102412
+0:The maximum resident set size (KB)                   = 824184
 
 Test 060 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_sfcdiff_restart
 Checking test 061 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2579,14 +2579,14 @@ Checking test 061 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 340.603883
-0:The maximum resident set size (KB)                   = 571548
+0:The total amount of wall time                        = 336.489343
+0:The maximum resident set size (KB)                   = 571816
 
 Test 061 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control
 Checking test 062 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2633,14 +2633,14 @@ Checking test 062 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 443.303819
-0:The maximum resident set size (KB)                   = 822008
+0:The total amount of wall time                        = 443.173414
+0:The maximum resident set size (KB)                   = 821980
 
 Test 062 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_decomp
 Checking test 063 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2687,14 +2687,14 @@ Checking test 063 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 463.504674
-0:The maximum resident set size (KB)                   = 821816
+0:The total amount of wall time                        = 463.420744
+0:The maximum resident set size (KB)                   = 821812
 
 Test 063 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_2threads
 Checking test 064 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2741,14 +2741,14 @@ Checking test 064 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1043.843457
-0:The maximum resident set size (KB)                   = 879704
+0:The total amount of wall time                        = 1052.483729
+0:The maximum resident set size (KB)                   = 879652
 
 Test 064 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_restart
 Checking test 065 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2787,14 +2787,14 @@ Checking test 065 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 329.004075
-0:The maximum resident set size (KB)                   = 567096
+0:The total amount of wall time                        = 324.967659
+0:The maximum resident set size (KB)                   = 567100
 
 Test 065 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_v1beta
 Checking test 066 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2841,14 +2841,14 @@ Checking test 066 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 453.410337
-0:The maximum resident set size (KB)                   = 820816
+0:The total amount of wall time                        = 453.206456
+0:The maximum resident set size (KB)                   = 820960
 
 Test 066 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_v1nssl
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_v1nssl
 Checking test 067 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2863,14 +2863,14 @@ Checking test 067 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 565.098189
-0:The maximum resident set size (KB)                   = 509424
+0:The total amount of wall time                        = 545.181053
+0:The maximum resident set size (KB)                   = 509548
 
 Test 067 rrfs_v1nssl PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_v1nssl_nohailnoccn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_v1nssl_nohailnoccn
 Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2885,14 +2885,14 @@ Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 545.284136
-0:The maximum resident set size (KB)                   = 502684
+0:The total amount of wall time                        = 532.860616
+0:The maximum resident set size (KB)                   = 502760
 
 Test 068 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_conus13km_hrrr_warm
 Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2901,14 +2901,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 190.866408
-0:The maximum resident set size (KB)                   = 640932
+0:The total amount of wall time                        = 190.066747
+0:The maximum resident set size (KB)                   = 641272
 
 Test 069 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_conus13km_radar_tten_warm
 Checking test 070 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2917,14 +2917,14 @@ Checking test 070 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 193.980424
-0:The maximum resident set size (KB)                   = 642796
+0:The total amount of wall time                        = 190.268445
+0:The maximum resident set size (KB)                   = 642832
 
 Test 070 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_smoke_conus13km_hrrr_warm
 Checking test 071 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2933,14 +2933,14 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 209.530758
-0:The maximum resident set size (KB)                   = 656636
+0:The total amount of wall time                        = 209.973314
+0:The maximum resident set size (KB)                   = 656992
 
 Test 071 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_csawmg
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_csawmg
 Checking test 072 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2951,14 +2951,14 @@ Checking test 072 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 397.559801
-0:The maximum resident set size (KB)                   = 532824
+0:The total amount of wall time                        = 378.399987
+0:The maximum resident set size (KB)                   = 532888
 
 Test 072 control_csawmg PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_csawmgt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_csawmgt
 Checking test 073 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2969,14 +2969,14 @@ Checking test 073 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 393.197499
-0:The maximum resident set size (KB)                   = 533216
+0:The total amount of wall time                        = 373.578942
+0:The maximum resident set size (KB)                   = 533248
 
 Test 073 control_csawmgt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_ras
 Checking test 074 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2987,54 +2987,54 @@ Checking test 074 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 202.068549
-0:The maximum resident set size (KB)                   = 491488
+0:The total amount of wall time                        = 198.208168
+0:The maximum resident set size (KB)                   = 491548
 
 Test 074 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_wam
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_wam
 Checking test 075 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 125.409959
-0:The maximum resident set size (KB)                   = 207580
+0:The total amount of wall time                        = 126.379628
+0:The maximum resident set size (KB)                   = 207700
 
 Test 075 control_wam PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_debug
 Checking test 076 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.941752
-0:The maximum resident set size (KB)                   = 623264
+0:The total amount of wall time                        = 159.726170
+0:The maximum resident set size (KB)                   = 623232
 
 Test 076 control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_2threads_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_2threads_debug
 Checking test 077 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 278.903418
-0:The maximum resident set size (KB)                   = 668512
+0:The total amount of wall time                        = 278.789937
+0:The maximum resident set size (KB)                   = 668464
 
 Test 077 control_2threads_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_CubedSphereGrid_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_CubedSphereGrid_debug
 Checking test 078 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3061,348 +3061,348 @@ Checking test 078 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 174.682534
-0:The maximum resident set size (KB)                   = 623408
+0:The total amount of wall time                        = 174.564414
+0:The maximum resident set size (KB)                   = 623564
 
 Test 078 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_wrtGauss_netcdf_parallel_debug
 Checking test 079 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 166.078687
-0:The maximum resident set size (KB)                   = 624172
+0:The total amount of wall time                        = 162.835609
+0:The maximum resident set size (KB)                   = 623384
 
 Test 079 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_stochy_debug
 Checking test 080 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 185.463372
-0:The maximum resident set size (KB)                   = 629552
+0:The total amount of wall time                        = 181.692733
+0:The maximum resident set size (KB)                   = 629612
 
 Test 080 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_lndp_debug
 Checking test 081 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 165.416911
-0:The maximum resident set size (KB)                   = 628296
+0:The total amount of wall time                        = 163.297707
+0:The maximum resident set size (KB)                   = 628744
 
 Test 081 control_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_csawmg_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_csawmg_debug
 Checking test 082 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 258.839987
-0:The maximum resident set size (KB)                   = 673624
+0:The total amount of wall time                        = 254.301729
+0:The maximum resident set size (KB)                   = 673324
 
 Test 082 control_csawmg_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_csawmgt_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_csawmgt_debug
 Checking test 083 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 251.624192
-0:The maximum resident set size (KB)                   = 672584
+0:The total amount of wall time                        = 250.992969
+0:The maximum resident set size (KB)                   = 672624
 
 Test 083 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_ras_debug
 Checking test 084 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 169.782824
-0:The maximum resident set size (KB)                   = 636416
+0:The total amount of wall time                        = 166.483061
+0:The maximum resident set size (KB)                   = 636348
 
 Test 084 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_diag_debug
 Checking test 085 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 172.679100
-0:The maximum resident set size (KB)                   = 681364
+0:The total amount of wall time                        = 172.545067
+0:The maximum resident set size (KB)                   = 681328
 
 Test 085 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_debug_p8
 Checking test 086 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 183.099677
-0:The maximum resident set size (KB)                   = 1448528
+0:The total amount of wall time                        = 183.785042
+0:The maximum resident set size (KB)                   = 1448568
 
 Test 086 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_debug
 Checking test 087 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 259.901143
-0:The maximum resident set size (KB)                   = 590816
+0:The total amount of wall time                        = 260.284476
+0:The maximum resident set size (KB)                   = 590908
 
 Test 087 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_control_debug
 Checking test 088 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.073030
-0:The maximum resident set size (KB)                   = 992028
+0:The total amount of wall time                        = 290.775069
+0:The maximum resident set size (KB)                   = 992088
 
 Test 088 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_debug
 Checking test 089 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.090984
-0:The maximum resident set size (KB)                   = 988088
+0:The total amount of wall time                        = 286.748234
+0:The maximum resident set size (KB)                   = 988432
 
 Test 089 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_unified_drag_suite_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_unified_drag_suite_debug
 Checking test 090 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.452668
-0:The maximum resident set size (KB)                   = 992052
+0:The total amount of wall time                        = 291.280962
+0:The maximum resident set size (KB)                   = 992056
 
 Test 090 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_diag_debug
 Checking test 091 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 307.880079
-0:The maximum resident set size (KB)                   = 1075364
+0:The total amount of wall time                        = 306.132988
+0:The maximum resident set size (KB)                   = 1075448
 
 Test 091 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_cires_ugwp_debug
 Checking test 092 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 302.629109
-0:The maximum resident set size (KB)                   = 990640
+0:The total amount of wall time                        = 297.784305
+0:The maximum resident set size (KB)                   = 990240
 
 Test 092 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_unified_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_unified_ugwp_debug
 Checking test 093 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 297.617851
-0:The maximum resident set size (KB)                   = 991848
+0:The total amount of wall time                        = 298.335029
+0:The maximum resident set size (KB)                   = 991700
 
 Test 093 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_lndp_debug
 Checking test 094 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 294.990699
-0:The maximum resident set size (KB)                   = 992724
+0:The total amount of wall time                        = 294.226485
+0:The maximum resident set size (KB)                   = 992792
 
 Test 094 rap_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_flake_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_flake_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_flake_debug
 Checking test 095 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 299.514233
-0:The maximum resident set size (KB)                   = 991772
+0:The total amount of wall time                        = 292.209128
+0:The maximum resident set size (KB)                   = 991484
 
 Test 095 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_progcld_thompson_debug
 Checking test 096 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.536810
-0:The maximum resident set size (KB)                   = 992404
+0:The total amount of wall time                        = 291.637667
+0:The maximum resident set size (KB)                   = 992012
 
 Test 096 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_noah_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_noah_debug
 Checking test 097 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.586417
-0:The maximum resident set size (KB)                   = 990592
+0:The total amount of wall time                        = 286.163173
+0:The maximum resident set size (KB)                   = 990540
 
 Test 097 rap_noah_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_rrtmgp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_rrtmgp_debug
 Checking test 098 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 488.852508
-0:The maximum resident set size (KB)                   = 1120844
+0:The total amount of wall time                        = 487.964219
+0:The maximum resident set size (KB)                   = 1121268
 
 Test 098 rap_rrtmgp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_sfcdiff_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_sfcdiff_debug
 Checking test 099 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.139002
-0:The maximum resident set size (KB)                   = 991720
+0:The total amount of wall time                        = 291.467949
+0:The maximum resident set size (KB)                   = 991872
 
 Test 099 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 100 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 477.080506
-0:The maximum resident set size (KB)                   = 990408
+0:The total amount of wall time                        = 478.062850
+0:The maximum resident set size (KB)                   = 990564
 
 Test 100 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rrfs_v1beta_debug
 Checking test 101 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.488012
-0:The maximum resident set size (KB)                   = 987240
+0:The total amount of wall time                        = 287.767842
+0:The maximum resident set size (KB)                   = 987404
 
 Test 101 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_wam_debug
 Checking test 102 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 298.610763
-0:The maximum resident set size (KB)                   = 240988
+0:The total amount of wall time                        = 296.599315
+0:The maximum resident set size (KB)                   = 241104
 
 Test 102 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 103 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3413,14 +3413,14 @@ Checking test 103 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 662.292752
-0:The maximum resident set size (KB)                   = 831416
+0:The total amount of wall time                        = 660.561682
+0:The maximum resident set size (KB)                   = 831100
 
 Test 103 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_control_dyn32_phy32
 Checking test 104 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3467,14 +3467,14 @@ Checking test 104 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 373.491756
-0:The maximum resident set size (KB)                   = 708952
+0:The total amount of wall time                        = 372.964751
+0:The maximum resident set size (KB)                   = 709000
 
 Test 104 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_dyn32_phy32
 Checking test 105 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3521,14 +3521,14 @@ Checking test 105 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 197.401896
-0:The maximum resident set size (KB)                   = 707444
+0:The total amount of wall time                        = 195.487756
+0:The maximum resident set size (KB)                   = 707432
 
 Test 105 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_2threads_dyn32_phy32
 Checking test 106 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3575,14 +3575,14 @@ Checking test 106 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 922.952824
-0:The maximum resident set size (KB)                   = 745548
+0:The total amount of wall time                        = 925.316212
+0:The maximum resident set size (KB)                   = 746016
 
 Test 106 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_2threads_dyn32_phy32
 Checking test 107 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3629,14 +3629,14 @@ Checking test 107 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 490.375424
-0:The maximum resident set size (KB)                   = 746736
+0:The total amount of wall time                        = 487.916074
+0:The maximum resident set size (KB)                   = 746804
 
 Test 107 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_decomp_dyn32_phy32
 Checking test 108 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3683,14 +3683,14 @@ Checking test 108 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 206.949321
-0:The maximum resident set size (KB)                   = 706256
+0:The total amount of wall time                        = 211.252438
+0:The maximum resident set size (KB)                   = 706112
 
 Test 108 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_restart_dyn32_phy32
 Checking test 109 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3729,14 +3729,14 @@ Checking test 109 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 282.038855
-0:The maximum resident set size (KB)                   = 543672
+0:The total amount of wall time                        = 282.210018
+0:The maximum resident set size (KB)                   = 543196
 
 Test 109 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_restart_dyn32_phy32
 Checking test 110 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3775,14 +3775,14 @@ Checking test 110 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 101.794626
-0:The maximum resident set size (KB)                   = 541676
+0:The total amount of wall time                        = 99.022297
+0:The maximum resident set size (KB)                   = 541668
 
 Test 110 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_control_dyn64_phy32
 Checking test 111 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3829,81 +3829,81 @@ Checking test 111 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 261.316594
-0:The maximum resident set size (KB)                   = 726412
+0:The total amount of wall time                        = 259.991485
+0:The maximum resident set size (KB)                   = 726524
 
 Test 111 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_control_debug_dyn32_phy32
 Checking test 112 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.497364
-0:The maximum resident set size (KB)                   = 878096
+0:The total amount of wall time                        = 287.098518
+0:The maximum resident set size (KB)                   = 877512
 
 Test 112 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hrrr_control_debug_dyn32_phy32
 Checking test 113 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.443396
-0:The maximum resident set size (KB)                   = 875204
+0:The total amount of wall time                        = 283.472586
+0:The maximum resident set size (KB)                   = 875152
 
 Test 113 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/rap_control_dyn64_phy32_debug
 Checking test 114 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 290.885772
-0:The maximum resident set size (KB)                   = 894760
+0:The total amount of wall time                        = 290.460110
+0:The maximum resident set size (KB)                   = 894700
 
 Test 114 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_atm
 Checking test 115 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 635.357216
-0:The maximum resident set size (KB)                   = 692384
+0:The total amount of wall time                        = 630.871784
+0:The maximum resident set size (KB)                   = 692352
 
 Test 115 hafs_regional_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_atm_thompson_gfdlsf
 Checking test 116 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 674.244468
-0:The maximum resident set size (KB)                   = 1053136
+0:The total amount of wall time                        = 684.830851
+0:The maximum resident set size (KB)                   = 1053164
 
 Test 116 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_atm_ocn
 Checking test 117 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3912,14 +3912,14 @@ Checking test 117 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 452.711481
-0:The maximum resident set size (KB)                   = 721180
+0:The total amount of wall time                        = 425.070742
+0:The maximum resident set size (KB)                   = 721476
 
 Test 117 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_atm_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_atm_wav
 Checking test 118 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3928,14 +3928,14 @@ Checking test 118 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1029.476454
-0:The maximum resident set size (KB)                   = 751728
+0:The total amount of wall time                        = 1066.193707
+0:The maximum resident set size (KB)                   = 752800
 
 Test 118 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_atm_ocn_wav
 Checking test 119 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3946,28 +3946,28 @@ Checking test 119 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1090.923181
-0:The maximum resident set size (KB)                   = 765848
+0:The total amount of wall time                        = 1155.140640
+0:The maximum resident set size (KB)                   = 765244
 
 Test 119 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_1nest_atm
 Checking test 120 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 1265.723887
-0:The maximum resident set size (KB)                   = 279128
+0:The total amount of wall time                        = 1267.631614
+0:The maximum resident set size (KB)                   = 279292
 
 Test 120 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_telescopic_2nests_atm
 Checking test 121 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3976,28 +3976,28 @@ Checking test 121 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 1362.450640
-0:The maximum resident set size (KB)                   = 291212
+0:The total amount of wall time                        = 1364.288774
+0:The maximum resident set size (KB)                   = 291268
 
 Test 121 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_global_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_global_1nest_atm
 Checking test 122 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 841.935826
-0:The maximum resident set size (KB)                   = 186692
+0:The total amount of wall time                        = 836.977330
+0:The maximum resident set size (KB)                   = 186848
 
 Test 122 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_global_multiple_4nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_global_multiple_4nests_atm
 Checking test 123 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4015,14 +4015,14 @@ Checking test 123 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-0:The total amount of wall time                        = 1491.873816
-0:The maximum resident set size (KB)                   = 264216
+0:The total amount of wall time                        = 1483.980542
+0:The maximum resident set size (KB)                   = 267544
 
 Test 123 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_specified_moving_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_specified_moving_1nest_atm
 Checking test 124 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4031,28 +4031,28 @@ Checking test 124 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 724.852104
-0:The maximum resident set size (KB)                   = 289992
+0:The total amount of wall time                        = 712.545196
+0:The maximum resident set size (KB)                   = 289496
 
 Test 124 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_storm_following_1nest_atm
 Checking test 125 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 691.525350
-0:The maximum resident set size (KB)                   = 289472
+0:The total amount of wall time                        = 687.994204
+0:The maximum resident set size (KB)                   = 289428
 
 Test 125 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 126 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4061,14 +4061,14 @@ Checking test 126 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 706.242560
-0:The maximum resident set size (KB)                   = 320388
+0:The total amount of wall time                        = 707.369469
+0:The maximum resident set size (KB)                   = 320096
 
 Test 126 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 127 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4079,28 +4079,28 @@ Checking test 127 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1340.056664
-0:The maximum resident set size (KB)                   = 386436
+0:The total amount of wall time                        = 1319.919386
+0:The maximum resident set size (KB)                   = 385976
 
 Test 127 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_global_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_global_storm_following_1nest_atm
 Checking test 128 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 416.971188
-0:The maximum resident set size (KB)                   = 204768
+0:The total amount of wall time                        = 416.814433
+0:The maximum resident set size (KB)                   = 204940
 
 Test 128 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_docn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_docn
 Checking test 129 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4108,14 +4108,14 @@ Checking test 129 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 420.043921
-0:The maximum resident set size (KB)                   = 738596
+0:The total amount of wall time                        = 417.938280
+0:The maximum resident set size (KB)                   = 737816
 
 Test 129 hafs_regional_docn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_docn_oisst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_docn_oisst
 Checking test 130 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4123,131 +4123,131 @@ Checking test 130 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 420.971861
-0:The maximum resident set size (KB)                   = 722552
+0:The total amount of wall time                        = 417.587584
+0:The maximum resident set size (KB)                   = 722708
 
 Test 130 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/hafs_regional_datm_cdeps
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/hafs_regional_datm_cdeps
 Checking test 131 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1284.159309
-0:The maximum resident set size (KB)                   = 891448
+0:The total amount of wall time                        = 1278.282868
+0:The maximum resident set size (KB)                   = 891404
 
 Test 131 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_control_cfsr
 Checking test 132 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.805258
-0:The maximum resident set size (KB)                   = 720248
+0:The total amount of wall time                        = 164.953142
+0:The maximum resident set size (KB)                   = 731128
 
 Test 132 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_restart_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_restart_cfsr
 Checking test 133 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 102.177022
-0:The maximum resident set size (KB)                   = 708300
+0:The total amount of wall time                        = 97.475771
+0:The maximum resident set size (KB)                   = 719480
 
 Test 133 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_control_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_control_gefs
 Checking test 134 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 163.945299
-0:The maximum resident set size (KB)                   = 610920
+0:The total amount of wall time                        = 161.509967
+0:The maximum resident set size (KB)                   = 610884
 
 Test 134 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_iau_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_iau_gefs
 Checking test 135 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.804406
-0:The maximum resident set size (KB)                   = 610912
+0:The total amount of wall time                        = 165.293542
+0:The maximum resident set size (KB)                   = 610904
 
 Test 135 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_stochy_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_stochy_gefs
 Checking test 136 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.408702
-0:The maximum resident set size (KB)                   = 610932
+0:The total amount of wall time                        = 164.775129
+0:The maximum resident set size (KB)                   = 610888
 
 Test 136 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_ciceC_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_ciceC_cfsr
 Checking test 137 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 171.096203
-0:The maximum resident set size (KB)                   = 731748
+0:The total amount of wall time                        = 171.075930
+0:The maximum resident set size (KB)                   = 731156
 
 Test 137 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_bulk_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_bulk_cfsr
 Checking test 138 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 170.119006
-0:The maximum resident set size (KB)                   = 731180
+0:The total amount of wall time                        = 162.630754
+0:The maximum resident set size (KB)                   = 731160
 
 Test 138 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_bulk_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_bulk_gefs
 Checking test 139 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.200309
-0:The maximum resident set size (KB)                   = 610928
+0:The total amount of wall time                        = 156.165953
+0:The maximum resident set size (KB)                   = 610932
 
 Test 139 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_mx025_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_mx025_cfsr
 Checking test 140 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4256,14 +4256,14 @@ Checking test 140 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 616.248513
-0:The maximum resident set size (KB)                   = 517876
+0:The total amount of wall time                        = 419.414965
+0:The maximum resident set size (KB)                   = 517864
 
 Test 140 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_mx025_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_mx025_gefs
 Checking test 141 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4272,64 +4272,64 @@ Checking test 141 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 426.979969
-0:The maximum resident set size (KB)                   = 498716
+0:The total amount of wall time                        = 724.681374
+0:The maximum resident set size (KB)                   = 498656
 
 Test 141 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_multiple_files_cfsr
 Checking test 142 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.224042
-0:The maximum resident set size (KB)                   = 731676
+0:The total amount of wall time                        = 162.305349
+0:The maximum resident set size (KB)                   = 731172
 
 Test 142 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_3072x1536_cfsr
 Checking test 143 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 269.440765
-0:The maximum resident set size (KB)                   = 1945576
+0:The total amount of wall time                        = 239.450499
+0:The maximum resident set size (KB)                   = 1944656
 
 Test 143 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_gfs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_gfs
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_gfs
 Checking test 144 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 271.846758
-0:The maximum resident set size (KB)                   = 1946256
+0:The total amount of wall time                        = 240.586005
+0:The maximum resident set size (KB)                   = 1944848
 
 Test 144 datm_cdeps_gfs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/datm_cdeps_debug_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/datm_cdeps_debug_cfsr
 Checking test 145 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 458.824816
-0:The maximum resident set size (KB)                   = 721112
+0:The total amount of wall time                        = 458.851218
+0:The maximum resident set size (KB)                   = 710096
 
 Test 145 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/control_atmwav
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/control_atmwav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/control_atmwav
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/control_atmwav
 Checking test 146 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4373,14 +4373,14 @@ Checking test 146 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 100.258596
-0:The maximum resident set size (KB)                   = 478536
+0:The total amount of wall time                        = 99.442593
+0:The maximum resident set size (KB)                   = 477984
 
 Test 146 control_atmwav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/atmaero_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/atmaero_control_p8
 Checking test 147 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4424,14 +4424,14 @@ Checking test 147 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 248.336755
-0:The maximum resident set size (KB)                   = 2705724
+0:The total amount of wall time                        = 238.874956
+0:The maximum resident set size (KB)                   = 2706080
 
 Test 147 atmaero_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/atmaero_control_p8_rad
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/atmaero_control_p8_rad
 Checking test 148 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4475,14 +4475,14 @@ Checking test 148 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 300.738205
-0:The maximum resident set size (KB)                   = 2760172
+0:The total amount of wall time                        = 300.817872
+0:The maximum resident set size (KB)                   = 2760400
 
 Test 148 atmaero_control_p8_rad PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad_micro
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/atmaero_control_p8_rad_micro
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad_micro
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/atmaero_control_p8_rad_micro
 Checking test 149 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4526,14 +4526,14 @@ Checking test 149 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 310.588238
-0:The maximum resident set size (KB)                   = 2766888
+0:The total amount of wall time                        = 308.258488
+0:The maximum resident set size (KB)                   = 2766868
 
 Test 149 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_atmaq
-working dir  = /glade/scratch/jongkim/rt-1445-intel/jongkim/FV3_RT/rt_23060/regional_atmaq
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_atmaq
+working dir  = /glade/scratch/jongkim/rt-1451-intel/jongkim/FV3_RT/rt_43265/regional_atmaq
 Checking test 150 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4549,12 +4549,12 @@ Checking test 150 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 1037.280755
-0:The maximum resident set size (KB)                   = 798152
+0:The total amount of wall time                        = 1130.890279
+0:The maximum resident set size (KB)                   = 798196
 
 Test 150 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct  5 19:43:46 MDT 2022
-Elapsed time: 01h:16m:19s. Have a nice day!
+Sun Oct  9 13:29:21 MDT 2022
+Elapsed time: 03h:41m:15s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,32 +1,32 @@
-Wed Oct  5 16:49:04 EDT 2022
+Sun Oct  9 20:53:20 EDT 2022
 Start Regression test
 
-Compile 001 elapsed time 662 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 668 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 287 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 251 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 548 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 517 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 444 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 762 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 663 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 312 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 290 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 588 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 537 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 480 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 008 elapsed time 527 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 468 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 453 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 667 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 396 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 426 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 186 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 196 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 588 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 628 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 255 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 159 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 563 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 432 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 412 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 471 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 478 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 708 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 196 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 482 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 405 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 212 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 629 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 612 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 260 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 165 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 588 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 452 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 467 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -91,14 +91,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 382.843753
-  0: The maximum resident set size (KB)                   = 1583928
+  0: The total amount of wall time                        = 368.510447
+  0: The maximum resident set size (KB)                   = 1585348
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -151,14 +151,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 233.943936
-  0: The maximum resident set size (KB)                   = 1022304
+  0: The total amount of wall time                        = 215.456117
+  0: The maximum resident set size (KB)                   = 1021840
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -211,14 +211,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 490.689912
-  0: The maximum resident set size (KB)                   = 1750028
+  0: The total amount of wall time                        = 477.406243
+  0: The maximum resident set size (KB)                   = 1760232
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_esmfthreads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -271,14 +271,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 396.536597
-  0: The maximum resident set size (KB)                   = 1790736
+  0: The total amount of wall time                        = 395.432467
+  0: The maximum resident set size (KB)                   = 1774068
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -331,14 +331,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 378.439706
-  0: The maximum resident set size (KB)                   = 1595216
+  0: The total amount of wall time                        = 377.312824
+  0: The maximum resident set size (KB)                   = 1595304
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 311.799720
-  0: The maximum resident set size (KB)                   = 1558584
+  0: The total amount of wall time                        = 320.839383
+  0: The maximum resident set size (KB)                   = 1543580
 
-Test 006 cpld_mpi_p8 PASS Tries: 2
+Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_ciceC_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_ciceC_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_ciceC_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -463,14 +463,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 382.255805
-  0: The maximum resident set size (KB)                   = 1581880
+  0: The total amount of wall time                        = 380.776529
+  0: The maximum resident set size (KB)                   = 1585388
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -523,14 +523,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 776.758441
-  0: The maximum resident set size (KB)                   = 1795844
+  0: The total amount of wall time                        = 774.246185
+  0: The maximum resident set size (KB)                   = 1762512
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_restart_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -583,14 +583,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 505.847842
-  0: The maximum resident set size (KB)                   = 1928452
+  0: The total amount of wall time                        = 469.176213
+  0: The maximum resident set size (KB)                   = 1921644
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -638,14 +638,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 935.924646
-  0: The maximum resident set size (KB)                   = 2497240
+  0: The total amount of wall time                        = 927.976222
+  0: The maximum resident set size (KB)                   = 2497812
 
-Test 010 cpld_bmark_p8 PASS
+Test 010 cpld_bmark_p8 PASS Tries: 2
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_restart_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -693,14 +693,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 620.052436
-  0: The maximum resident set size (KB)                   = 2325412
+  0: The total amount of wall time                        = 628.762400
+  0: The maximum resident set size (KB)                   = 2328480
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_bmark_esmfthreads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_bmark_esmfthreads_p8
 Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -748,14 +748,14 @@ Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 834.694217
-   0: The maximum resident set size (KB)                   = 2536484
+   0: The total amount of wall time                        = 802.501897
+   0: The maximum resident set size (KB)                   = 2521736
 
 Test 012 cpld_bmark_esmfthreads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -819,14 +819,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 253.597108
-  0: The maximum resident set size (KB)                   = 1466548
+  0: The total amount of wall time                        = 242.945732
+  0: The maximum resident set size (KB)                   = 1466560
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_nowave_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -888,14 +888,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 298.603766
-  0: The maximum resident set size (KB)                   = 1498492
+  0: The total amount of wall time                        = 282.927813
+  0: The maximum resident set size (KB)                   = 1484336
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -948,14 +948,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 579.884605
-  0: The maximum resident set size (KB)                   = 1637192
+  0: The total amount of wall time                        = 578.414012
+  0: The maximum resident set size (KB)                   = 1650784
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_noaero_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_debug_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1007,14 +1007,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 393.816115
-  0: The maximum resident set size (KB)                   = 1463400
+  0: The total amount of wall time                        = 390.690134
+  0: The maximum resident set size (KB)                   = 1464472
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_noaero_p8_agrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1076,14 +1076,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 293.108936
-  0: The maximum resident set size (KB)                   = 1487972
+  0: The total amount of wall time                        = 295.769835
+  0: The maximum resident set size (KB)                   = 1488124
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1133,14 +1133,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 593.682466
- 0: The maximum resident set size (KB)                   = 2568524
+ 0: The total amount of wall time                        = 591.018645
+ 0: The maximum resident set size (KB)                   = 2568340
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_warmstart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1190,14 +1190,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 161.425134
- 0: The maximum resident set size (KB)                   = 2575364
+ 0: The total amount of wall time                        = 157.473896
+ 0: The maximum resident set size (KB)                   = 2582416
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/cpld_restart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1247,14 +1247,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 81.781140
- 0: The maximum resident set size (KB)                   = 1999928
+ 0: The total amount of wall time                        = 82.203846
+ 0: The maximum resident set size (KB)                   = 1991640
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control
 Checking test 021 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1301,14 +1301,14 @@ Checking test 021 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 145.894217
-  0: The maximum resident set size (KB)                   = 436848
+  0: The total amount of wall time                        = 146.833624
+  0: The maximum resident set size (KB)                   = 436900
 
 Test 021 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_decomp
 Checking test 022 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1351,14 +1351,14 @@ Checking test 022 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.863947
-  0: The maximum resident set size (KB)                   = 435748
+  0: The total amount of wall time                        = 147.408537
+  0: The maximum resident set size (KB)                   = 435780
 
 Test 022 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_2dwrtdecomp
 Checking test 023 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1369,14 +1369,14 @@ Checking test 023 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 144.057236
-  0: The maximum resident set size (KB)                   = 436900
+  0: The total amount of wall time                        = 143.974974
+  0: The maximum resident set size (KB)                   = 436884
 
 Test 023 control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_2threads
 Checking test 024 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1419,14 +1419,14 @@ Checking test 024 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 185.161048
- 0: The maximum resident set size (KB)                   = 491044
+ 0: The total amount of wall time                        = 185.124864
+ 0: The maximum resident set size (KB)                   = 490968
 
 Test 024 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_restart
 Checking test 025 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1465,14 +1465,14 @@ Checking test 025 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 73.508998
-  0: The maximum resident set size (KB)                   = 174608
+  0: The total amount of wall time                        = 74.967111
+  0: The maximum resident set size (KB)                   = 174680
 
 Test 025 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_fhzero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_fhzero
 Checking test 026 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1515,14 +1515,14 @@ Checking test 026 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 139.002668
-  0: The maximum resident set size (KB)                   = 436768
+  0: The total amount of wall time                        = 133.605409
+  0: The maximum resident set size (KB)                   = 436856
 
 Test 026 control_fhzero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_CubedSphereGrid
 Checking test 027 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1549,28 +1549,28 @@ Checking test 027 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 136.344704
-  0: The maximum resident set size (KB)                   = 437168
+  0: The total amount of wall time                        = 136.603541
+  0: The maximum resident set size (KB)                   = 437180
 
 Test 027 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_CubedSphereGrid_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_CubedSphereGrid_parallel
 Checking test 028 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 183.740637
-  0: The maximum resident set size (KB)                   = 437120
+  0: The total amount of wall time                        = 141.031800
+  0: The maximum resident set size (KB)                   = 437176
 
 Test 028 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_latlon
 Checking test 029 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1581,14 +1581,14 @@ Checking test 029 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.447140
-  0: The maximum resident set size (KB)                   = 436864
+  0: The total amount of wall time                        = 140.226150
+  0: The maximum resident set size (KB)                   = 436728
 
 Test 029 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_wrtGauss_netcdf_parallel
 Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1599,14 +1599,14 @@ Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.926821
-  0: The maximum resident set size (KB)                   = 436756
+  0: The total amount of wall time                        = 145.721196
+  0: The maximum resident set size (KB)                   = 436668
 
 Test 030 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_c48
 Checking test 031 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1645,14 +1645,14 @@ Checking test 031 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 370.714332
-0: The maximum resident set size (KB)                   = 629696
+0: The total amount of wall time                        = 371.055072
+0: The maximum resident set size (KB)                   = 628956
 
 Test 031 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c192
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_c192
 Checking test 032 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1663,14 +1663,14 @@ Checking test 032 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 576.995752
-  0: The maximum resident set size (KB)                   = 540000
+  0: The total amount of wall time                        = 571.873505
+  0: The maximum resident set size (KB)                   = 539852
 
 Test 032 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_c384
 Checking test 033 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1681,14 +1681,14 @@ Checking test 033 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 803.670908
-  0: The maximum resident set size (KB)                   = 813224
+  0: The total amount of wall time                        = 796.571377
+  0: The maximum resident set size (KB)                   = 812176
 
-Test 033 control_c384 PASS Tries: 2
+Test 033 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_c384gdas
 Checking test 034 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1731,14 +1731,14 @@ Checking test 034 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 701.255731
-  0: The maximum resident set size (KB)                   = 932832
+  0: The total amount of wall time                        = 678.519613
+  0: The maximum resident set size (KB)                   = 933224
 
 Test 034 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384_progsigma
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_c384_progsigma
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384_progsigma
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_c384_progsigma
 Checking test 035 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1749,14 +1749,14 @@ Checking test 035 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 824.156643
-  0: The maximum resident set size (KB)                   = 830592
+  0: The total amount of wall time                        = 810.396853
+  0: The maximum resident set size (KB)                   = 831556
 
 Test 035 control_c384_progsigma PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_stochy
 Checking test 036 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1767,28 +1767,28 @@ Checking test 036 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 93.363021
-  0: The maximum resident set size (KB)                   = 441112
+  0: The total amount of wall time                        = 94.881109
+  0: The maximum resident set size (KB)                   = 440992
 
-Test 036 control_stochy PASS Tries: 2
+Test 036 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_stochy_restart
 Checking test 037 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 52.029315
-  0: The maximum resident set size (KB)                   = 191860
+  0: The total amount of wall time                        = 50.245285
+  0: The maximum resident set size (KB)                   = 186180
 
 Test 037 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_lndp
 Checking test 038 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 038 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 123.954068
-  0: The maximum resident set size (KB)                   = 441196
+  0: The total amount of wall time                        = 85.870896
+  0: The maximum resident set size (KB)                   = 441004
 
-Test 038 control_lndp PASS Tries: 2
+Test 038 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_iovr4
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_iovr4
 Checking test 039 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1821,14 +1821,14 @@ Checking test 039 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 144.946385
-  0: The maximum resident set size (KB)                   = 436820
+  0: The total amount of wall time                        = 147.691924
+  0: The maximum resident set size (KB)                   = 436928
 
 Test 039 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_iovr5
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_iovr5
 Checking test 040 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1843,14 +1843,14 @@ Checking test 040 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.653655
-  0: The maximum resident set size (KB)                   = 436900
+  0: The total amount of wall time                        = 142.563475
+  0: The maximum resident set size (KB)                   = 436832
 
 Test 040 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_p8
 Checking test 041 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1897,14 +1897,14 @@ Checking test 041 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 261.937350
-  0: The maximum resident set size (KB)                   = 1403264
+  0: The total amount of wall time                        = 175.009873
+  0: The maximum resident set size (KB)                   = 1379780
 
-Test 041 control_p8 PASS Tries: 2
+Test 041 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_p8_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_lndp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_p8_lndp
 Checking test 042 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1923,14 +1923,14 @@ Checking test 042 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 340.785889
-  0: The maximum resident set size (KB)                   = 1380060
+  0: The total amount of wall time                        = 325.916863
+  0: The maximum resident set size (KB)                   = 1403908
 
 Test 042 control_p8_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_restart_p8
 Checking test 043 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1969,14 +1969,14 @@ Checking test 043 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 103.289714
-  0: The maximum resident set size (KB)                   = 549716
+  0: The total amount of wall time                        = 104.602598
+  0: The maximum resident set size (KB)                   = 550096
 
 Test 043 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_decomp_p8
 Checking test 044 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2019,14 +2019,14 @@ Checking test 044 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 182.516848
-  0: The maximum resident set size (KB)                   = 1397724
+  0: The total amount of wall time                        = 179.975589
+  0: The maximum resident set size (KB)                   = 1397652
 
 Test 044 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_2threads_p8
 Checking test 045 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2069,14 +2069,14 @@ Checking test 045 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 230.536948
- 0: The maximum resident set size (KB)                   = 1484948
+ 0: The total amount of wall time                        = 225.640469
+ 0: The maximum resident set size (KB)                   = 1484684
 
-Test 045 control_2threads_p8 PASS Tries: 2
+Test 045 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_p8_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_p8_rrtmgp
 Checking test 046 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2123,14 +2123,14 @@ Checking test 046 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 294.536400
-  0: The maximum resident set size (KB)                   = 1504728
+  0: The total amount of wall time                        = 226.264853
+  0: The maximum resident set size (KB)                   = 1518972
 
-Test 046 control_p8_rrtmgp PASS Tries: 2
+Test 046 control_p8_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/merra2_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/merra2_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/merra2_thompson
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2177,14 +2177,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.229532
-  0: The maximum resident set size (KB)                   = 1409560
+  0: The total amount of wall time                        = 179.231827
+  0: The maximum resident set size (KB)                   = 1409648
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2195,28 +2195,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 366.099781
- 0: The maximum resident set size (KB)                   = 544292
+ 0: The total amount of wall time                        = 365.601432
+ 0: The maximum resident set size (KB)                   = 544412
 
 Test 048 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 201.988078
- 0: The maximum resident set size (KB)                   = 541196
+ 0: The total amount of wall time                        = 199.445148
+ 0: The maximum resident set size (KB)                   = 541152
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_control_2dwrtdecomp
 Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2227,14 +2227,14 @@ Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 392.044604
- 0: The maximum resident set size (KB)                   = 544340
+ 0: The total amount of wall time                        = 365.361194
+ 0: The maximum resident set size (KB)                   = 544348
 
 Test 050 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_noquilt
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2242,14 +2242,14 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 389.967595
- 0: The maximum resident set size (KB)                   = 554396
+ 0: The total amount of wall time                        = 386.006126
+ 0: The maximum resident set size (KB)                   = 554400
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2260,28 +2260,28 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 289.974073
- 0: The maximum resident set size (KB)                   = 545384
+ 0: The total amount of wall time                        = 283.579701
+ 0: The maximum resident set size (KB)                   = 545236
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_netcdf_parallel
 Checking test 053 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 363.120510
- 0: The maximum resident set size (KB)                   = 542616
+ 0: The total amount of wall time                        = 362.804720
+ 0: The maximum resident set size (KB)                   = 542756
 
 Test 053 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_3km
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_3km
 Checking test 054 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 054 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 287.877004
-  0: The maximum resident set size (KB)                   = 571012
+  0: The total amount of wall time                        = 290.151166
+  0: The maximum resident set size (KB)                   = 570976
 
 Test 054 regional_3km PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_3km_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_3km_decomp
 Checking test 055 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2310,14 +2310,14 @@ Checking test 055 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 306.188057
-  0: The maximum resident set size (KB)                   = 581580
+  0: The total amount of wall time                        = 306.888791
+  0: The maximum resident set size (KB)                   = 581432
 
 Test 055 regional_3km_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_control
 Checking test 056 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2364,14 +2364,14 @@ Checking test 056 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.854691
-  0: The maximum resident set size (KB)                   = 806676
+  0: The total amount of wall time                        = 461.065644
+  0: The maximum resident set size (KB)                   = 806732
 
 Test 056 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_rrtmgp
 Checking test 057 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2418,14 +2418,14 @@ Checking test 057 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 505.707678
-  0: The maximum resident set size (KB)                   = 924168
+  0: The total amount of wall time                        = 509.566825
+  0: The maximum resident set size (KB)                   = 924092
 
 Test 057 rap_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_spp_sppt_shum_skeb
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_spp_sppt_shum_skeb
 Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2436,14 +2436,14 @@ Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 357.095545
-  0: The maximum resident set size (KB)                   = 880124
+  0: The total amount of wall time                        = 351.049585
+  0: The maximum resident set size (KB)                   = 880300
 
 Test 058 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_decomp
 Checking test 059 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2490,14 +2490,14 @@ Checking test 059 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 485.587904
-  0: The maximum resident set size (KB)                   = 805876
+  0: The total amount of wall time                        = 488.477502
+  0: The maximum resident set size (KB)                   = 805832
 
 Test 059 rap_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_2threads
 Checking test 060 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2544,14 +2544,14 @@ Checking test 060 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 590.140502
- 0: The maximum resident set size (KB)                   = 871260
+ 0: The total amount of wall time                        = 587.855019
+ 0: The maximum resident set size (KB)                   = 871236
 
 Test 060 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_restart
 Checking test 061 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2590,14 +2590,14 @@ Checking test 061 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.228519
-  0: The maximum resident set size (KB)                   = 549380
+  0: The total amount of wall time                        = 234.161191
+  0: The maximum resident set size (KB)                   = 549476
 
 Test 061 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_sfcdiff
 Checking test 062 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2644,14 +2644,14 @@ Checking test 062 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.978927
-  0: The maximum resident set size (KB)                   = 806816
+  0: The total amount of wall time                        = 455.528336
+  0: The maximum resident set size (KB)                   = 806908
 
 Test 062 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_sfcdiff_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_sfcdiff_decomp
 Checking test 063 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2698,14 +2698,14 @@ Checking test 063 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 482.103210
-  0: The maximum resident set size (KB)                   = 805640
+  0: The total amount of wall time                        = 482.573090
+  0: The maximum resident set size (KB)                   = 805668
 
 Test 063 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_sfcdiff_restart
 Checking test 064 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2744,14 +2744,14 @@ Checking test 064 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 342.509904
-  0: The maximum resident set size (KB)                   = 550852
+  0: The total amount of wall time                        = 339.665449
+  0: The maximum resident set size (KB)                   = 550704
 
 Test 064 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control
 Checking test 065 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 065 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 443.902709
-  0: The maximum resident set size (KB)                   = 803332
+  0: The total amount of wall time                        = 441.240413
+  0: The maximum resident set size (KB)                   = 803524
 
 Test 065 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_decomp
 Checking test 066 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2852,14 +2852,14 @@ Checking test 066 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.685331
-  0: The maximum resident set size (KB)                   = 803184
+  0: The total amount of wall time                        = 460.157622
+  0: The maximum resident set size (KB)                   = 803308
 
 Test 066 hrrr_control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_2threads
 Checking test 067 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2906,14 +2906,14 @@ Checking test 067 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 563.036192
- 0: The maximum resident set size (KB)                   = 865156
+ 0: The total amount of wall time                        = 556.217389
+ 0: The maximum resident set size (KB)                   = 865388
 
 Test 067 hrrr_control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_restart
 Checking test 068 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 068 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.186009
-  0: The maximum resident set size (KB)                   = 546320
+  0: The total amount of wall time                        = 329.333200
+  0: The maximum resident set size (KB)                   = 546204
 
 Test 068 hrrr_control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_v1beta
 Checking test 069 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3006,14 +3006,14 @@ Checking test 069 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 457.049849
-  0: The maximum resident set size (KB)                   = 801752
+  0: The total amount of wall time                        = 453.129198
+  0: The maximum resident set size (KB)                   = 801868
 
 Test 069 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_v1nssl
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_v1nssl
 Checking test 070 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3028,14 +3028,14 @@ Checking test 070 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 556.971958
-  0: The maximum resident set size (KB)                   = 490548
+  0: The total amount of wall time                        = 553.184044
+  0: The maximum resident set size (KB)                   = 490568
 
 Test 070 rrfs_v1nssl PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_v1nssl_nohailnoccn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_v1nssl_nohailnoccn
 Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3050,14 +3050,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 540.970806
-  0: The maximum resident set size (KB)                   = 484136
+  0: The total amount of wall time                        = 540.720616
+  0: The maximum resident set size (KB)                   = 484192
 
 Test 071 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_conus13km_hrrr_warm
 Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3066,14 +3066,14 @@ Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 199.448277
-  0: The maximum resident set size (KB)                   = 617636
+  0: The total amount of wall time                        = 197.010367
+  0: The maximum resident set size (KB)                   = 617508
 
 Test 072 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_conus13km_radar_tten_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_conus13km_radar_tten_warm
 Checking test 073 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3082,14 +3082,14 @@ Checking test 073 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 200.318910
-  0: The maximum resident set size (KB)                   = 620680
+  0: The total amount of wall time                        = 190.159871
+  0: The maximum resident set size (KB)                   = 620540
 
 Test 073 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_smoke_conus13km_hrrr_warm
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3098,14 +3098,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 218.932322
-  0: The maximum resident set size (KB)                   = 628216
+  0: The total amount of wall time                        = 215.746822
+  0: The maximum resident set size (KB)                   = 627688
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_csawmgt
 Checking test 075 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3116,14 +3116,14 @@ Checking test 075 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 389.952310
-  0: The maximum resident set size (KB)                   = 505892
+  0: The total amount of wall time                        = 391.003237
+  0: The maximum resident set size (KB)                   = 505688
 
 Test 075 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_ras
 Checking test 076 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3134,54 +3134,54 @@ Checking test 076 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 198.110294
-  0: The maximum resident set size (KB)                   = 472340
+  0: The total amount of wall time                        = 196.434645
+  0: The maximum resident set size (KB)                   = 472264
 
 Test 076 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_wam
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_wam
 Checking test 077 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 122.498587
-  0: The maximum resident set size (KB)                   = 185984
+  0: The total amount of wall time                        = 122.820755
+  0: The maximum resident set size (KB)                   = 186376
 
 Test 077 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_debug
 Checking test 078 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.937856
-  0: The maximum resident set size (KB)                   = 602772
+  0: The total amount of wall time                        = 153.756534
+  0: The maximum resident set size (KB)                   = 602232
 
 Test 078 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_2threads_debug
 Checking test 079 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 268.655201
- 0: The maximum resident set size (KB)                   = 655324
+ 0: The total amount of wall time                        = 266.347178
+ 0: The maximum resident set size (KB)                   = 654432
 
 Test 079 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_CubedSphereGrid_debug
 Checking test 080 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3208,348 +3208,348 @@ Checking test 080 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.509258
-  0: The maximum resident set size (KB)                   = 602260
+  0: The total amount of wall time                        = 163.929409
+  0: The maximum resident set size (KB)                   = 602256
 
 Test 080 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_wrtGauss_netcdf_parallel_debug
 Checking test 081 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.850159
-  0: The maximum resident set size (KB)                   = 602464
+  0: The total amount of wall time                        = 154.652233
+  0: The maximum resident set size (KB)                   = 602528
 
 Test 081 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_stochy_debug
 Checking test 082 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.549668
-  0: The maximum resident set size (KB)                   = 609504
+  0: The total amount of wall time                        = 178.574355
+  0: The maximum resident set size (KB)                   = 609288
 
 Test 082 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_lndp_debug
 Checking test 083 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.864748
-  0: The maximum resident set size (KB)                   = 607200
+  0: The total amount of wall time                        = 157.150771
+  0: The maximum resident set size (KB)                   = 606964
 
 Test 083 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_csawmg_debug
 Checking test 084 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.023357
-  0: The maximum resident set size (KB)                   = 644028
+  0: The total amount of wall time                        = 252.042986
+  0: The maximum resident set size (KB)                   = 644236
 
 Test 084 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_csawmgt_debug
 Checking test 085 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 245.232883
-  0: The maximum resident set size (KB)                   = 643764
+  0: The total amount of wall time                        = 251.602158
+  0: The maximum resident set size (KB)                   = 643700
 
 Test 085 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_ras_debug
 Checking test 086 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.565489
-  0: The maximum resident set size (KB)                   = 616508
+  0: The total amount of wall time                        = 160.219498
+  0: The maximum resident set size (KB)                   = 616400
 
 Test 086 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_diag_debug
 Checking test 087 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.732473
-  0: The maximum resident set size (KB)                   = 661852
+  0: The total amount of wall time                        = 163.453093
+  0: The maximum resident set size (KB)                   = 661924
 
 Test 087 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_debug_p8
 Checking test 088 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 184.782392
-  0: The maximum resident set size (KB)                   = 1380220
+  0: The total amount of wall time                        = 179.093016
+  0: The maximum resident set size (KB)                   = 1379812
 
 Test 088 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_debug
 Checking test 089 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 257.336543
- 0: The maximum resident set size (KB)                   = 570820
+ 0: The total amount of wall time                        = 258.446954
+ 0: The maximum resident set size (KB)                   = 571796
 
 Test 089 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_control_debug
 Checking test 090 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.307375
-  0: The maximum resident set size (KB)                   = 971448
+  0: The total amount of wall time                        = 286.681784
+  0: The maximum resident set size (KB)                   = 971212
 
 Test 090 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_debug
 Checking test 091 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.928318
-  0: The maximum resident set size (KB)                   = 967300
+  0: The total amount of wall time                        = 279.864363
+  0: The maximum resident set size (KB)                   = 967364
 
 Test 091 hrrr_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_unified_drag_suite_debug
 Checking test 092 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.847906
-  0: The maximum resident set size (KB)                   = 971340
+  0: The total amount of wall time                        = 288.277497
+  0: The maximum resident set size (KB)                   = 971044
 
 Test 092 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_diag_debug
 Checking test 093 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.854993
-  0: The maximum resident set size (KB)                   = 1054580
+  0: The total amount of wall time                        = 300.729407
+  0: The maximum resident set size (KB)                   = 1054172
 
 Test 093 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_cires_ugwp_debug
 Checking test 094 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.119323
-  0: The maximum resident set size (KB)                   = 969528
+  0: The total amount of wall time                        = 292.213854
+  0: The maximum resident set size (KB)                   = 969248
 
 Test 094 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_unified_ugwp_debug
 Checking test 095 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.087419
-  0: The maximum resident set size (KB)                   = 971492
+  0: The total amount of wall time                        = 291.666858
+  0: The maximum resident set size (KB)                   = 970840
 
 Test 095 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_lndp_debug
 Checking test 096 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.283567
-  0: The maximum resident set size (KB)                   = 972260
+  0: The total amount of wall time                        = 287.682988
+  0: The maximum resident set size (KB)                   = 971792
 
 Test 096 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_flake_debug
 Checking test 097 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.139378
-  0: The maximum resident set size (KB)                   = 971220
+  0: The total amount of wall time                        = 285.642111
+  0: The maximum resident set size (KB)                   = 970612
 
 Test 097 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_progcld_thompson_debug
 Checking test 098 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.796564
-  0: The maximum resident set size (KB)                   = 971236
+  0: The total amount of wall time                        = 284.225541
+  0: The maximum resident set size (KB)                   = 970888
 
 Test 098 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_noah_debug
 Checking test 099 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.480554
-  0: The maximum resident set size (KB)                   = 970324
+  0: The total amount of wall time                        = 282.228167
+  0: The maximum resident set size (KB)                   = 969776
 
 Test 099 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_rrtmgp_debug
 Checking test 100 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 483.019776
-  0: The maximum resident set size (KB)                   = 1092120
+  0: The total amount of wall time                        = 481.149207
+  0: The maximum resident set size (KB)                   = 1092436
 
 Test 100 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_sfcdiff_debug
 Checking test 101 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.429497
-  0: The maximum resident set size (KB)                   = 971068
+  0: The total amount of wall time                        = 284.196413
+  0: The maximum resident set size (KB)                   = 970148
 
 Test 101 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 102 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 473.320178
-  0: The maximum resident set size (KB)                   = 968868
+  0: The total amount of wall time                        = 468.884650
+  0: The maximum resident set size (KB)                   = 969304
 
 Test 102 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rrfs_v1beta_debug
 Checking test 103 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.638588
-  0: The maximum resident set size (KB)                   = 966212
+  0: The total amount of wall time                        = 281.120470
+  0: The maximum resident set size (KB)                   = 967120
 
 Test 103 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_wam_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_wam_debug
 Checking test 104 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 292.592660
-  0: The maximum resident set size (KB)                   = 218460
+  0: The total amount of wall time                        = 292.037140
+  0: The maximum resident set size (KB)                   = 218160
 
 Test 104 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 105 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3560,14 +3560,14 @@ Checking test 105 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 318.758237
-  0: The maximum resident set size (KB)                   = 789272
+  0: The total amount of wall time                        = 322.037415
+  0: The maximum resident set size (KB)                   = 789952
 
 Test 105 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_control_dyn32_phy32
 Checking test 106 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3614,14 +3614,14 @@ Checking test 106 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 376.537978
-  0: The maximum resident set size (KB)                   = 689424
+  0: The total amount of wall time                        = 377.675174
+  0: The maximum resident set size (KB)                   = 689432
 
 Test 106 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_dyn32_phy32
 Checking test 107 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3668,14 +3668,14 @@ Checking test 107 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.838167
-  0: The maximum resident set size (KB)                   = 687428
+  0: The total amount of wall time                        = 196.834906
+  0: The maximum resident set size (KB)                   = 687608
 
 Test 107 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_2threads_dyn32_phy32
 Checking test 108 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3722,14 +3722,14 @@ Checking test 108 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 483.341763
- 0: The maximum resident set size (KB)                   = 735024
+ 0: The total amount of wall time                        = 487.390245
+ 0: The maximum resident set size (KB)                   = 735364
 
 Test 108 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_2threads_dyn32_phy32
 Checking test 109 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3776,14 +3776,14 @@ Checking test 109 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 249.195268
- 0: The maximum resident set size (KB)                   = 730768
+ 0: The total amount of wall time                        = 250.887035
+ 0: The maximum resident set size (KB)                   = 730968
 
 Test 109 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_decomp_dyn32_phy32
 Checking test 110 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3830,14 +3830,14 @@ Checking test 110 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.382670
-  0: The maximum resident set size (KB)                   = 687300
+  0: The total amount of wall time                        = 205.988792
+  0: The maximum resident set size (KB)                   = 687268
 
 Test 110 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_restart_dyn32_phy32
 Checking test 111 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3876,14 +3876,14 @@ Checking test 111 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 279.345824
-  0: The maximum resident set size (KB)                   = 512180
+  0: The total amount of wall time                        = 285.712050
+  0: The maximum resident set size (KB)                   = 521580
 
 Test 111 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_restart_dyn32_phy32
 Checking test 112 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3922,14 +3922,14 @@ Checking test 112 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 99.803775
-  0: The maximum resident set size (KB)                   = 519348
+  0: The total amount of wall time                        = 100.619310
+  0: The maximum resident set size (KB)                   = 519312
 
 Test 112 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn64_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_control_dyn64_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn64_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_control_dyn64_phy32
 Checking test 113 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3976,81 +3976,81 @@ Checking test 113 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 250.561998
-  0: The maximum resident set size (KB)                   = 706352
+  0: The total amount of wall time                        = 251.321571
+  0: The maximum resident set size (KB)                   = 706420
 
 Test 113 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_control_debug_dyn32_phy32
 Checking test 114 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.474863
-  0: The maximum resident set size (KB)                   = 855628
+  0: The total amount of wall time                        = 284.193070
+  0: The maximum resident set size (KB)                   = 855572
 
 Test 114 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hrrr_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hrrr_control_debug_dyn32_phy32
 Checking test 115 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.809050
-  0: The maximum resident set size (KB)                   = 852768
+  0: The total amount of wall time                        = 280.515325
+  0: The maximum resident set size (KB)                   = 853116
 
 Test 115 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/rap_control_dyn64_phy32_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/rap_control_dyn64_phy32_debug
 Checking test 116 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.907783
-  0: The maximum resident set size (KB)                   = 872204
+  0: The total amount of wall time                        = 285.074369
+  0: The maximum resident set size (KB)                   = 872256
 
 Test 116 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_atm
 Checking test 117 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 342.284454
-  0: The maximum resident set size (KB)                   = 662452
+  0: The total amount of wall time                        = 349.885283
+  0: The maximum resident set size (KB)                   = 661984
 
 Test 117 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_atm_thompson_gfdlsf
 Checking test 118 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 389.178847
-  0: The maximum resident set size (KB)                   = 1022044
+  0: The total amount of wall time                        = 396.593415
+  0: The maximum resident set size (KB)                   = 1022328
 
 Test 118 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_atm_ocn
 Checking test 119 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4059,14 +4059,14 @@ Checking test 119 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 423.128723
-  0: The maximum resident set size (KB)                   = 692888
+  0: The total amount of wall time                        = 434.092338
+  0: The maximum resident set size (KB)                   = 692628
 
 Test 119 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_atm_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_atm_wav
 Checking test 120 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4075,14 +4075,14 @@ Checking test 120 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 889.011449
-  0: The maximum resident set size (KB)                   = 727752
+  0: The total amount of wall time                        = 894.136785
+  0: The maximum resident set size (KB)                   = 726916
 
 Test 120 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_atm_ocn_wav
 Checking test 121 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4093,28 +4093,28 @@ Checking test 121 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 992.465195
-  0: The maximum resident set size (KB)                   = 737600
+  0: The total amount of wall time                        = 997.744613
+  0: The maximum resident set size (KB)                   = 736356
 
 Test 121 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_1nest_atm
 Checking test 122 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 566.302824
-  0: The maximum resident set size (KB)                   = 261856
+  0: The total amount of wall time                        = 569.533632
+  0: The maximum resident set size (KB)                   = 261600
 
 Test 122 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_telescopic_2nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_telescopic_2nests_atm
 Checking test 123 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4123,28 +4123,28 @@ Checking test 123 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 612.626695
-  0: The maximum resident set size (KB)                   = 267572
+  0: The total amount of wall time                        = 618.559875
+  0: The maximum resident set size (KB)                   = 268160
 
 Test 123 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_global_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_global_1nest_atm
 Checking test 124 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 254.682119
-  0: The maximum resident set size (KB)                   = 165796
+  0: The total amount of wall time                        = 255.638908
+  0: The maximum resident set size (KB)                   = 165848
 
 Test 124 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_global_multiple_4nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_global_multiple_4nests_atm
 Checking test 125 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4162,14 +4162,14 @@ Checking test 125 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 721.189540
-  0: The maximum resident set size (KB)                   = 237176
+  0: The total amount of wall time                        = 730.375660
+  0: The maximum resident set size (KB)                   = 235648
 
 Test 125 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_specified_moving_1nest_atm
 Checking test 126 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4178,28 +4178,28 @@ Checking test 126 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 328.189867
-  0: The maximum resident set size (KB)                   = 271884
+  0: The total amount of wall time                        = 334.037534
+  0: The maximum resident set size (KB)                   = 272616
 
 Test 126 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_storm_following_1nest_atm
 Checking test 127 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 316.519923
-  0: The maximum resident set size (KB)                   = 272516
+  0: The total amount of wall time                        = 319.710704
+  0: The maximum resident set size (KB)                   = 272512
 
 Test 127 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 128 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4208,14 +4208,14 @@ Checking test 128 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 328.494063
-  0: The maximum resident set size (KB)                   = 301444
+  0: The total amount of wall time                        = 341.652372
+  0: The maximum resident set size (KB)                   = 301440
 
 Test 128 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 129 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4226,28 +4226,28 @@ Checking test 129 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 873.044959
-  0: The maximum resident set size (KB)                   = 359484
+  0: The total amount of wall time                        = 886.425901
+  0: The maximum resident set size (KB)                   = 359796
 
 Test 129 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_global_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_global_storm_following_1nest_atm
 Checking test 130 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 94.093872
-  0: The maximum resident set size (KB)                   = 184804
+  0: The total amount of wall time                        = 92.937421
+  0: The maximum resident set size (KB)                   = 184748
 
 Test 130 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_docn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_docn
 Checking test 131 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4255,14 +4255,14 @@ Checking test 131 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 407.024079
-  0: The maximum resident set size (KB)                   = 702976
+  0: The total amount of wall time                        = 423.331034
+  0: The maximum resident set size (KB)                   = 702940
 
 Test 131 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_docn_oisst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_docn_oisst
 Checking test 132 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4270,131 +4270,131 @@ Checking test 132 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 408.870656
-  0: The maximum resident set size (KB)                   = 686500
+  0: The total amount of wall time                        = 418.627972
+  0: The maximum resident set size (KB)                   = 686184
 
 Test 132 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/hafs_regional_datm_cdeps
 Checking test 133 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1168.238946
-  0: The maximum resident set size (KB)                   = 809832
+  0: The total amount of wall time                        = 1171.908333
+  0: The maximum resident set size (KB)                   = 809848
 
 Test 133 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_control_cfsr
 Checking test 134 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 158.154624
- 0: The maximum resident set size (KB)                   = 721124
+ 0: The total amount of wall time                        = 158.141796
+ 0: The maximum resident set size (KB)                   = 720972
 
 Test 134 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_restart_cfsr
 Checking test 135 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 92.200256
- 0: The maximum resident set size (KB)                   = 709008
+ 0: The total amount of wall time                        = 92.698260
+ 0: The maximum resident set size (KB)                   = 708944
 
 Test 135 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_control_gefs
 Checking test 136 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.839018
- 0: The maximum resident set size (KB)                   = 605908
+ 0: The total amount of wall time                        = 152.695580
+ 0: The maximum resident set size (KB)                   = 605328
 
 Test 136 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_iau_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_iau_gefs
 Checking test 137 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.681524
- 0: The maximum resident set size (KB)                   = 600940
+ 0: The total amount of wall time                        = 154.566865
+ 0: The maximum resident set size (KB)                   = 603340
 
 Test 137 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_stochy_gefs
 Checking test 138 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.949296
- 0: The maximum resident set size (KB)                   = 600992
+ 0: The total amount of wall time                        = 155.979509
+ 0: The maximum resident set size (KB)                   = 601248
 
 Test 138 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_ciceC_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_ciceC_cfsr
 Checking test 139 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 157.320625
- 0: The maximum resident set size (KB)                   = 721284
+ 0: The total amount of wall time                        = 160.140465
+ 0: The maximum resident set size (KB)                   = 721156
 
 Test 139 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_bulk_cfsr
 Checking test 140 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.855933
- 0: The maximum resident set size (KB)                   = 721360
+ 0: The total amount of wall time                        = 157.893212
+ 0: The maximum resident set size (KB)                   = 721136
 
 Test 140 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_bulk_gefs
 Checking test 141 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.678354
- 0: The maximum resident set size (KB)                   = 602940
+ 0: The total amount of wall time                        = 153.030800
+ 0: The maximum resident set size (KB)                   = 601212
 
 Test 141 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_mx025_cfsr
 Checking test 142 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4403,14 +4403,14 @@ Checking test 142 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 432.000247
-  0: The maximum resident set size (KB)                   = 494512
+  0: The total amount of wall time                        = 457.125152
+  0: The maximum resident set size (KB)                   = 494792
 
 Test 142 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_mx025_gefs
 Checking test 143 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4419,64 +4419,64 @@ Checking test 143 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 401.185747
-  0: The maximum resident set size (KB)                   = 476888
+  0: The total amount of wall time                        = 454.304892
+  0: The maximum resident set size (KB)                   = 476316
 
 Test 143 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_multiple_files_cfsr
 Checking test 144 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.840526
- 0: The maximum resident set size (KB)                   = 721144
+ 0: The total amount of wall time                        = 157.769502
+ 0: The maximum resident set size (KB)                   = 721120
 
 Test 144 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_3072x1536_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_3072x1536_cfsr
 Checking test 145 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 213.066101
- 0: The maximum resident set size (KB)                   = 1967588
+ 0: The total amount of wall time                        = 213.334798
+ 0: The maximum resident set size (KB)                   = 1967468
 
 Test 145 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_gfs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_gfs
 Checking test 146 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 214.922931
- 0: The maximum resident set size (KB)                   = 1963200
+ 0: The total amount of wall time                        = 215.806347
+ 0: The maximum resident set size (KB)                   = 1963228
 
 Test 146 datm_cdeps_gfs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/datm_cdeps_debug_cfsr
 Checking test 147 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 369.177006
- 0: The maximum resident set size (KB)                   = 715148
+ 0: The total amount of wall time                        = 372.234654
+ 0: The maximum resident set size (KB)                   = 714912
 
 Test 147 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/control_atmwav
 Checking test 148 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4520,14 +4520,14 @@ Checking test 148 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 93.006829
-  0: The maximum resident set size (KB)                   = 449436
+  0: The total amount of wall time                        = 96.138745
+  0: The maximum resident set size (KB)                   = 449468
 
 Test 148 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/atmaero_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/atmaero_control_p8
 Checking test 149 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4571,14 +4571,14 @@ Checking test 149 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 242.466253
-  0: The maximum resident set size (KB)                   = 1477460
+  0: The total amount of wall time                        = 255.433741
+  0: The maximum resident set size (KB)                   = 1477324
 
 Test 149 atmaero_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/atmaero_control_p8_rad
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/atmaero_control_p8_rad
 Checking test 150 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4622,14 +4622,14 @@ Checking test 150 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 295.016303
-  0: The maximum resident set size (KB)                   = 1481064
+  0: The total amount of wall time                        = 300.994047
+  0: The maximum resident set size (KB)                   = 1481372
 
 Test 150 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/atmaero_control_p8_rad_micro
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/atmaero_control_p8_rad_micro
 Checking test 151 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4673,14 +4673,14 @@ Checking test 151 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 299.294220
-  0: The maximum resident set size (KB)                   = 1486032
+  0: The total amount of wall time                        = 304.098561
+  0: The maximum resident set size (KB)                   = 1485872
 
 Test 151 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_atmaq
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_22599/regional_atmaq
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_atmaq
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_26423/regional_atmaq
 Checking test 152 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4696,12 +4696,12 @@ Checking test 152 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 689.994127
-  0: The maximum resident set size (KB)                   = 744816
+  0: The total amount of wall time                        = 712.304569
+  0: The maximum resident set size (KB)                   = 744820
 
 Test 152 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct  5 20:43:55 EDT 2022
-Elapsed time: 03h:54m:52s. Have a nice day!
+Mon Oct 10 06:10:01 EDT 2022
+Elapsed time: 09h:16m:42s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,21 +1,21 @@
-Wed Oct  5 19:32:13 UTC 2022
+Sun Oct  9 19:49:00 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 227 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 351 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 130 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 234 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 431 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 350 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 345 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 316 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 278 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 145 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 114 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 306 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 97 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 377 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 302 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 302 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 266 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 228 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 141 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 116 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -62,14 +62,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 843.730687
-  0: The maximum resident set size (KB)                   = 477168
+  0: The total amount of wall time                        = 818.756511
+  0: The maximum resident set size (KB)                   = 476756
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -108,14 +108,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 397.793076
-  0: The maximum resident set size (KB)                   = 181780
+  0: The total amount of wall time                        = 405.727644
+  0: The maximum resident set size (KB)                   = 184604
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -154,14 +154,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 672.566660
-0: The maximum resident set size (KB)                   = 703372
+0: The total amount of wall time                        = 676.523759
+0: The maximum resident set size (KB)                   = 704376
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -172,14 +172,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 646.543047
-  0: The maximum resident set size (KB)                   = 483196
+  0: The total amount of wall time                        = 665.294180
+  0: The maximum resident set size (KB)                   = 481516
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_ras
 Checking test 005 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -190,14 +190,14 @@ Checking test 005 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 828.251337
-  0: The maximum resident set size (KB)                   = 485464
+  0: The total amount of wall time                        = 829.761189
+  0: The maximum resident set size (KB)                   = 490636
 
 Test 005 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_p8
 Checking test 006 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -244,14 +244,14 @@ Checking test 006 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 892.477339
-  0: The maximum resident set size (KB)                   = 1238028
+  0: The total amount of wall time                        = 901.096989
+  0: The maximum resident set size (KB)                   = 1233492
 
 Test 006 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_control
 Checking test 007 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -298,14 +298,14 @@ Checking test 007 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1510.642322
-  0: The maximum resident set size (KB)                   = 827160
+  0: The total amount of wall time                        = 1433.202689
+  0: The maximum resident set size (KB)                   = 830476
 
 Test 007 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_decomp
 Checking test 008 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1420.355909
-  0: The maximum resident set size (KB)                   = 827036
+  0: The total amount of wall time                        = 1425.502470
+  0: The maximum resident set size (KB)                   = 830984
 
 Test 008 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_2threads
 Checking test 009 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1461.910013
- 0: The maximum resident set size (KB)                   = 894776
+ 0: The total amount of wall time                        = 1469.104212
+ 0: The maximum resident set size (KB)                   = 895988
 
 Test 009 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_restart
 Checking test 010 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -452,14 +452,14 @@ Checking test 010 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 717.349011
-  0: The maximum resident set size (KB)                   = 540584
+  0: The total amount of wall time                        = 710.484227
+  0: The maximum resident set size (KB)                   = 542672
 
 Test 010 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_sfcdiff
 Checking test 011 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1520.765161
-  0: The maximum resident set size (KB)                   = 833200
+  0: The total amount of wall time                        = 1456.224776
+  0: The maximum resident set size (KB)                   = 833568
 
 Test 011 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_sfcdiff_decomp
 Checking test 012 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1473.293345
-  0: The maximum resident set size (KB)                   = 828880
+  0: The total amount of wall time                        = 1439.301565
+  0: The maximum resident set size (KB)                   = 830944
 
 Test 012 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_sfcdiff_restart
 Checking test 013 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -606,14 +606,14 @@ Checking test 013 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1065.440006
-  0: The maximum resident set size (KB)                   = 543252
+  0: The total amount of wall time                        = 1061.959809
+  0: The maximum resident set size (KB)                   = 543696
 
 Test 013 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control
 Checking test 014 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -660,14 +660,14 @@ Checking test 014 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1486.443423
-  0: The maximum resident set size (KB)                   = 824872
+  0: The total amount of wall time                        = 1425.488786
+  0: The maximum resident set size (KB)                   = 826788
 
 Test 014 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_2threads
 Checking test 015 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1443.184791
- 0: The maximum resident set size (KB)                   = 893604
+ 0: The total amount of wall time                        = 1425.525824
+ 0: The maximum resident set size (KB)                   = 891012
 
 Test 015 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_decomp
 Checking test 016 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1425.249934
-  0: The maximum resident set size (KB)                   = 823944
+  0: The total amount of wall time                        = 1406.242143
+  0: The maximum resident set size (KB)                   = 830452
 
 Test 016 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_restart
 Checking test 017 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -814,14 +814,14 @@ Checking test 017 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1046.657696
-  0: The maximum resident set size (KB)                   = 535752
+  0: The total amount of wall time                        = 1049.039890
+  0: The maximum resident set size (KB)                   = 540344
 
 Test 017 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rrfs_v1beta
 Checking test 018 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -868,14 +868,14 @@ Checking test 018 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1533.500594
-  0: The maximum resident set size (KB)                   = 822596
+  0: The total amount of wall time                        = 1440.959929
+  0: The maximum resident set size (KB)                   = 826192
 
 Test 018 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rrfs_conus13km_hrrr_warm
 Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -884,14 +884,14 @@ Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1371.951497
-  0: The maximum resident set size (KB)                   = 635884
+  0: The total amount of wall time                        = 1409.814178
+  0: The maximum resident set size (KB)                   = 635060
 
 Test 019 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rrfs_conus13km_radar_tten_warm
 Checking test 020 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -900,14 +900,14 @@ Checking test 020 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1389.933445
-  0: The maximum resident set size (KB)                   = 639296
+  0: The total amount of wall time                        = 1422.276172
+  0: The maximum resident set size (KB)                   = 643860
 
 Test 020 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rrfs_smoke_conus13km_hrrr_warm
 Checking test 021 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -916,194 +916,194 @@ Checking test 021 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1516.280463
-  0: The maximum resident set size (KB)                   = 651248
+  0: The total amount of wall time                        = 1495.286920
+  0: The maximum resident set size (KB)                   = 651000
 
 Test 021 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_debug
 Checking test 022 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 103.473944
-  0: The maximum resident set size (KB)                   = 468868
+  0: The total amount of wall time                        = 100.016348
+  0: The maximum resident set size (KB)                   = 472280
 
 Test 022 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_diag_debug
 Checking test 023 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 132.332245
-  0: The maximum resident set size (KB)                   = 524148
+  0: The total amount of wall time                        = 126.093263
+  0: The maximum resident set size (KB)                   = 529248
 
 Test 023 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/regional_debug
 Checking test 024 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 128.899774
- 0: The maximum resident set size (KB)                   = 560216
+ 0: The total amount of wall time                        = 130.401868
+ 0: The maximum resident set size (KB)                   = 559084
 
 Test 024 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_control_debug
 Checking test 025 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.130253
-  0: The maximum resident set size (KB)                   = 838076
+  0: The total amount of wall time                        = 170.745555
+  0: The maximum resident set size (KB)                   = 843244
 
 Test 025 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_debug
 Checking test 026 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.104368
-  0: The maximum resident set size (KB)                   = 834432
+  0: The total amount of wall time                        = 170.381273
+  0: The maximum resident set size (KB)                   = 843048
 
 Test 026 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_diag_debug
 Checking test 027 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.069523
-  0: The maximum resident set size (KB)                   = 922268
+  0: The total amount of wall time                        = 212.287596
+  0: The maximum resident set size (KB)                   = 926340
 
 Test 027 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 028 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.018709
-  0: The maximum resident set size (KB)                   = 839296
+  0: The total amount of wall time                        = 268.421701
+  0: The maximum resident set size (KB)                   = 844760
 
 Test 028 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_progcld_thompson_debug
 Checking test 029 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.594977
-  0: The maximum resident set size (KB)                   = 841676
+  0: The total amount of wall time                        = 174.183088
+  0: The maximum resident set size (KB)                   = 839148
 
 Test 029 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rrfs_v1beta_debug
 Checking test 030 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.060099
-  0: The maximum resident set size (KB)                   = 840216
+  0: The total amount of wall time                        = 171.322056
+  0: The maximum resident set size (KB)                   = 842920
 
 Test 030 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_ras_debug
 Checking test 031 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 104.103723
-  0: The maximum resident set size (KB)                   = 483792
+  0: The total amount of wall time                        = 104.555221
+  0: The maximum resident set size (KB)                   = 482960
 
 Test 031 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_stochy_debug
 Checking test 032 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 119.035154
-  0: The maximum resident set size (KB)                   = 474260
+  0: The total amount of wall time                        = 119.253983
+  0: The maximum resident set size (KB)                   = 473408
 
 Test 032 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_debug_p8
 Checking test 033 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.385094
-  0: The maximum resident set size (KB)                   = 1233268
+  0: The total amount of wall time                        = 118.245319
+  0: The maximum resident set size (KB)                   = 1231396
 
 Test 033 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/control_wam_debug
 Checking test 034 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 184.743329
-  0: The maximum resident set size (KB)                   = 191696
+  0: The total amount of wall time                        = 184.321194
+  0: The maximum resident set size (KB)                   = 192688
 
 Test 034 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_control_dyn32_phy32
 Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1426.243379
-  0: The maximum resident set size (KB)                   = 689724
+  0: The total amount of wall time                        = 1443.362414
+  0: The maximum resident set size (KB)                   = 690096
 
 Test 035 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_dyn32_phy32
 Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1204,14 +1204,14 @@ Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 774.817338
-  0: The maximum resident set size (KB)                   = 688184
+  0: The total amount of wall time                        = 748.422942
+  0: The maximum resident set size (KB)                   = 682296
 
 Test 036 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_2threads_dyn32_phy32
 Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1258,14 +1258,14 @@ Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1453.246853
- 0: The maximum resident set size (KB)                   = 725948
+ 0: The total amount of wall time                        = 1431.403198
+ 0: The maximum resident set size (KB)                   = 729856
 
 Test 037 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_2threads_dyn32_phy32
 Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1312,14 +1312,14 @@ Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 725.864826
- 0: The maximum resident set size (KB)                   = 724524
+ 0: The total amount of wall time                        = 702.992555
+ 0: The maximum resident set size (KB)                   = 725612
 
 Test 038 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_decomp_dyn32_phy32
 Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1366,14 +1366,14 @@ Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 764.676887
-  0: The maximum resident set size (KB)                   = 684016
+  0: The total amount of wall time                        = 697.442698
+  0: The maximum resident set size (KB)                   = 683712
 
 Test 039 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_restart_dyn32_phy32
 Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1412,14 +1412,14 @@ Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1053.279829
-  0: The maximum resident set size (KB)                   = 508296
+  0: The total amount of wall time                        = 1074.836394
+  0: The maximum resident set size (KB)                   = 506540
 
 Test 040 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_restart_dyn32_phy32
 Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1458,14 +1458,14 @@ Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 363.662754
-  0: The maximum resident set size (KB)                   = 504708
+  0: The total amount of wall time                        = 358.017443
+  0: The maximum resident set size (KB)                   = 507056
 
 Test 041 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_control_dyn64_phy32
 Checking test 042 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1512,56 +1512,56 @@ Checking test 042 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1070.870926
-  0: The maximum resident set size (KB)                   = 704864
+  0: The total amount of wall time                        = 1064.869820
+  0: The maximum resident set size (KB)                   = 704868
 
 Test 042 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_control_debug_dyn32_phy32
 Checking test 043 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.931655
-  0: The maximum resident set size (KB)                   = 699956
+  0: The total amount of wall time                        = 170.945186
+  0: The maximum resident set size (KB)                   = 696764
 
 Test 043 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/hrrr_control_debug_dyn32_phy32
 Checking test 044 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.096304
-  0: The maximum resident set size (KB)                   = 705636
+  0: The total amount of wall time                        = 170.021380
+  0: The maximum resident set size (KB)                   = 695240
 
 Test 044 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/rap_control_dyn64_phy32_debug
 Checking test 045 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.744706
-  0: The maximum resident set size (KB)                   = 718816
+  0: The total amount of wall time                        = 203.302532
+  0: The maximum resident set size (KB)                   = 714224
 
 Test 045 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/cpld_control_p8
 Checking test 046 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1626,14 +1626,14 @@ Checking test 046 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1679.083554
-  0: The maximum resident set size (KB)                   = 1427068
+  0: The total amount of wall time                        = 1721.685266
+  0: The maximum resident set size (KB)                   = 1426572
 
 Test 046 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/cpld_control_nowave_noaero_p8
 Checking test 047 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1695,14 +1695,14 @@ Checking test 047 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1228.624695
-  0: The maximum resident set size (KB)                   = 1326704
+  0: The total amount of wall time                        = 1214.139330
+  0: The maximum resident set size (KB)                   = 1327984
 
 Test 047 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/cpld_debug_p8
 Checking test 048 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1755,25 +1755,25 @@ Checking test 048 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 840.330123
-  0: The maximum resident set size (KB)                   = 1439788
+  0: The total amount of wall time                        = 847.879514
+  0: The maximum resident set size (KB)                   = 1444236
 
 Test 048 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5794/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17635/datm_cdeps_control_cfsr
 Checking test 049 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 172.195011
- 0: The maximum resident set size (KB)                   = 665132
+ 0: The total amount of wall time                        = 179.211953
+ 0: The maximum resident set size (KB)                   = 665748
 
 Test 049 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct  6 03:35:42 UTC 2022
-Elapsed time: 08h:03m:30s. Have a nice day!
+Sun Oct  9 20:42:43 UTC 2022
+Elapsed time: 00h:53m:44s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,32 +1,32 @@
-Wed Oct  5 18:32:50 UTC 2022
+Sun Oct  9 19:32:27 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 589 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 554 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 002 elapsed time 556 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 209 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 192 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 384 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 381 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 336 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 355 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 333 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 312 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 652 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 178 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 316 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 321 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 178 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 526 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 534 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 184 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 109 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 524 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 334 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 330 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 212 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 203 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 389 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 391 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 330 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 349 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 334 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 311 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 651 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 172 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 337 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 328 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 173 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 534 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 549 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 182 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 108 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 573 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 353 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 332 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -91,14 +91,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 332.917852
-  0: The maximum resident set size (KB)                   = 3183424
+  0: The total amount of wall time                        = 338.258357
+  0: The maximum resident set size (KB)                   = 3176920
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -151,14 +151,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 191.190994
-  0: The maximum resident set size (KB)                   = 3052732
+  0: The total amount of wall time                        = 190.781034
+  0: The maximum resident set size (KB)                   = 3052368
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -211,14 +211,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 416.354992
-  0: The maximum resident set size (KB)                   = 3456400
+  0: The total amount of wall time                        = 423.812191
+  0: The maximum resident set size (KB)                   = 3452048
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_esmfthreads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -271,14 +271,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 349.162446
-  0: The maximum resident set size (KB)                   = 3516284
+  0: The total amount of wall time                        = 352.122001
+  0: The maximum resident set size (KB)                   = 3508840
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -331,14 +331,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 334.004870
-  0: The maximum resident set size (KB)                   = 3168300
+  0: The total amount of wall time                        = 334.280069
+  0: The maximum resident set size (KB)                   = 3168396
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 276.556621
-  0: The maximum resident set size (KB)                   = 3028592
+  0: The total amount of wall time                        = 275.462546
+  0: The maximum resident set size (KB)                   = 3021164
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_ciceC_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_ciceC_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_ciceC_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -463,14 +463,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 333.770374
-  0: The maximum resident set size (KB)                   = 3179764
+  0: The total amount of wall time                        = 338.190736
+  0: The maximum resident set size (KB)                   = 3174520
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -523,14 +523,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 654.083333
-  0: The maximum resident set size (KB)                   = 3221712
+  0: The total amount of wall time                        = 652.776037
+  0: The maximum resident set size (KB)                   = 3224484
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -583,14 +583,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 406.415910
-  0: The maximum resident set size (KB)                   = 3132272
+  0: The total amount of wall time                        = 405.998882
+  0: The maximum resident set size (KB)                   = 3138236
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -638,14 +638,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 825.138164
-  0: The maximum resident set size (KB)                   = 3996388
+  0: The total amount of wall time                        = 828.836687
+  0: The maximum resident set size (KB)                   = 3996052
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_restart_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -693,14 +693,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 505.475359
-  0: The maximum resident set size (KB)                   = 3940444
+  0: The total amount of wall time                        = 517.680355
+  0: The maximum resident set size (KB)                   = 3942756
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_bmark_esmfthreads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_bmark_esmfthreads_p8
 Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -748,14 +748,14 @@ Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 751.931678
-   0: The maximum resident set size (KB)                   = 4041468
+   0: The total amount of wall time                        = 766.223658
+   0: The maximum resident set size (KB)                   = 4038096
 
 Test 012 cpld_bmark_esmfthreads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -819,14 +819,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 230.133539
-  0: The maximum resident set size (KB)                   = 1723284
+  0: The total amount of wall time                        = 230.251915
+  0: The maximum resident set size (KB)                   = 1730160
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -888,14 +888,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 253.550818
-  0: The maximum resident set size (KB)                   = 1760324
+  0: The total amount of wall time                        = 254.318219
+  0: The maximum resident set size (KB)                   = 1763792
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -948,14 +948,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 654.817148
-  0: The maximum resident set size (KB)                   = 3244616
+  0: The total amount of wall time                        = 654.865959
+  0: The maximum resident set size (KB)                   = 3244676
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_debug_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1007,14 +1007,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 400.924936
-  0: The maximum resident set size (KB)                   = 1754504
+  0: The total amount of wall time                        = 399.286073
+  0: The maximum resident set size (KB)                   = 1744360
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_noaero_p8_agrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1076,14 +1076,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 260.797344
-  0: The maximum resident set size (KB)                   = 1760536
+  0: The total amount of wall time                        = 264.483018
+  0: The maximum resident set size (KB)                   = 1764852
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1133,14 +1133,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 502.205808
- 0: The maximum resident set size (KB)                   = 2805036
+ 0: The total amount of wall time                        = 493.276662
+ 0: The maximum resident set size (KB)                   = 2798668
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_warmstart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1190,14 +1190,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 135.286478
- 0: The maximum resident set size (KB)                   = 2800872
+ 0: The total amount of wall time                        = 137.418100
+ 0: The maximum resident set size (KB)                   = 2794056
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/cpld_restart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1247,14 +1247,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 72.224863
- 0: The maximum resident set size (KB)                   = 2242120
+ 0: The total amount of wall time                        = 72.496686
+ 0: The maximum resident set size (KB)                   = 2234576
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control
 Checking test 021 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1301,14 +1301,14 @@ Checking test 021 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.245395
-  0: The maximum resident set size (KB)                   = 627384
+  0: The total amount of wall time                        = 132.754456
+  0: The maximum resident set size (KB)                   = 626748
 
 Test 021 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_decomp
 Checking test 022 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1351,14 +1351,14 @@ Checking test 022 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 139.460557
-  0: The maximum resident set size (KB)                   = 620492
+  0: The total amount of wall time                        = 138.094699
+  0: The maximum resident set size (KB)                   = 614964
 
 Test 022 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_2dwrtdecomp
 Checking test 023 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1369,14 +1369,14 @@ Checking test 023 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 132.651953
-  0: The maximum resident set size (KB)                   = 627024
+  0: The total amount of wall time                        = 133.280828
+  0: The maximum resident set size (KB)                   = 622072
 
 Test 023 control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_2threads
 Checking test 024 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1419,14 +1419,14 @@ Checking test 024 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 163.162749
- 0: The maximum resident set size (KB)                   = 662368
+ 0: The total amount of wall time                        = 162.603759
+ 0: The maximum resident set size (KB)                   = 662504
 
 Test 024 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_restart
 Checking test 025 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1465,14 +1465,14 @@ Checking test 025 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 69.120688
-  0: The maximum resident set size (KB)                   = 463800
+  0: The total amount of wall time                        = 69.087339
+  0: The maximum resident set size (KB)                   = 468324
 
 Test 025 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_fhzero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_fhzero
 Checking test 026 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1515,14 +1515,14 @@ Checking test 026 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.103714
-  0: The maximum resident set size (KB)                   = 626344
+  0: The total amount of wall time                        = 125.733623
+  0: The maximum resident set size (KB)                   = 627460
 
 Test 026 control_fhzero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_CubedSphereGrid
 Checking test 027 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1549,28 +1549,28 @@ Checking test 027 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.349521
-  0: The maximum resident set size (KB)                   = 626820
+  0: The total amount of wall time                        = 129.093458
+  0: The maximum resident set size (KB)                   = 627028
 
 Test 027 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_CubedSphereGrid_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_CubedSphereGrid_parallel
 Checking test 028 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 126.906187
-  0: The maximum resident set size (KB)                   = 630408
+  0: The total amount of wall time                        = 127.488201
+  0: The maximum resident set size (KB)                   = 630868
 
 Test 028 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_latlon
 Checking test 029 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1581,32 +1581,32 @@ Checking test 029 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.171845
-  0: The maximum resident set size (KB)                   = 627208
+  0: The total amount of wall time                        = 132.455920
+  0: The maximum resident set size (KB)                   = 626644
 
 Test 029 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_wrtGauss_netcdf_parallel
 Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.190670
-  0: The maximum resident set size (KB)                   = 627836
+  0: The total amount of wall time                        = 134.583106
+  0: The maximum resident set size (KB)                   = 626884
 
 Test 030 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_c48
 Checking test 031 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1645,14 +1645,14 @@ Checking test 031 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 345.275927
-0: The maximum resident set size (KB)                   = 801360
+0: The total amount of wall time                        = 351.597432
+0: The maximum resident set size (KB)                   = 816280
 
 Test 031 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_c192
 Checking test 032 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1663,14 +1663,14 @@ Checking test 032 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 527.575706
-  0: The maximum resident set size (KB)                   = 761852
+  0: The total amount of wall time                        = 522.497038
+  0: The maximum resident set size (KB)                   = 758584
 
 Test 032 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_c384
 Checking test 033 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1681,14 +1681,14 @@ Checking test 033 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 689.890123
-  0: The maximum resident set size (KB)                   = 1081636
+  0: The total amount of wall time                        = 689.776177
+  0: The maximum resident set size (KB)                   = 1076304
 
 Test 033 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_c384gdas
 Checking test 034 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1731,14 +1731,14 @@ Checking test 034 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 580.492726
-  0: The maximum resident set size (KB)                   = 1245976
+  0: The total amount of wall time                        = 587.844506
+  0: The maximum resident set size (KB)                   = 1242712
 
 Test 034 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384_progsigma
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_c384_progsigma
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384_progsigma
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_c384_progsigma
 Checking test 035 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1749,14 +1749,14 @@ Checking test 035 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 705.629778
-  0: The maximum resident set size (KB)                   = 1078876
+  0: The total amount of wall time                        = 704.854408
+  0: The maximum resident set size (KB)                   = 1070328
 
 Test 035 control_c384_progsigma PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_stochy
 Checking test 036 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1767,28 +1767,28 @@ Checking test 036 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 85.947318
+  0: The total amount of wall time                        = 86.111541
   0: The maximum resident set size (KB)                   = 629900
 
 Test 036 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_stochy_restart
 Checking test 037 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.880499
-  0: The maximum resident set size (KB)                   = 477948
+  0: The total amount of wall time                        = 45.974949
+  0: The maximum resident set size (KB)                   = 473296
 
 Test 037 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_lndp
 Checking test 038 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 038 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 80.161274
-  0: The maximum resident set size (KB)                   = 626660
+  0: The total amount of wall time                        = 79.023948
+  0: The maximum resident set size (KB)                   = 625292
 
 Test 038 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_iovr4
 Checking test 039 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1821,14 +1821,14 @@ Checking test 039 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.144930
-  0: The maximum resident set size (KB)                   = 629752
+  0: The total amount of wall time                        = 133.621064
+  0: The maximum resident set size (KB)                   = 630528
 
 Test 039 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_iovr5
 Checking test 040 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1843,14 +1843,14 @@ Checking test 040 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.937258
-  0: The maximum resident set size (KB)                   = 627416
+  0: The total amount of wall time                        = 133.167055
+  0: The maximum resident set size (KB)                   = 626028
 
 Test 040 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_p8
 Checking test 041 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1897,14 +1897,14 @@ Checking test 041 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 163.831888
-  0: The maximum resident set size (KB)                   = 1600760
+  0: The total amount of wall time                        = 165.436186
+  0: The maximum resident set size (KB)                   = 1606004
 
 Test 041 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_p8_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_p8_lndp
 Checking test 042 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1923,14 +1923,14 @@ Checking test 042 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 307.216224
-  0: The maximum resident set size (KB)                   = 1599704
+  0: The total amount of wall time                        = 309.899192
+  0: The maximum resident set size (KB)                   = 1599692
 
 Test 042 control_p8_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_restart_p8
 Checking test 043 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1969,14 +1969,14 @@ Checking test 043 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 85.932690
-  0: The maximum resident set size (KB)                   = 856892
+  0: The total amount of wall time                        = 84.494525
+  0: The maximum resident set size (KB)                   = 859896
 
 Test 043 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_decomp_p8
 Checking test 044 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2019,14 +2019,14 @@ Checking test 044 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.346244
-  0: The maximum resident set size (KB)                   = 1593248
+  0: The total amount of wall time                        = 169.479186
+  0: The maximum resident set size (KB)                   = 1582180
 
 Test 044 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_2threads_p8
 Checking test 045 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2069,14 +2069,14 @@ Checking test 045 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 196.563195
- 0: The maximum resident set size (KB)                   = 1659488
+ 0: The total amount of wall time                        = 199.989012
+ 0: The maximum resident set size (KB)                   = 1668680
 
 Test 045 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_p8_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_p8_rrtmgp
 Checking test 046 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2123,14 +2123,14 @@ Checking test 046 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.988898
-  0: The maximum resident set size (KB)                   = 1726564
+  0: The total amount of wall time                        = 198.698826
+  0: The maximum resident set size (KB)                   = 1732168
 
 Test 046 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/merra2_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/merra2_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/merra2_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2177,14 +2177,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.765898
-  0: The maximum resident set size (KB)                   = 1610508
+  0: The total amount of wall time                        = 169.054521
+  0: The maximum resident set size (KB)                   = 1615780
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2195,28 +2195,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 346.182663
- 0: The maximum resident set size (KB)                   = 843444
+ 0: The total amount of wall time                        = 344.712778
+ 0: The maximum resident set size (KB)                   = 843808
 
 Test 048 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 188.864212
- 0: The maximum resident set size (KB)                   = 831000
+ 0: The total amount of wall time                        = 188.191389
+ 0: The maximum resident set size (KB)                   = 830640
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_control_2dwrtdecomp
 Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2227,14 +2227,14 @@ Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 345.779080
- 0: The maximum resident set size (KB)                   = 843460
+ 0: The total amount of wall time                        = 344.831479
+ 0: The maximum resident set size (KB)                   = 842816
 
 Test 050 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2242,14 +2242,14 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 367.791314
- 0: The maximum resident set size (KB)                   = 831160
+ 0: The total amount of wall time                        = 369.959188
+ 0: The maximum resident set size (KB)                   = 829320
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2260,28 +2260,28 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 248.868280
- 0: The maximum resident set size (KB)                   = 803924
+ 0: The total amount of wall time                        = 251.497225
+ 0: The maximum resident set size (KB)                   = 812220
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_netcdf_parallel
 Checking test 053 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 340.381704
- 0: The maximum resident set size (KB)                   = 833964
+ 0: The total amount of wall time                        = 341.480361
+ 0: The maximum resident set size (KB)                   = 833092
 
 Test 053 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_3km
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_3km
 Checking test 054 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 054 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 251.990344
-  0: The maximum resident set size (KB)                   = 853480
+  0: The total amount of wall time                        = 255.496110
+  0: The maximum resident set size (KB)                   = 856628
 
 Test 054 regional_3km PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_3km_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_3km_decomp
 Checking test 055 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2310,14 +2310,14 @@ Checking test 055 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 269.886541
-  0: The maximum resident set size (KB)                   = 858444
+  0: The total amount of wall time                        = 270.909035
+  0: The maximum resident set size (KB)                   = 858984
 
 Test 055 regional_3km_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_control
 Checking test 056 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2364,14 +2364,14 @@ Checking test 056 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 441.881809
-  0: The maximum resident set size (KB)                   = 1050420
+  0: The total amount of wall time                        = 442.336830
+  0: The maximum resident set size (KB)                   = 1066368
 
 Test 056 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_rrtmgp
 Checking test 057 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2418,14 +2418,14 @@ Checking test 057 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 472.778263
-  0: The maximum resident set size (KB)                   = 1215688
+  0: The total amount of wall time                        = 477.602400
+  0: The maximum resident set size (KB)                   = 1213448
 
 Test 057 rap_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_spp_sppt_shum_skeb
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_spp_sppt_shum_skeb
 Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2436,14 +2436,14 @@ Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 289.855222
-  0: The maximum resident set size (KB)                   = 1181184
+  0: The total amount of wall time                        = 290.070575
+  0: The maximum resident set size (KB)                   = 1178772
 
 Test 058 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_decomp
 Checking test 059 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2490,14 +2490,14 @@ Checking test 059 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 462.693624
-  0: The maximum resident set size (KB)                   = 998272
+  0: The total amount of wall time                        = 465.014675
+  0: The maximum resident set size (KB)                   = 999096
 
 Test 059 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_2threads
 Checking test 060 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2544,14 +2544,14 @@ Checking test 060 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 526.787005
- 0: The maximum resident set size (KB)                   = 1055008
+ 0: The total amount of wall time                        = 522.826774
+ 0: The maximum resident set size (KB)                   = 1059092
 
 Test 060 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_restart
 Checking test 061 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2590,14 +2590,14 @@ Checking test 061 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 224.950555
-  0: The maximum resident set size (KB)                   = 964900
+  0: The total amount of wall time                        = 223.222315
+  0: The maximum resident set size (KB)                   = 963004
 
 Test 061 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_sfcdiff
 Checking test 062 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2644,14 +2644,14 @@ Checking test 062 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.406962
-  0: The maximum resident set size (KB)                   = 1053088
+  0: The total amount of wall time                        = 439.468426
+  0: The maximum resident set size (KB)                   = 1054888
 
 Test 062 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_sfcdiff_decomp
 Checking test 063 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2698,14 +2698,14 @@ Checking test 063 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.163922
-  0: The maximum resident set size (KB)                   = 1004568
+  0: The total amount of wall time                        = 465.672300
+  0: The maximum resident set size (KB)                   = 1000780
 
 Test 063 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_sfcdiff_restart
 Checking test 064 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2744,14 +2744,14 @@ Checking test 064 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 328.578855
-  0: The maximum resident set size (KB)                   = 980752
+  0: The total amount of wall time                        = 329.090173
+  0: The maximum resident set size (KB)                   = 980348
 
 Test 064 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control
 Checking test 065 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 065 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 423.349882
-  0: The maximum resident set size (KB)                   = 1052136
+  0: The total amount of wall time                        = 422.068109
+  0: The maximum resident set size (KB)                   = 1051940
 
 Test 065 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_decomp
 Checking test 066 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2852,14 +2852,14 @@ Checking test 066 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 443.843581
-  0: The maximum resident set size (KB)                   = 997460
+  0: The total amount of wall time                        = 444.124607
+  0: The maximum resident set size (KB)                   = 992908
 
 Test 066 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_2threads
 Checking test 067 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2906,14 +2906,14 @@ Checking test 067 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 495.965539
- 0: The maximum resident set size (KB)                   = 1050888
+ 0: The total amount of wall time                        = 498.380187
+ 0: The maximum resident set size (KB)                   = 1057676
 
 Test 067 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_restart
 Checking test 068 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 068 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 317.356052
-  0: The maximum resident set size (KB)                   = 976048
+  0: The total amount of wall time                        = 317.792520
+  0: The maximum resident set size (KB)                   = 977848
 
 Test 068 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_v1beta
 Checking test 069 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3006,14 +3006,14 @@ Checking test 069 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 438.755210
-  0: The maximum resident set size (KB)                   = 1049532
+  0: The total amount of wall time                        = 437.827353
+  0: The maximum resident set size (KB)                   = 1044916
 
 Test 069 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_v1nssl
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_v1nssl
 Checking test 070 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3028,14 +3028,14 @@ Checking test 070 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 511.632516
-  0: The maximum resident set size (KB)                   = 689604
+  0: The total amount of wall time                        = 511.935752
+  0: The maximum resident set size (KB)                   = 684824
 
 Test 070 rrfs_v1nssl PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_v1nssl_nohailnoccn
 Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3050,14 +3050,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 501.529388
-  0: The maximum resident set size (KB)                   = 751420
+  0: The total amount of wall time                        = 501.506531
+  0: The maximum resident set size (KB)                   = 751396
 
 Test 071 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_conus13km_hrrr_warm
 Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3066,14 +3066,14 @@ Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 175.075856
-  0: The maximum resident set size (KB)                   = 933000
+  0: The total amount of wall time                        = 174.355895
+  0: The maximum resident set size (KB)                   = 933188
 
 Test 072 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_conus13km_radar_tten_warm
 Checking test 073 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3082,14 +3082,14 @@ Checking test 073 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 175.703654
-  0: The maximum resident set size (KB)                   = 935168
+  0: The total amount of wall time                        = 175.104455
+  0: The maximum resident set size (KB)                   = 931752
 
 Test 073 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_smoke_conus13km_hrrr_warm
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3098,14 +3098,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 193.125621
-  0: The maximum resident set size (KB)                   = 959936
+  0: The total amount of wall time                        = 195.105398
+  0: The maximum resident set size (KB)                   = 964508
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_csawmg
 Checking test 075 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3116,14 +3116,14 @@ Checking test 075 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 339.327275
-  0: The maximum resident set size (KB)                   = 731904
+  0: The total amount of wall time                        = 339.345492
+  0: The maximum resident set size (KB)                   = 729044
 
 Test 075 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_csawmgt
 Checking test 076 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3134,14 +3134,14 @@ Checking test 076 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 336.519529
-  0: The maximum resident set size (KB)                   = 729820
+  0: The total amount of wall time                        = 333.110071
+  0: The maximum resident set size (KB)                   = 729548
 
 Test 076 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_ras
 Checking test 077 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3152,54 +3152,54 @@ Checking test 077 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 177.759910
-  0: The maximum resident set size (KB)                   = 728776
+  0: The total amount of wall time                        = 177.892564
+  0: The maximum resident set size (KB)                   = 720704
 
 Test 077 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_wam
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_wam
 Checking test 078 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 107.556985
-  0: The maximum resident set size (KB)                   = 638180
+  0: The total amount of wall time                        = 109.062575
+  0: The maximum resident set size (KB)                   = 637092
 
 Test 078 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_debug
 Checking test 079 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.944893
-  0: The maximum resident set size (KB)                   = 789272
+  0: The total amount of wall time                        = 152.422705
+  0: The maximum resident set size (KB)                   = 795968
 
 Test 079 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_2threads_debug
 Checking test 080 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 217.431513
- 0: The maximum resident set size (KB)                   = 831440
+ 0: The total amount of wall time                        = 217.682237
+ 0: The maximum resident set size (KB)                   = 837804
 
 Test 080 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_CubedSphereGrid_debug
 Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3226,348 +3226,348 @@ Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.384631
-  0: The maximum resident set size (KB)                   = 792468
+  0: The total amount of wall time                        = 165.738519
+  0: The maximum resident set size (KB)                   = 792604
 
 Test 081 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_wrtGauss_netcdf_parallel_debug
 Checking test 082 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 156.382250
-  0: The maximum resident set size (KB)                   = 792012
+  0: The total amount of wall time                        = 155.659347
+  0: The maximum resident set size (KB)                   = 789780
 
 Test 082 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_stochy_debug
 Checking test 083 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.536951
-  0: The maximum resident set size (KB)                   = 798308
+  0: The total amount of wall time                        = 172.396882
+  0: The maximum resident set size (KB)                   = 800484
 
 Test 083 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_lndp_debug
 Checking test 084 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.431393
-  0: The maximum resident set size (KB)                   = 801768
+  0: The total amount of wall time                        = 155.738015
+  0: The maximum resident set size (KB)                   = 801208
 
 Test 084 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_csawmg_debug
 Checking test 085 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.660836
-  0: The maximum resident set size (KB)                   = 840052
+  0: The total amount of wall time                        = 234.728170
+  0: The maximum resident set size (KB)                   = 849120
 
 Test 085 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_csawmgt_debug
 Checking test 086 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 230.820366
-  0: The maximum resident set size (KB)                   = 848180
+  0: The total amount of wall time                        = 230.306093
+  0: The maximum resident set size (KB)                   = 851180
 
 Test 086 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_ras_debug
 Checking test 087 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.620584
-  0: The maximum resident set size (KB)                   = 808048
+  0: The total amount of wall time                        = 157.287505
+  0: The maximum resident set size (KB)                   = 814756
 
 Test 087 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_diag_debug
 Checking test 088 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.276628
-  0: The maximum resident set size (KB)                   = 849308
+  0: The total amount of wall time                        = 163.304181
+  0: The maximum resident set size (KB)                   = 852160
 
 Test 088 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_debug_p8
 Checking test 089 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.897178
-  0: The maximum resident set size (KB)                   = 1619248
+  0: The total amount of wall time                        = 170.891423
+  0: The maximum resident set size (KB)                   = 1620636
 
 Test 089 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 247.675839
- 0: The maximum resident set size (KB)                   = 859548
+ 0: The total amount of wall time                        = 251.549488
+ 0: The maximum resident set size (KB)                   = 862984
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.805974
-  0: The maximum resident set size (KB)                   = 1172692
+  0: The total amount of wall time                        = 281.937072
+  0: The maximum resident set size (KB)                   = 1172076
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_debug
 Checking test 092 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.552214
-  0: The maximum resident set size (KB)                   = 1171188
+  0: The total amount of wall time                        = 270.114326
+  0: The maximum resident set size (KB)                   = 1167776
 
 Test 092 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_unified_drag_suite_debug
 Checking test 093 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.470584
-  0: The maximum resident set size (KB)                   = 1173552
+  0: The total amount of wall time                        = 272.792252
+  0: The maximum resident set size (KB)                   = 1173528
 
 Test 093 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_diag_debug
 Checking test 094 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.930419
-  0: The maximum resident set size (KB)                   = 1260072
+  0: The total amount of wall time                        = 295.577352
+  0: The maximum resident set size (KB)                   = 1255672
 
 Test 094 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_cires_ugwp_debug
 Checking test 095 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.447217
-  0: The maximum resident set size (KB)                   = 1171112
+  0: The total amount of wall time                        = 280.869977
+  0: The maximum resident set size (KB)                   = 1169692
 
 Test 095 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_unified_ugwp_debug
 Checking test 096 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.449558
-  0: The maximum resident set size (KB)                   = 1175736
+  0: The total amount of wall time                        = 281.974583
+  0: The maximum resident set size (KB)                   = 1176312
 
 Test 096 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_lndp_debug
 Checking test 097 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.546761
-  0: The maximum resident set size (KB)                   = 1174652
+  0: The total amount of wall time                        = 279.359958
+  0: The maximum resident set size (KB)                   = 1169872
 
 Test 097 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_flake_debug
 Checking test 098 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.315345
-  0: The maximum resident set size (KB)                   = 1177256
+  0: The total amount of wall time                        = 279.466899
+  0: The maximum resident set size (KB)                   = 1169992
 
 Test 098 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_progcld_thompson_debug
 Checking test 099 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.372217
-  0: The maximum resident set size (KB)                   = 1175328
+  0: The total amount of wall time                        = 280.300465
+  0: The maximum resident set size (KB)                   = 1173708
 
 Test 099 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_noah_debug
 Checking test 100 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.835901
-  0: The maximum resident set size (KB)                   = 1174232
+  0: The total amount of wall time                        = 273.874772
+  0: The maximum resident set size (KB)                   = 1169980
 
 Test 100 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_rrtmgp_debug
 Checking test 101 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 462.023899
-  0: The maximum resident set size (KB)                   = 1306516
+  0: The total amount of wall time                        = 468.307811
+  0: The maximum resident set size (KB)                   = 1298724
 
 Test 101 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_sfcdiff_debug
 Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.168970
-  0: The maximum resident set size (KB)                   = 1175996
+  0: The total amount of wall time                        = 277.229755
+  0: The maximum resident set size (KB)                   = 1173768
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 440.824712
-  0: The maximum resident set size (KB)                   = 1170628
+  0: The total amount of wall time                        = 455.085327
+  0: The maximum resident set size (KB)                   = 1174160
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rrfs_v1beta_debug
 Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.119121
-  0: The maximum resident set size (KB)                   = 1168768
+  0: The total amount of wall time                        = 277.116139
+  0: The maximum resident set size (KB)                   = 1172480
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 279.319103
-  0: The maximum resident set size (KB)                   = 526624
+  0: The total amount of wall time                        = 283.215015
+  0: The maximum resident set size (KB)                   = 519372
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3578,14 +3578,14 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 263.785432
-  0: The maximum resident set size (KB)                   = 1078412
+  0: The total amount of wall time                        = 265.936520
+  0: The maximum resident set size (KB)                   = 1077536
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_control_dyn32_phy32
 Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3632,14 +3632,14 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 358.269237
-  0: The maximum resident set size (KB)                   = 996572
+  0: The total amount of wall time                        = 358.595296
+  0: The maximum resident set size (KB)                   = 995496
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_dyn32_phy32
 Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3686,14 +3686,14 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 185.201117
-  0: The maximum resident set size (KB)                   = 953396
+  0: The total amount of wall time                        = 185.528610
+  0: The maximum resident set size (KB)                   = 962584
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_2threads_dyn32_phy32
 Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3740,14 +3740,14 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 436.559369
- 0: The maximum resident set size (KB)                   = 931308
+ 0: The total amount of wall time                        = 431.748888
+ 0: The maximum resident set size (KB)                   = 928032
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_2threads_dyn32_phy32
 Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3794,14 +3794,14 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 222.966565
- 0: The maximum resident set size (KB)                   = 926260
+ 0: The total amount of wall time                        = 222.529906
+ 0: The maximum resident set size (KB)                   = 922200
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_decomp_dyn32_phy32
 Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3848,14 +3848,14 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.136236
-  0: The maximum resident set size (KB)                   = 890084
+  0: The total amount of wall time                        = 197.309378
+  0: The maximum resident set size (KB)                   = 886576
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_restart_dyn32_phy32
 Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3894,14 +3894,14 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 268.482634
-  0: The maximum resident set size (KB)                   = 937060
+  0: The total amount of wall time                        = 269.399091
+  0: The maximum resident set size (KB)                   = 947588
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_restart_dyn32_phy32
 Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3940,14 +3940,14 @@ Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 95.224466
-  0: The maximum resident set size (KB)                   = 866612
+  0: The total amount of wall time                        = 95.145779
+  0: The maximum resident set size (KB)                   = 857468
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_control_dyn64_phy32
 Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3994,81 +3994,81 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.341138
-  0: The maximum resident set size (KB)                   = 957772
+  0: The total amount of wall time                        = 232.733465
+  0: The maximum resident set size (KB)                   = 970336
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_control_debug_dyn32_phy32
 Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.553717
-  0: The maximum resident set size (KB)                   = 1058380
+  0: The total amount of wall time                        = 272.954860
+  0: The maximum resident set size (KB)                   = 1054228
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hrrr_control_debug_dyn32_phy32
 Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.079620
-  0: The maximum resident set size (KB)                   = 1049316
+  0: The total amount of wall time                        = 266.140855
+  0: The maximum resident set size (KB)                   = 1060908
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/rap_control_dyn64_phy32_debug
 Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.847145
-  0: The maximum resident set size (KB)                   = 1091392
+  0: The total amount of wall time                        = 275.257867
+  0: The maximum resident set size (KB)                   = 1097536
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_atm
 Checking test 118 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 302.270832
-  0: The maximum resident set size (KB)                   = 978108
+  0: The total amount of wall time                        = 300.742566
+  0: The maximum resident set size (KB)                   = 973228
 
 Test 118 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_atm_thompson_gfdlsf
 Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 379.704615
-  0: The maximum resident set size (KB)                   = 1338892
+  0: The total amount of wall time                        = 378.675346
+  0: The maximum resident set size (KB)                   = 1349448
 
 Test 119 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_atm_ocn
 Checking test 120 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4077,14 +4077,14 @@ Checking test 120 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 379.464467
-  0: The maximum resident set size (KB)                   = 1192492
+  0: The total amount of wall time                        = 382.060494
+  0: The maximum resident set size (KB)                   = 1198460
 
 Test 120 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_atm_wav
 Checking test 121 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4093,14 +4093,14 @@ Checking test 121 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 715.896922
-  0: The maximum resident set size (KB)                   = 1218872
+  0: The total amount of wall time                        = 718.985049
+  0: The maximum resident set size (KB)                   = 1222012
 
 Test 121 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_atm_ocn_wav
 Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4111,28 +4111,28 @@ Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 806.525749
-  0: The maximum resident set size (KB)                   = 1227412
+  0: The total amount of wall time                        = 810.685408
+  0: The maximum resident set size (KB)                   = 1236520
 
 Test 122 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_1nest_atm
 Checking test 123 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 465.376325
-  0: The maximum resident set size (KB)                   = 536124
+  0: The total amount of wall time                        = 467.905626
+  0: The maximum resident set size (KB)                   = 533084
 
 Test 123 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_telescopic_2nests_atm
 Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4141,28 +4141,28 @@ Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 515.407954
-  0: The maximum resident set size (KB)                   = 588148
+  0: The total amount of wall time                        = 513.463022
+  0: The maximum resident set size (KB)                   = 592536
 
 Test 124 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_global_1nest_atm
 Checking test 125 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 213.371132
-  0: The maximum resident set size (KB)                   = 378216
+  0: The total amount of wall time                        = 213.741794
+  0: The maximum resident set size (KB)                   = 378188
 
 Test 125 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_global_multiple_4nests_atm
 Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4180,14 +4180,14 @@ Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 588.452760
-  0: The maximum resident set size (KB)                   = 380224
+  0: The total amount of wall time                        = 591.978363
+  0: The maximum resident set size (KB)                   = 386632
 
 Test 126 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_specified_moving_1nest_atm
 Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4196,28 +4196,28 @@ Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 277.891899
-  0: The maximum resident set size (KB)                   = 541288
+  0: The total amount of wall time                        = 278.273173
+  0: The maximum resident set size (KB)                   = 544912
 
 Test 127 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_storm_following_1nest_atm
 Checking test 128 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 265.163334
-  0: The maximum resident set size (KB)                   = 543744
+  0: The total amount of wall time                        = 266.982267
+  0: The maximum resident set size (KB)                   = 548080
 
 Test 128 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4226,14 +4226,14 @@ Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 272.364865
-  0: The maximum resident set size (KB)                   = 612928
+  0: The total amount of wall time                        = 276.798112
+  0: The maximum resident set size (KB)                   = 617520
 
 Test 129 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4244,28 +4244,28 @@ Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 620.707415
-  0: The maximum resident set size (KB)                   = 596064
+  0: The total amount of wall time                        = 620.695105
+  0: The maximum resident set size (KB)                   = 600052
 
 Test 130 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_global_storm_following_1nest_atm
 Checking test 131 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 78.723625
-  0: The maximum resident set size (KB)                   = 396064
+  0: The total amount of wall time                        = 80.110136
+  0: The maximum resident set size (KB)                   = 395848
 
 Test 131 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_docn
 Checking test 132 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4273,14 +4273,14 @@ Checking test 132 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 379.019301
-  0: The maximum resident set size (KB)                   = 1209328
+  0: The total amount of wall time                        = 382.485759
+  0: The maximum resident set size (KB)                   = 1202864
 
 Test 132 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_docn_oisst
 Checking test 133 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4288,131 +4288,131 @@ Checking test 133 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 380.806759
-  0: The maximum resident set size (KB)                   = 1191120
+  0: The total amount of wall time                        = 383.893327
+  0: The maximum resident set size (KB)                   = 1201204
 
 Test 133 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/hafs_regional_datm_cdeps
 Checking test 134 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 950.314611
-  0: The maximum resident set size (KB)                   = 1045328
+  0: The total amount of wall time                        = 944.247572
+  0: The maximum resident set size (KB)                   = 1042636
 
 Test 134 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_control_cfsr
 Checking test 135 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.537166
- 0: The maximum resident set size (KB)                   = 1065724
+ 0: The total amount of wall time                        = 154.777614
+ 0: The maximum resident set size (KB)                   = 1056140
 
 Test 135 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_restart_cfsr
 Checking test 136 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.585486
- 0: The maximum resident set size (KB)                   = 1029180
+ 0: The total amount of wall time                        = 94.406105
+ 0: The maximum resident set size (KB)                   = 1008884
 
 Test 136 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_control_gefs
 Checking test 137 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.233177
- 0: The maximum resident set size (KB)                   = 956828
+ 0: The total amount of wall time                        = 151.560971
+ 0: The maximum resident set size (KB)                   = 961380
 
 Test 137 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_iau_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_iau_gefs
 Checking test 138 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.080682
- 0: The maximum resident set size (KB)                   = 965408
+ 0: The total amount of wall time                        = 156.357420
+ 0: The maximum resident set size (KB)                   = 954364
 
 Test 138 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_stochy_gefs
 Checking test 139 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.057799
- 0: The maximum resident set size (KB)                   = 969596
+ 0: The total amount of wall time                        = 156.725076
+ 0: The maximum resident set size (KB)                   = 966052
 
 Test 139 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_ciceC_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_ciceC_cfsr
 Checking test 140 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.032894
- 0: The maximum resident set size (KB)                   = 1047024
+ 0: The total amount of wall time                        = 155.696997
+ 0: The maximum resident set size (KB)                   = 1057484
 
 Test 140 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_bulk_cfsr
 Checking test 141 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.015746
- 0: The maximum resident set size (KB)                   = 1054232
+ 0: The total amount of wall time                        = 157.142004
+ 0: The maximum resident set size (KB)                   = 1061640
 
 Test 141 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_bulk_gefs
 Checking test 142 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.962890
- 0: The maximum resident set size (KB)                   = 961656
+ 0: The total amount of wall time                        = 155.511354
+ 0: The maximum resident set size (KB)                   = 960864
 
 Test 142 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_mx025_cfsr
 Checking test 143 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4421,14 +4421,14 @@ Checking test 143 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 433.933618
-  0: The maximum resident set size (KB)                   = 878908
+  0: The total amount of wall time                        = 439.186139
+  0: The maximum resident set size (KB)                   = 883400
 
 Test 143 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_mx025_gefs
 Checking test 144 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4437,64 +4437,64 @@ Checking test 144 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 434.391039
-  0: The maximum resident set size (KB)                   = 932136
+  0: The total amount of wall time                        = 437.144071
+  0: The maximum resident set size (KB)                   = 940132
 
 Test 144 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_multiple_files_cfsr
 Checking test 145 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 159.614522
- 0: The maximum resident set size (KB)                   = 1061020
+ 0: The total amount of wall time                        = 155.351280
+ 0: The maximum resident set size (KB)                   = 1068596
 
 Test 145 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_3072x1536_cfsr
 Checking test 146 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 208.213202
- 0: The maximum resident set size (KB)                   = 2363512
+ 0: The total amount of wall time                        = 211.176594
+ 0: The maximum resident set size (KB)                   = 2377756
 
 Test 146 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_gfs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_gfs
 Checking test 147 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 216.319658
- 0: The maximum resident set size (KB)                   = 2301100
+ 0: The total amount of wall time                        = 214.007858
+ 0: The maximum resident set size (KB)                   = 2359836
 
 Test 147 datm_cdeps_gfs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/datm_cdeps_debug_cfsr
 Checking test 148 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 447.286748
- 0: The maximum resident set size (KB)                   = 1009460
+ 0: The total amount of wall time                        = 454.948443
+ 0: The maximum resident set size (KB)                   = 1003664
 
 Test 148 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/control_atmwav
 Checking test 149 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4538,14 +4538,14 @@ Checking test 149 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 87.907613
-  0: The maximum resident set size (KB)                   = 656644
+  0: The total amount of wall time                        = 84.905747
+  0: The maximum resident set size (KB)                   = 658752
 
 Test 149 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/atmaero_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/atmaero_control_p8
 Checking test 150 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4589,14 +4589,14 @@ Checking test 150 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.151070
-  0: The maximum resident set size (KB)                   = 2976864
+  0: The total amount of wall time                        = 225.681229
+  0: The maximum resident set size (KB)                   = 2973072
 
 Test 150 atmaero_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/atmaero_control_p8_rad
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/atmaero_control_p8_rad
 Checking test 151 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4640,14 +4640,14 @@ Checking test 151 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.384094
-  0: The maximum resident set size (KB)                   = 3046468
+  0: The total amount of wall time                        = 275.341565
+  0: The maximum resident set size (KB)                   = 3046936
 
 Test 151 atmaero_control_p8_rad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad_micro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/atmaero_control_p8_rad_micro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad_micro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/atmaero_control_p8_rad_micro
 Checking test 152 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4691,14 +4691,14 @@ Checking test 152 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 280.795274
-  0: The maximum resident set size (KB)                   = 3052616
+  0: The total amount of wall time                        = 283.732798
+  0: The maximum resident set size (KB)                   = 3055452
 
 Test 152 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_atmaq
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_13638/regional_atmaq
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_atmaq
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31512/regional_atmaq
 Checking test 153 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4714,12 +4714,12 @@ Checking test 153 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 657.343346
-  0: The maximum resident set size (KB)                   = 1066148
+  0: The total amount of wall time                        = 663.734057
+  0: The maximum resident set size (KB)                   = 1073668
 
 Test 153 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct  6 00:20:07 UTC 2022
-Elapsed time: 05h:47m:17s. Have a nice day!
+Sun Oct  9 20:32:17 UTC 2022
+Elapsed time: 00h:59m:51s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,32 +1,29 @@
-Wed Oct  5 20:40:43 GMT 2022
-Start Regression test
+Compile 001 elapsed time 1831 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 1658 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 307 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 277 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 1379 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 006 elapsed time 1385 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 008 elapsed time 1439 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 009 elapsed time 1374 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 010 elapsed time 1240 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 860 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 1241 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 1250 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 015 elapsed time 237 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 237 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 1637 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 018 elapsed time 1658 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 019 elapsed time 295 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 020 elapsed time 161 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 1635 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 022 elapsed time 1289 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 023 elapsed time 1328 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-Compile 001 elapsed time 1792 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 1795 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 374 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 319 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 1497 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 006 elapsed time 1420 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 007 elapsed time 1420 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 1477 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 009 elapsed time 1456 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 010 elapsed time 1266 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 916 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 253 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 1317 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 1350 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 015 elapsed time 336 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 336 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 1646 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 018 elapsed time 1669 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 019 elapsed time 333 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 020 elapsed time 175 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 1658 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 022 elapsed time 1321 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 023 elapsed time 1362 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -91,14 +88,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 553.526008
-  0: The maximum resident set size (KB)                   = 1767680
+  0: The total amount of wall time                        = 485.226772
+  0: The maximum resident set size (KB)                   = 1765072
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -151,14 +148,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 295.177560
-  0: The maximum resident set size (KB)                   = 1483372
+  0: The total amount of wall time                        = 288.644918
+  0: The maximum resident set size (KB)                   = 1477384
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -211,74 +208,69 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 979.194641
-  0: The maximum resident set size (KB)                   = 1953004
+  0: The total amount of wall time                        = 950.759949
+  0: The maximum resident set size (KB)                   = 1956564
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_esmfthreads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 1008.402525
-  0: The maximum resident set size (KB)                   = 1975344
-
-Test 004 cpld_esmfthreads_p8 PASS
+ Comparing sfcf024.tile1.nc ............MISSING file
+ Comparing sfcf024.tile2.nc ............MISSING file
+ Comparing sfcf024.tile3.nc ............MISSING file
+ Comparing sfcf024.tile4.nc ............MISSING file
+ Comparing sfcf024.tile5.nc ............MISSING file
+ Comparing sfcf024.tile6.nc ............MISSING file
+ Comparing atmf024.tile1.nc ............MISSING file
+ Comparing atmf024.tile2.nc ............MISSING file
+ Comparing atmf024.tile3.nc ............MISSING file
+ Comparing atmf024.tile4.nc ............MISSING file
+ Comparing atmf024.tile5.nc ............MISSING file
+ Comparing atmf024.tile6.nc ............MISSING file
+ Comparing gocart.inst_aod.20210323_0600z.nc4 ............MISSING file
+ Comparing RESTART/coupler.res ............MISSING file
+ Comparing RESTART/fv_core.res.nc ............MISSING file
+ Comparing RESTART/fv_core.res.tile1.nc ............MISSING file
+ Comparing RESTART/fv_core.res.tile2.nc ............MISSING file
+ Comparing RESTART/fv_core.res.tile3.nc ............MISSING file
+ Comparing RESTART/fv_core.res.tile4.nc ............MISSING file
+ Comparing RESTART/fv_core.res.tile5.nc ............MISSING file
+ Comparing RESTART/fv_core.res.tile6.nc ............MISSING file
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............MISSING file
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............MISSING file
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............MISSING file
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............MISSING file
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............MISSING file
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............MISSING file
+ Comparing RESTART/fv_tracer.res.tile1.nc ............MISSING file
+ Comparing RESTART/fv_tracer.res.tile2.nc ............MISSING file
+ Comparing RESTART/fv_tracer.res.tile3.nc ............MISSING file
+ Comparing RESTART/fv_tracer.res.tile4.nc ............MISSING file
+ Comparing RESTART/fv_tracer.res.tile5.nc ............MISSING file
+ Comparing RESTART/fv_tracer.res.tile6.nc ............MISSING file
+ Comparing RESTART/phy_data.tile1.nc ............MISSING file
+ Comparing RESTART/phy_data.tile2.nc ............MISSING file
+ Comparing RESTART/phy_data.tile3.nc ............MISSING file
+ Comparing RESTART/phy_data.tile4.nc ............MISSING file
+ Comparing RESTART/phy_data.tile5.nc ............MISSING file
+ Comparing RESTART/phy_data.tile6.nc ............MISSING file
+ Comparing RESTART/sfc_data.tile1.nc ............MISSING file
+ Comparing RESTART/sfc_data.tile2.nc ............MISSING file
+ Comparing RESTART/sfc_data.tile3.nc ............MISSING file
+ Comparing RESTART/sfc_data.tile4.nc ............MISSING file
+ Comparing RESTART/sfc_data.tile5.nc ............MISSING file
+ Comparing RESTART/sfc_data.tile6.nc ............MISSING file
+ Comparing RESTART/MOM.res.nc ............MISSING file
+ Comparing RESTART/iced.2021-03-23-21600.nc ............MISSING file
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc ............MISSING file
+ Comparing 20210323.060000.out_pnt.ww3 ............MISSING file
+ Comparing 20210323.060000.out_grd.ww3 ............MISSING file
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -331,14 +323,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 530.938302
-  0: The maximum resident set size (KB)                   = 1774348
+  0: The total amount of wall time                        = 490.763241
+  0: The maximum resident set size (KB)                   = 1762288
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_mpi_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -391,14 +383,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 449.295133
-  0: The maximum resident set size (KB)                   = 1726556
+  0: The total amount of wall time                        = 411.306037
+  0: The maximum resident set size (KB)                   = 1725240
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_control_ciceC_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -463,14 +455,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 533.508400
-  0: The maximum resident set size (KB)                   = 1770180
+  0: The total amount of wall time                        = 491.318417
+  0: The maximum resident set size (KB)                   = 1775588
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_control_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_control_noaero_p8
 Checking test 008 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -534,14 +526,14 @@ Checking test 008 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 356.941921
-  0: The maximum resident set size (KB)                   = 1632680
+  0: The total amount of wall time                        = 337.971142
+  0: The maximum resident set size (KB)                   = 1628968
 
 Test 008 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_control_nowave_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_control_nowave_noaero_p8
 Checking test 009 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -603,14 +595,14 @@ Checking test 009 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 404.392484
-  0: The maximum resident set size (KB)                   = 1665264
+  0: The total amount of wall time                        = 372.289702
+  0: The maximum resident set size (KB)                   = 1657924
 
 Test 009 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -663,14 +655,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 903.545373
-  0: The maximum resident set size (KB)                   = 1839412
+  0: The total amount of wall time                        = 917.251725
+  0: The maximum resident set size (KB)                   = 1817400
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_debug_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_debug_noaero_p8
 Checking test 011 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -722,14 +714,14 @@ Checking test 011 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 564.655786
-  0: The maximum resident set size (KB)                   = 1650892
+  0: The total amount of wall time                        = 566.665700
+  0: The maximum resident set size (KB)                   = 1648848
 
 Test 011 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_control_noaero_p8_agrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_control_noaero_p8_agrid
 Checking test 012 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -791,14 +783,14 @@ Checking test 012 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 412.358939
-  0: The maximum resident set size (KB)                   = 1667088
+  0: The total amount of wall time                        = 404.989754
+  0: The maximum resident set size (KB)                   = 1662392
 
 Test 012 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_control_c48
 Checking test 013 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -848,14 +840,14 @@ Checking test 013 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 791.162940
- 0: The maximum resident set size (KB)                   = 2771360
+ 0: The total amount of wall time                        = 796.495140
+ 0: The maximum resident set size (KB)                   = 2756700
 
 Test 013 cpld_control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_warmstart_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_warmstart_c48
 Checking test 014 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -905,14 +897,14 @@ Checking test 014 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 222.464706
- 0: The maximum resident set size (KB)                   = 2774832
+ 0: The total amount of wall time                        = 218.457535
+ 0: The maximum resident set size (KB)                   = 2757468
 
 Test 014 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/cpld_restart_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/cpld_restart_c48
 Checking test 015 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -962,14 +954,14 @@ Checking test 015 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 137.865966
- 0: The maximum resident set size (KB)                   = 2197156
+ 0: The total amount of wall time                        = 116.943184
+ 0: The maximum resident set size (KB)                   = 2196572
 
 Test 015 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1016,14 +1008,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 213.117692
-  0: The maximum resident set size (KB)                   = 569932
+  0: The total amount of wall time                        = 208.018250
+  0: The maximum resident set size (KB)                   = 574108
 
 Test 016 control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1066,14 +1058,14 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.819632
-  0: The maximum resident set size (KB)                   = 564908
+  0: The total amount of wall time                        = 209.035774
+  0: The maximum resident set size (KB)                   = 558720
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1084,14 +1076,14 @@ Checking test 018 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 224.005536
-  0: The maximum resident set size (KB)                   = 573392
+  0: The total amount of wall time                        = 188.666074
+  0: The maximum resident set size (KB)                   = 571360
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1134,14 +1126,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 435.253048
- 0: The maximum resident set size (KB)                   = 621448
+ 0: The total amount of wall time                        = 418.334183
+ 0: The maximum resident set size (KB)                   = 619744
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1180,14 +1172,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 98.930016
-  0: The maximum resident set size (KB)                   = 372072
+  0: The total amount of wall time                        = 96.464619
+  0: The maximum resident set size (KB)                   = 373800
 
 Test 020 control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_fhzero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1230,14 +1222,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 211.513446
-  0: The maximum resident set size (KB)                   = 575900
+  0: The total amount of wall time                        = 186.524432
+  0: The maximum resident set size (KB)                   = 570752
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1264,28 +1256,28 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 186.876965
-  0: The maximum resident set size (KB)                   = 572040
+  0: The total amount of wall time                        = 191.395311
+  0: The maximum resident set size (KB)                   = 573092
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_CubedSphereGrid_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_CubedSphereGrid_parallel
 Checking test 023 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 201.313182
-  0: The maximum resident set size (KB)                   = 574944
+  0: The total amount of wall time                        = 187.851488
+  0: The maximum resident set size (KB)                   = 571940
 
 Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_latlon
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_latlon
 Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1296,14 +1288,14 @@ Checking test 024 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 200.161306
-  0: The maximum resident set size (KB)                   = 568896
+  0: The total amount of wall time                        = 192.320731
+  0: The maximum resident set size (KB)                   = 573788
 
 Test 024 control_latlon PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_wrtGauss_netcdf_parallel
 Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1314,14 +1306,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.549797
-  0: The maximum resident set size (KB)                   = 573872
+  0: The total amount of wall time                        = 189.098169
+  0: The maximum resident set size (KB)                   = 578012
 
 Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_c48
 Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1360,14 +1352,14 @@ Checking test 026 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 600.541095
-0: The maximum resident set size (KB)                   = 786352
+0: The total amount of wall time                        = 588.786456
+0: The maximum resident set size (KB)                   = 789696
 
 Test 026 control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_c192
 Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1378,14 +1370,14 @@ Checking test 027 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 762.035564
-  0: The maximum resident set size (KB)                   = 691532
+  0: The total amount of wall time                        = 728.702521
+  0: The maximum resident set size (KB)                   = 693424
 
 Test 027 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_c384
 Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1396,14 +1388,14 @@ Checking test 028 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 976.650143
-  0: The maximum resident set size (KB)                   = 1062688
+  0: The total amount of wall time                        = 1037.154837
+  0: The maximum resident set size (KB)                   = 1063044
 
 Test 028 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_c384gdas
 Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1446,14 +1438,14 @@ Checking test 029 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 843.772418
-  0: The maximum resident set size (KB)                   = 1149368
+  0: The total amount of wall time                        = 834.680950
+  0: The maximum resident set size (KB)                   = 1146244
 
 Test 029 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384_progsigma
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_c384_progsigma
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384_progsigma
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_c384_progsigma
 Checking test 030 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1464,14 +1456,14 @@ Checking test 030 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 990.064330
-  0: The maximum resident set size (KB)                   = 1002828
+  0: The total amount of wall time                        = 993.407887
+  0: The maximum resident set size (KB)                   = 995568
 
 Test 030 control_c384_progsigma PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_stochy
 Checking test 031 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1482,28 +1474,28 @@ Checking test 031 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 133.630263
-  0: The maximum resident set size (KB)                   = 577176
+  0: The total amount of wall time                        = 126.938855
+  0: The maximum resident set size (KB)                   = 574060
 
 Test 031 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_stochy_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_stochy_restart
 Checking test 032 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 72.522463
-  0: The maximum resident set size (KB)                   = 389488
+  0: The total amount of wall time                        = 77.536726
+  0: The maximum resident set size (KB)                   = 391312
 
 Test 032 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_lndp
 Checking test 033 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1514,14 +1506,14 @@ Checking test 033 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 131.534613
-  0: The maximum resident set size (KB)                   = 574668
+  0: The total amount of wall time                        = 116.400902
+  0: The maximum resident set size (KB)                   = 575360
 
 Test 033 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_iovr4
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_iovr4
 Checking test 034 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1536,14 +1528,14 @@ Checking test 034 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 211.776536
-  0: The maximum resident set size (KB)                   = 577448
+  0: The total amount of wall time                        = 192.756342
+  0: The maximum resident set size (KB)                   = 564492
 
 Test 034 control_iovr4 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_iovr5
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_iovr5
 Checking test 035 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1558,14 +1550,14 @@ Checking test 035 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 222.341165
-  0: The maximum resident set size (KB)                   = 569756
+  0: The total amount of wall time                        = 195.110273
+  0: The maximum resident set size (KB)                   = 565232
 
 Test 035 control_iovr5 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_p8
 Checking test 036 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1612,14 +1604,14 @@ Checking test 036 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 259.434177
-  0: The maximum resident set size (KB)                   = 1536880
+  0: The total amount of wall time                        = 242.614227
+  0: The maximum resident set size (KB)                   = 1534824
 
 Test 036 control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_p8_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_p8_lndp
 Checking test 037 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1638,14 +1630,14 @@ Checking test 037 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 474.710510
-  0: The maximum resident set size (KB)                   = 1535908
+  0: The total amount of wall time                        = 438.610161
+  0: The maximum resident set size (KB)                   = 1547004
 
 Test 037 control_p8_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_restart_p8
 Checking test 038 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1684,14 +1676,14 @@ Checking test 038 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.170699
-  0: The maximum resident set size (KB)                   = 764120
+  0: The total amount of wall time                        = 129.917698
+  0: The maximum resident set size (KB)                   = 768484
 
 Test 038 control_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_decomp_p8
 Checking test 039 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1734,14 +1726,14 @@ Checking test 039 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 242.257693
-  0: The maximum resident set size (KB)                   = 1521488
+  0: The total amount of wall time                        = 255.694377
+  0: The maximum resident set size (KB)                   = 1527000
 
 Test 039 control_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_2threads_p8
 Checking test 040 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1784,14 +1776,14 @@ Checking test 040 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 536.963405
- 0: The maximum resident set size (KB)                   = 1613444
+ 0: The total amount of wall time                        = 537.810683
+ 0: The maximum resident set size (KB)                   = 1609548
 
 Test 040 control_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_p8_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_p8_rrtmgp
 Checking test 041 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1838,14 +1830,14 @@ Checking test 041 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 279.529642
-  0: The maximum resident set size (KB)                   = 1660004
+  0: The total amount of wall time                        = 277.409336
+  0: The maximum resident set size (KB)                   = 1660892
 
 Test 041 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/merra2_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/merra2_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/merra2_thompson
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/merra2_thompson
 Checking test 042 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1892,14 +1884,14 @@ Checking test 042 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 246.275694
-  0: The maximum resident set size (KB)                   = 1549168
+  0: The total amount of wall time                        = 245.455230
+  0: The maximum resident set size (KB)                   = 1545220
 
 Test 042 merra2_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_control
 Checking test 043 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1910,28 +1902,28 @@ Checking test 043 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 512.197670
- 0: The maximum resident set size (KB)                   = 749964
+ 0: The total amount of wall time                        = 480.633567
+ 0: The maximum resident set size (KB)                   = 744768
 
 Test 043 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_restart
 Checking test 044 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 332.030051
- 0: The maximum resident set size (KB)                   = 735508
+ 0: The total amount of wall time                        = 289.308420
+ 0: The maximum resident set size (KB)                   = 734032
 
 Test 044 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_control_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_control_2dwrtdecomp
 Checking test 045 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1942,14 +1934,14 @@ Checking test 045 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 504.308749
- 0: The maximum resident set size (KB)                   = 745184
+ 0: The total amount of wall time                        = 488.468749
+ 0: The maximum resident set size (KB)                   = 740916
 
 Test 045 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_noquilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_noquilt
 Checking test 046 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1957,14 +1949,14 @@ Checking test 046 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 533.978532
- 0: The maximum resident set size (KB)                   = 730836
+ 0: The total amount of wall time                        = 512.753531
+ 0: The maximum resident set size (KB)                   = 725676
 
 Test 046 regional_noquilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_2threads
 Checking test 047 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1975,28 +1967,28 @@ Checking test 047 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 1188.361935
- 0: The maximum resident set size (KB)                   = 705452
+ 0: The total amount of wall time                        = 1096.770832
+ 0: The maximum resident set size (KB)                   = 714236
 
 Test 047 regional_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_netcdf_parallel
 Checking test 048 regional_netcdf_parallel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 482.171593
- 0: The maximum resident set size (KB)                   = 737316
+ 0: The total amount of wall time                        = 478.712667
+ 0: The maximum resident set size (KB)                   = 739444
 
 Test 048 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_3km
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_3km
 Checking test 049 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2007,14 +1999,14 @@ Checking test 049 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 386.247165
-  0: The maximum resident set size (KB)                   = 775352
+  0: The total amount of wall time                        = 356.649175
+  0: The maximum resident set size (KB)                   = 770504
 
 Test 049 regional_3km PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_3km_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_3km_decomp
 Checking test 050 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2025,14 +2017,14 @@ Checking test 050 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 394.879199
-  0: The maximum resident set size (KB)                   = 776040
+  0: The total amount of wall time                        = 383.766605
+  0: The maximum resident set size (KB)                   = 773384
 
 Test 050 regional_3km_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_control
 Checking test 051 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2079,14 +2071,14 @@ Checking test 051 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 634.528671
-  0: The maximum resident set size (KB)                   = 951132
+  0: The total amount of wall time                        = 612.669089
+  0: The maximum resident set size (KB)                   = 959956
 
 Test 051 rap_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_rrtmgp
 Checking test 052 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2133,14 +2125,14 @@ Checking test 052 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 675.217982
-  0: The maximum resident set size (KB)                   = 1080564
+  0: The total amount of wall time                        = 645.820346
+  0: The maximum resident set size (KB)                   = 1080716
 
 Test 052 rap_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_spp_sppt_shum_skeb
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_spp_sppt_shum_skeb
 Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2151,14 +2143,14 @@ Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 858.970274
-  0: The maximum resident set size (KB)                   = 1055596
+  0: The total amount of wall time                        = 853.994680
+  0: The maximum resident set size (KB)                   = 1072796
 
 Test 053 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_decomp
 Checking test 054 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2205,14 +2197,14 @@ Checking test 054 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 653.513313
-  0: The maximum resident set size (KB)                   = 950828
+  0: The total amount of wall time                        = 634.781779
+  0: The maximum resident set size (KB)                   = 950064
 
 Test 054 rap_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_2threads
 Checking test 055 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2259,14 +2251,14 @@ Checking test 055 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1316.482880
- 0: The maximum resident set size (KB)                   = 1011272
+ 0: The total amount of wall time                        = 1299.297777
+ 0: The maximum resident set size (KB)                   = 1009028
 
 Test 055 rap_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_restart
 Checking test 056 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2305,14 +2297,14 @@ Checking test 056 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 357.391671
-  0: The maximum resident set size (KB)                   = 820120
+  0: The total amount of wall time                        = 302.561033
+  0: The maximum resident set size (KB)                   = 819028
 
 Test 056 rap_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_sfcdiff
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_sfcdiff
 Checking test 057 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2359,14 +2351,14 @@ Checking test 057 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 642.400348
-  0: The maximum resident set size (KB)                   = 947848
+  0: The total amount of wall time                        = 598.623985
+  0: The maximum resident set size (KB)                   = 944904
 
 Test 057 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_sfcdiff_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_sfcdiff_decomp
 Checking test 058 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2413,14 +2405,14 @@ Checking test 058 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 653.827120
-  0: The maximum resident set size (KB)                   = 934452
+  0: The total amount of wall time                        = 626.653636
+  0: The maximum resident set size (KB)                   = 930256
 
 Test 058 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_sfcdiff_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_sfcdiff_restart
 Checking test 059 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2459,14 +2451,14 @@ Checking test 059 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 515.309052
-  0: The maximum resident set size (KB)                   = 837292
+  0: The total amount of wall time                        = 451.589809
+  0: The maximum resident set size (KB)                   = 831508
 
 Test 059 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control
 Checking test 060 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2513,14 +2505,14 @@ Checking test 060 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 603.727523
-  0: The maximum resident set size (KB)                   = 943292
+  0: The total amount of wall time                        = 576.425064
+  0: The maximum resident set size (KB)                   = 944400
 
 Test 060 hrrr_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_decomp
 Checking test 061 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2567,14 +2559,14 @@ Checking test 061 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 636.201495
-  0: The maximum resident set size (KB)                   = 936384
+  0: The total amount of wall time                        = 633.272744
+  0: The maximum resident set size (KB)                   = 934560
 
 Test 061 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_2threads
 Checking test 062 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2621,14 +2613,14 @@ Checking test 062 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1282.931640
- 0: The maximum resident set size (KB)                   = 1014544
+ 0: The total amount of wall time                        = 1265.192476
+ 0: The maximum resident set size (KB)                   = 1014600
 
 Test 062 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_restart
 Checking test 063 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2667,14 +2659,14 @@ Checking test 063 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 448.364841
-  0: The maximum resident set size (KB)                   = 826928
+  0: The total amount of wall time                        = 444.797569
+  0: The maximum resident set size (KB)                   = 825116
 
 Test 063 hrrr_control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_v1beta
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_v1beta
 Checking test 064 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2721,14 +2713,14 @@ Checking test 064 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 647.652844
-  0: The maximum resident set size (KB)                   = 938188
+  0: The total amount of wall time                        = 633.159870
+  0: The maximum resident set size (KB)                   = 950776
 
 Test 064 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_v1nssl
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_v1nssl
 Checking test 065 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2743,14 +2735,14 @@ Checking test 065 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 741.977013
-  0: The maximum resident set size (KB)                   = 626632
+  0: The total amount of wall time                        = 744.036355
+  0: The maximum resident set size (KB)                   = 630888
 
 Test 065 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_v1nssl_nohailnoccn
 Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2765,14 +2757,14 @@ Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 753.801843
-  0: The maximum resident set size (KB)                   = 624124
+  0: The total amount of wall time                        = 736.862235
+  0: The maximum resident set size (KB)                   = 628028
 
 Test 066 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_conus13km_hrrr_warm
 Checking test 067 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2781,14 +2773,14 @@ Checking test 067 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 251.049681
-  0: The maximum resident set size (KB)                   = 852568
+  0: The total amount of wall time                        = 284.522294
+  0: The maximum resident set size (KB)                   = 853752
 
 Test 067 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_conus13km_radar_tten_warm
 Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2797,14 +2789,14 @@ Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 249.287414
-  0: The maximum resident set size (KB)                   = 853992
+  0: The total amount of wall time                        = 267.703949
+  0: The maximum resident set size (KB)                   = 857540
 
 Test 068 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_smoke_conus13km_hrrr_warm
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2813,14 +2805,14 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 276.554108
-  0: The maximum resident set size (KB)                   = 877200
+  0: The total amount of wall time                        = 308.998514
+  0: The maximum resident set size (KB)                   = 876964
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_csawmg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_csawmg
 Checking test 070 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2831,14 +2823,14 @@ Checking test 070 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 488.547739
-  0: The maximum resident set size (KB)                   = 668308
+  0: The total amount of wall time                        = 496.207227
+  0: The maximum resident set size (KB)                   = 659140
 
 Test 070 control_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_csawmgt
 Checking test 071 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2849,14 +2841,14 @@ Checking test 071 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 523.056491
-  0: The maximum resident set size (KB)                   = 672152
+  0: The total amount of wall time                        = 483.110659
+  0: The maximum resident set size (KB)                   = 663588
 
 Test 071 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_ras
 Checking test 072 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2867,54 +2859,54 @@ Checking test 072 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 258.926834
-  0: The maximum resident set size (KB)                   = 640012
+  0: The total amount of wall time                        = 280.667910
+  0: The maximum resident set size (KB)                   = 622120
 
 Test 072 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_wam
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_wam
 Checking test 073 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 161.583280
-  0: The maximum resident set size (KB)                   = 474392
+  0: The total amount of wall time                        = 173.560078
+  0: The maximum resident set size (KB)                   = 478512
 
 Test 073 control_wam PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_debug
 Checking test 074 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.396189
-  0: The maximum resident set size (KB)                   = 732628
+  0: The total amount of wall time                        = 203.457893
+  0: The maximum resident set size (KB)                   = 729988
 
 Test 074 control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_2threads_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_2threads_debug
 Checking test 075 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 411.334350
- 0: The maximum resident set size (KB)                   = 785048
+ 0: The total amount of wall time                        = 358.276225
+ 0: The maximum resident set size (KB)                   = 780752
 
 Test 075 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_CubedSphereGrid_debug
 Checking test 076 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2941,348 +2933,348 @@ Checking test 076 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 293.729714
-  0: The maximum resident set size (KB)                   = 737336
+  0: The total amount of wall time                        = 230.347820
+  0: The maximum resident set size (KB)                   = 732148
 
 Test 076 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_wrtGauss_netcdf_parallel_debug
 Checking test 077 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 226.634886
-  0: The maximum resident set size (KB)                   = 734988
+  0: The total amount of wall time                        = 207.250748
+  0: The maximum resident set size (KB)                   = 731116
 
 Test 077 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_stochy_debug
 Checking test 078 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.460706
-  0: The maximum resident set size (KB)                   = 739284
+  0: The total amount of wall time                        = 247.307167
+  0: The maximum resident set size (KB)                   = 738664
 
 Test 078 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_lndp_debug
 Checking test 079 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 219.696316
-  0: The maximum resident set size (KB)                   = 738372
+  0: The total amount of wall time                        = 220.494640
+  0: The maximum resident set size (KB)                   = 735692
 
 Test 079 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_csawmg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_csawmg_debug
 Checking test 080 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 319.041472
-  0: The maximum resident set size (KB)                   = 784624
+  0: The total amount of wall time                        = 348.924195
+  0: The maximum resident set size (KB)                   = 786368
 
 Test 080 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_csawmgt_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_csawmgt_debug
 Checking test 081 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 366.291198
-  0: The maximum resident set size (KB)                   = 781500
+  0: The total amount of wall time                        = 345.521223
+  0: The maximum resident set size (KB)                   = 782872
 
 Test 081 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_ras_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_ras_debug
 Checking test 082 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 240.742827
-  0: The maximum resident set size (KB)                   = 746576
+  0: The total amount of wall time                        = 236.606365
+  0: The maximum resident set size (KB)                   = 747260
 
 Test 082 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_diag_debug
 Checking test 083 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.109790
-  0: The maximum resident set size (KB)                   = 791784
+  0: The total amount of wall time                        = 238.316518
+  0: The maximum resident set size (KB)                   = 799812
 
 Test 083 control_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_debug_p8
 Checking test 084 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.377037
-  0: The maximum resident set size (KB)                   = 1553788
+  0: The total amount of wall time                        = 279.059125
+  0: The maximum resident set size (KB)                   = 1552600
 
 Test 084 control_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_debug
 Checking test 085 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 335.096500
- 0: The maximum resident set size (KB)                   = 755820
+ 0: The total amount of wall time                        = 366.330175
+ 0: The maximum resident set size (KB)                   = 754012
 
 Test 085 regional_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_control_debug
 Checking test 086 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 375.767404
-  0: The maximum resident set size (KB)                   = 1107700
+  0: The total amount of wall time                        = 422.788647
+  0: The maximum resident set size (KB)                   = 1108680
 
 Test 086 rap_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_debug
 Checking test 087 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 421.868391
-  0: The maximum resident set size (KB)                   = 1106716
+  0: The total amount of wall time                        = 404.362884
+  0: The maximum resident set size (KB)                   = 1104696
 
 Test 087 hrrr_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_unified_drag_suite_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_unified_drag_suite_debug
 Checking test 088 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 422.919968
-  0: The maximum resident set size (KB)                   = 1109768
+  0: The total amount of wall time                        = 373.249747
+  0: The maximum resident set size (KB)                   = 1104172
 
 Test 088 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_diag_debug
 Checking test 089 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 405.901420
-  0: The maximum resident set size (KB)                   = 1189580
+  0: The total amount of wall time                        = 394.094688
+  0: The maximum resident set size (KB)                   = 1187340
 
 Test 089 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_cires_ugwp_debug
 Checking test 090 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 387.993538
-  0: The maximum resident set size (KB)                   = 1108692
+  0: The total amount of wall time                        = 377.321651
+  0: The maximum resident set size (KB)                   = 1112624
 
 Test 090 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_unified_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_unified_ugwp_debug
 Checking test 091 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 383.586895
-  0: The maximum resident set size (KB)                   = 1104064
+  0: The total amount of wall time                        = 396.145544
+  0: The maximum resident set size (KB)                   = 1108844
 
 Test 091 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_lndp_debug
 Checking test 092 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 380.971334
-  0: The maximum resident set size (KB)                   = 1111072
+  0: The total amount of wall time                        = 388.860633
+  0: The maximum resident set size (KB)                   = 1107100
 
 Test 092 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_flake_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_flake_debug
 Checking test 093 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 366.002562
-  0: The maximum resident set size (KB)                   = 1108828
+  0: The total amount of wall time                        = 411.863526
+  0: The maximum resident set size (KB)                   = 1107092
 
 Test 093 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_progcld_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_progcld_thompson_debug
 Checking test 094 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 425.553812
-  0: The maximum resident set size (KB)                   = 1109004
+  0: The total amount of wall time                        = 437.969587
+  0: The maximum resident set size (KB)                   = 1105968
 
 Test 094 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_noah_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_noah_debug
 Checking test 095 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 398.075204
-  0: The maximum resident set size (KB)                   = 1117812
+  0: The total amount of wall time                        = 414.065522
+  0: The maximum resident set size (KB)                   = 1109772
 
 Test 095 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_rrtmgp_debug
 Checking test 096 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 638.279475
-  0: The maximum resident set size (KB)                   = 1233964
+  0: The total amount of wall time                        = 627.889653
+  0: The maximum resident set size (KB)                   = 1232808
 
 Test 096 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_sfcdiff_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_sfcdiff_debug
 Checking test 097 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 436.027834
-  0: The maximum resident set size (KB)                   = 1107264
+  0: The total amount of wall time                        = 387.592338
+  0: The maximum resident set size (KB)                   = 1104588
 
 Test 097 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 098 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 619.831457
-  0: The maximum resident set size (KB)                   = 1106704
+  0: The total amount of wall time                        = 603.944625
+  0: The maximum resident set size (KB)                   = 1107032
 
 Test 098 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rrfs_v1beta_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rrfs_v1beta_debug
 Checking test 099 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 383.781148
-  0: The maximum resident set size (KB)                   = 1104184
+  0: The total amount of wall time                        = 367.371347
+  0: The maximum resident set size (KB)                   = 1109596
 
 Test 099 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_wam_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_wam_debug
 Checking test 100 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 373.304090
-  0: The maximum resident set size (KB)                   = 433192
+  0: The total amount of wall time                        = 371.559045
+  0: The maximum resident set size (KB)                   = 432672
 
 Test 100 control_wam_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 101 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3293,14 +3285,14 @@ Checking test 101 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 863.917100
-  0: The maximum resident set size (KB)                   = 955712
+  0: The total amount of wall time                        = 792.468959
+  0: The maximum resident set size (KB)                   = 967204
 
 Test 101 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_control_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_control_dyn32_phy32
 Checking test 102 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3347,14 +3339,14 @@ Checking test 102 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 591.193282
-  0: The maximum resident set size (KB)                   = 853844
+  0: The total amount of wall time                        = 491.392226
+  0: The maximum resident set size (KB)                   = 844112
 
 Test 102 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_dyn32_phy32
 Checking test 103 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3401,14 +3393,14 @@ Checking test 103 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 310.759707
-  0: The maximum resident set size (KB)                   = 826788
+  0: The total amount of wall time                        = 255.368227
+  0: The maximum resident set size (KB)                   = 825420
 
 Test 103 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_2threads_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_2threads_dyn32_phy32
 Checking test 104 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3455,14 +3447,14 @@ Checking test 104 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1134.954904
- 0: The maximum resident set size (KB)                   = 879952
+ 0: The total amount of wall time                        = 1053.542112
+ 0: The maximum resident set size (KB)                   = 870832
 
 Test 104 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_2threads_dyn32_phy32
 Checking test 105 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3509,14 +3501,14 @@ Checking test 105 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 592.112087
- 0: The maximum resident set size (KB)                   = 864732
+ 0: The total amount of wall time                        = 546.252158
+ 0: The maximum resident set size (KB)                   = 872628
 
 Test 105 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_decomp_dyn32_phy32
 Checking test 106 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3563,14 +3555,14 @@ Checking test 106 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 320.340853
-  0: The maximum resident set size (KB)                   = 818196
+  0: The total amount of wall time                        = 271.316959
+  0: The maximum resident set size (KB)                   = 818240
 
 Test 106 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_restart_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_restart_dyn32_phy32
 Checking test 107 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3609,14 +3601,14 @@ Checking test 107 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 388.453694
-  0: The maximum resident set size (KB)                   = 801048
+  0: The total amount of wall time                        = 359.480276
+  0: The maximum resident set size (KB)                   = 800616
 
 Test 107 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_restart_dyn32_phy32
 Checking test 108 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3655,14 +3647,14 @@ Checking test 108 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.945038
-  0: The maximum resident set size (KB)                   = 760072
+  0: The total amount of wall time                        = 136.368919
+  0: The maximum resident set size (KB)                   = 762568
 
 Test 108 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_control_dyn64_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_control_dyn64_phy32
 Checking test 109 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3709,81 +3701,81 @@ Checking test 109 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 392.152623
-  0: The maximum resident set size (KB)                   = 862300
+  0: The total amount of wall time                        = 320.048416
+  0: The maximum resident set size (KB)                   = 870776
 
 Test 109 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_control_debug_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_control_debug_dyn32_phy32
 Checking test 110 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 396.423902
-  0: The maximum resident set size (KB)                   = 993680
+  0: The total amount of wall time                        = 358.537078
+  0: The maximum resident set size (KB)                   = 996592
 
 Test 110 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hrrr_control_debug_dyn32_phy32
 Checking test 111 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 373.309838
-  0: The maximum resident set size (KB)                   = 995968
+  0: The total amount of wall time                        = 357.354447
+  0: The maximum resident set size (KB)                   = 992076
 
 Test 111 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/rap_control_dyn64_phy32_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/rap_control_dyn64_phy32_debug
 Checking test 112 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 370.920211
-  0: The maximum resident set size (KB)                   = 1025204
+  0: The total amount of wall time                        = 390.343237
+  0: The maximum resident set size (KB)                   = 1025596
 
 Test 112 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_atm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_atm
 Checking test 113 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 798.691269
-  0: The maximum resident set size (KB)                   = 1168356
+  0: The total amount of wall time                        = 763.346606
+  0: The maximum resident set size (KB)                   = 1176172
 
 Test 113 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_atm_thompson_gfdlsf
 Checking test 114 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 910.496686
-  0: The maximum resident set size (KB)                   = 1527664
+  0: The total amount of wall time                        = 873.531296
+  0: The maximum resident set size (KB)                   = 1525824
 
 Test 114 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_atm_ocn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_atm_ocn
 Checking test 115 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3792,14 +3784,14 @@ Checking test 115 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 651.308441
-  0: The maximum resident set size (KB)                   = 1259008
+  0: The total amount of wall time                        = 549.711528
+  0: The maximum resident set size (KB)                   = 1261184
 
 Test 115 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_atm_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_atm_wav
 Checking test 116 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3808,14 +3800,14 @@ Checking test 116 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 977.705795
-  0: The maximum resident set size (KB)                   = 1297772
+  0: The total amount of wall time                        = 932.138188
+  0: The maximum resident set size (KB)                   = 1303104
 
 Test 116 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_atm_ocn_wav
 Checking test 117 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3826,14 +3818,14 @@ Checking test 117 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1080.916880
-  0: The maximum resident set size (KB)                   = 1308864
+  0: The total amount of wall time                        = 1031.089768
+  0: The maximum resident set size (KB)                   = 1270876
 
 Test 117 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_docn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_docn
 Checking test 118 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3841,14 +3833,14 @@ Checking test 118 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 587.948309
-  0: The maximum resident set size (KB)                   = 1262980
+  0: The total amount of wall time                        = 568.100048
+  0: The maximum resident set size (KB)                   = 1247600
 
 Test 118 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_docn_oisst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_docn_oisst
 Checking test 119 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3856,131 +3848,131 @@ Checking test 119 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 576.044299
-  0: The maximum resident set size (KB)                   = 1239704
+  0: The total amount of wall time                        = 548.944011
+  0: The maximum resident set size (KB)                   = 1238744
 
 Test 119 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/hafs_regional_datm_cdeps
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/hafs_regional_datm_cdeps
 Checking test 120 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1295.997567
-  0: The maximum resident set size (KB)                   = 978508
+  0: The total amount of wall time                        = 1248.505043
+  0: The maximum resident set size (KB)                   = 975180
 
 Test 120 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_control_cfsr
 Checking test 121 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 228.371358
- 0: The maximum resident set size (KB)                   = 954136
+ 0: The total amount of wall time                        = 214.952497
+ 0: The maximum resident set size (KB)                   = 976388
 
 Test 121 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_restart_cfsr
 Checking test 122 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.248082
- 0: The maximum resident set size (KB)                   = 929800
+ 0: The total amount of wall time                        = 128.123938
+ 0: The maximum resident set size (KB)                   = 931816
 
 Test 122 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_control_gefs
 Checking test 123 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 216.753230
- 0: The maximum resident set size (KB)                   = 867336
+ 0: The total amount of wall time                        = 235.924715
+ 0: The maximum resident set size (KB)                   = 862336
 
 Test 123 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_iau_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_iau_gefs
 Checking test 124 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 216.808280
- 0: The maximum resident set size (KB)                   = 874712
+ 0: The total amount of wall time                        = 217.406044
+ 0: The maximum resident set size (KB)                   = 865868
 
 Test 124 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_stochy_gefs
 Checking test 125 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 217.635949
- 0: The maximum resident set size (KB)                   = 861640
+ 0: The total amount of wall time                        = 215.420867
+ 0: The maximum resident set size (KB)                   = 862280
 
 Test 125 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_ciceC_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_ciceC_cfsr
 Checking test 126 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 217.546119
- 0: The maximum resident set size (KB)                   = 969576
+ 0: The total amount of wall time                        = 220.680201
+ 0: The maximum resident set size (KB)                   = 967472
 
 Test 126 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_bulk_cfsr
 Checking test 127 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 220.726795
- 0: The maximum resident set size (KB)                   = 966888
+ 0: The total amount of wall time                        = 214.758489
+ 0: The maximum resident set size (KB)                   = 957808
 
 Test 127 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_bulk_gefs
 Checking test 128 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 216.183896
- 0: The maximum resident set size (KB)                   = 868224
+ 0: The total amount of wall time                        = 206.009621
+ 0: The maximum resident set size (KB)                   = 861884
 
 Test 128 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_mx025_cfsr
 Checking test 129 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3989,14 +3981,14 @@ Checking test 129 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 602.938639
-  0: The maximum resident set size (KB)                   = 762584
+  0: The total amount of wall time                        = 595.228180
+  0: The maximum resident set size (KB)                   = 769716
 
 Test 129 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_mx025_gefs
 Checking test 130 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4005,64 +3997,64 @@ Checking test 130 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 616.840071
-  0: The maximum resident set size (KB)                   = 734712
+  0: The total amount of wall time                        = 619.783961
+  0: The maximum resident set size (KB)                   = 735732
 
 Test 130 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_multiple_files_cfsr
 Checking test 131 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 223.618044
- 0: The maximum resident set size (KB)                   = 975636
+ 0: The total amount of wall time                        = 231.596259
+ 0: The maximum resident set size (KB)                   = 964004
 
 Test 131 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_3072x1536_cfsr
 Checking test 132 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 307.047443
- 0: The maximum resident set size (KB)                   = 2252176
+ 0: The total amount of wall time                        = 287.641275
+ 0: The maximum resident set size (KB)                   = 2257472
 
 Test 132 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_gfs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_gfs
 Checking test 133 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 337.905963
- 0: The maximum resident set size (KB)                   = 2193516
+ 0: The total amount of wall time                        = 307.538910
+ 0: The maximum resident set size (KB)                   = 2191760
 
 Test 133 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/datm_cdeps_debug_cfsr
 Checking test 134 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 603.403476
- 0: The maximum resident set size (KB)                   = 930232
+ 0: The total amount of wall time                        = 588.229292
+ 0: The maximum resident set size (KB)                   = 918676
 
 Test 134 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/control_atmwav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/control_atmwav
 Checking test 135 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4106,14 +4098,14 @@ Checking test 135 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 137.718754
-  0: The maximum resident set size (KB)                   = 595336
+  0: The total amount of wall time                        = 130.261159
+  0: The maximum resident set size (KB)                   = 597276
 
 Test 135 control_atmwav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/atmaero_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/atmaero_control_p8
 Checking test 136 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4157,14 +4149,14 @@ Checking test 136 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.711341
-  0: The maximum resident set size (KB)                   = 1627356
+  0: The total amount of wall time                        = 317.930397
+  0: The maximum resident set size (KB)                   = 1634992
 
 Test 136 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/atmaero_control_p8_rad
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/atmaero_control_p8_rad
 Checking test 137 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4208,14 +4200,14 @@ Checking test 137 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 393.623298
-  0: The maximum resident set size (KB)                   = 1659768
+  0: The total amount of wall time                        = 391.879752
+  0: The maximum resident set size (KB)                   = 1656756
 
 Test 137 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/atmaero_control_p8_rad_micro
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/atmaero_control_p8_rad_micro
 Checking test 138 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4259,14 +4251,14 @@ Checking test 138 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 397.108574
-  0: The maximum resident set size (KB)                   = 1660816
+  0: The total amount of wall time                        = 403.932224
+  0: The maximum resident set size (KB)                   = 1663800
 
 Test 138 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_atmaq
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_140792/regional_atmaq
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_atmaq
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_17933/regional_atmaq
 Checking test 139 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4282,12 +4274,76 @@ Checking test 139 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1120.346504
-  0: The maximum resident set size (KB)                   = 1070872
+  0: The total amount of wall time                        = 1032.359046
+  0: The maximum resident set size (KB)                   = 970044
 
 Test 139 regional_atmaq PASS
 
+Mon Oct 10 12:38:54 GMT 2022
+Start Regression test
+
+Compile 001 elapsed time 1835 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_56349/cpld_esmfthreads_p8
+Checking test 001 cpld_esmfthreads_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 1157.207285
+  0: The maximum resident set size (KB)                   = 1988052
+
+Test 001 cpld_esmfthreads_p8 PASS
+
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct  5 23:41:48 GMT 2022
-Elapsed time: 03h:01m:05s. Have a nice day!
+Mon Oct 10 13:38:50 GMT 2022
+Elapsed time: 00h:59m:56s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,32 +1,32 @@
-Wed Oct  5 12:19:22 CDT 2022
+Sun Oct  9 08:46:24 CDT 2022
 Start Regression test
 
-Compile 001 elapsed time 680 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 645 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 257 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 216 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 421 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 441 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 395 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 431 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 497 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 343 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 744 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 230 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 353 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 152 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 618 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 570 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 199 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 137 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 669 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 353 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 355 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 664 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 604 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 231 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 248 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 456 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 462 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 437 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 379 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 664 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 214 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 336 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 214 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 209 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 587 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 575 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 222 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 129 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 545 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 431 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 403 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -91,14 +91,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.605365
-  0: The maximum resident set size (KB)                   = 3176728
+  0: The total amount of wall time                        = 342.655427
+  0: The maximum resident set size (KB)                   = 3175772
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -151,14 +151,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 200.445181
-  0: The maximum resident set size (KB)                   = 3047872
+  0: The total amount of wall time                        = 201.259552
+  0: The maximum resident set size (KB)                   = 3048636
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -211,14 +211,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 424.262683
-  0: The maximum resident set size (KB)                   = 3448376
+  0: The total amount of wall time                        = 424.924675
+  0: The maximum resident set size (KB)                   = 3446272
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_esmfthreads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -271,14 +271,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 403.330979
-  0: The maximum resident set size (KB)                   = 3519928
+  0: The total amount of wall time                        = 405.178409
+  0: The maximum resident set size (KB)                   = 3511828
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -331,14 +331,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 342.935764
-  0: The maximum resident set size (KB)                   = 3172184
+  0: The total amount of wall time                        = 337.958921
+  0: The maximum resident set size (KB)                   = 3164740
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -391,14 +391,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 283.783768
-  0: The maximum resident set size (KB)                   = 3032744
+  0: The total amount of wall time                        = 276.595020
+  0: The maximum resident set size (KB)                   = 3026456
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_ciceC_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_ciceC_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_ciceC_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -463,14 +463,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 350.897451
-  0: The maximum resident set size (KB)                   = 3105844
+  0: The total amount of wall time                        = 339.263205
+  0: The maximum resident set size (KB)                   = 3177044
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -523,14 +523,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 744.419769
-  0: The maximum resident set size (KB)                   = 3229052
+  0: The total amount of wall time                        = 653.251843
+  0: The maximum resident set size (KB)                   = 3220892
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -583,14 +583,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 464.216836
-  0: The maximum resident set size (KB)                   = 3138968
+  0: The total amount of wall time                        = 420.082735
+  0: The maximum resident set size (KB)                   = 3137464
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -638,14 +638,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 834.664257
-  0: The maximum resident set size (KB)                   = 3996500
+  0: The total amount of wall time                        = 830.806869
+  0: The maximum resident set size (KB)                   = 4000684
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_restart_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -693,14 +693,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 544.280300
-  0: The maximum resident set size (KB)                   = 3958748
+  0: The total amount of wall time                        = 557.183060
+  0: The maximum resident set size (KB)                   = 3871628
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_bmark_esmfthreads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_bmark_esmfthreads_p8
 Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -748,14 +748,14 @@ Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 844.236662
-   0: The maximum resident set size (KB)                   = 4038408
+   0: The total amount of wall time                        = 853.107998
+   0: The maximum resident set size (KB)                   = 3957332
 
 Test 012 cpld_bmark_esmfthreads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -819,14 +819,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 242.286221
-  0: The maximum resident set size (KB)                   = 1729068
+  0: The total amount of wall time                        = 232.594310
+  0: The maximum resident set size (KB)                   = 1736852
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c96_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_nowave_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c96_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -888,14 +888,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 260.559839
-  0: The maximum resident set size (KB)                   = 1706420
+  0: The total amount of wall time                        = 252.051721
+  0: The maximum resident set size (KB)                   = 1753372
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -948,14 +948,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 680.594114
-  0: The maximum resident set size (KB)                   = 3240576
+  0: The total amount of wall time                        = 685.784628
+  0: The maximum resident set size (KB)                   = 3240912
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_debug_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_debug_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_debug_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1007,14 +1007,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 419.165584
-  0: The maximum resident set size (KB)                   = 1748044
+  0: The total amount of wall time                        = 411.498560
+  0: The maximum resident set size (KB)                   = 1754664
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_noaero_p8_agrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1076,14 +1076,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 259.305473
-  0: The maximum resident set size (KB)                   = 1760176
+  0: The total amount of wall time                        = 257.082912
+  0: The maximum resident set size (KB)                   = 1768368
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1133,14 +1133,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 496.498192
- 0: The maximum resident set size (KB)                   = 2797392
+ 0: The total amount of wall time                        = 494.751983
+ 0: The maximum resident set size (KB)                   = 2797836
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_warmstart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1190,14 +1190,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 142.750554
- 0: The maximum resident set size (KB)                   = 2807516
+ 0: The total amount of wall time                        = 135.895535
+ 0: The maximum resident set size (KB)                   = 2796244
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/cpld_restart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1247,14 +1247,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 73.410420
- 0: The maximum resident set size (KB)                   = 2239840
+ 0: The total amount of wall time                        = 71.664913
+ 0: The maximum resident set size (KB)                   = 2246620
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control
 Checking test 021 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1301,14 +1301,14 @@ Checking test 021 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.893537
-  0: The maximum resident set size (KB)                   = 632236
+  0: The total amount of wall time                        = 134.043330
+  0: The maximum resident set size (KB)                   = 628540
 
 Test 021 control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_decomp
 Checking test 022 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1351,14 +1351,14 @@ Checking test 022 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.412995
-  0: The maximum resident set size (KB)                   = 624236
+  0: The total amount of wall time                        = 140.361604
+  0: The maximum resident set size (KB)                   = 621176
 
 Test 022 control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_2dwrtdecomp
 Checking test 023 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1369,14 +1369,14 @@ Checking test 023 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.340559
-  0: The maximum resident set size (KB)                   = 626928
+  0: The total amount of wall time                        = 136.531821
+  0: The maximum resident set size (KB)                   = 626952
 
 Test 023 control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_2threads
 Checking test 024 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1419,14 +1419,14 @@ Checking test 024 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 159.593706
- 0: The maximum resident set size (KB)                   = 669440
+ 0: The total amount of wall time                        = 158.000920
+ 0: The maximum resident set size (KB)                   = 674076
 
 Test 024 control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_restart
 Checking test 025 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1465,14 +1465,14 @@ Checking test 025 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 72.886797
-  0: The maximum resident set size (KB)                   = 459172
+  0: The total amount of wall time                        = 69.679427
+  0: The maximum resident set size (KB)                   = 466448
 
 Test 025 control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_fhzero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_fhzero
 Checking test 026 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1515,14 +1515,14 @@ Checking test 026 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.398431
-  0: The maximum resident set size (KB)                   = 631676
+  0: The total amount of wall time                        = 125.674073
+  0: The maximum resident set size (KB)                   = 629928
 
 Test 026 control_fhzero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_CubedSphereGrid
 Checking test 027 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1549,28 +1549,28 @@ Checking test 027 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.819766
-  0: The maximum resident set size (KB)                   = 629804
+  0: The total amount of wall time                        = 130.039093
+  0: The maximum resident set size (KB)                   = 630268
 
 Test 027 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_CubedSphereGrid_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_CubedSphereGrid_parallel
 Checking test 028 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 126.445218
-  0: The maximum resident set size (KB)                   = 629948
+  0: The total amount of wall time                        = 126.547353
+  0: The maximum resident set size (KB)                   = 631160
 
 Test 028 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_latlon
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_latlon
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_latlon
 Checking test 029 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1581,14 +1581,14 @@ Checking test 029 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 132.572077
-  0: The maximum resident set size (KB)                   = 629096
+  0: The total amount of wall time                        = 132.444993
+  0: The maximum resident set size (KB)                   = 628120
 
 Test 029 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_wrtGauss_netcdf_parallel
 Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1599,14 +1599,14 @@ Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.297406
-  0: The maximum resident set size (KB)                   = 629080
+  0: The total amount of wall time                        = 137.933558
+  0: The maximum resident set size (KB)                   = 633468
 
 Test 030 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_c48
 Checking test 031 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1645,14 +1645,14 @@ Checking test 031 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 341.908059
-0: The maximum resident set size (KB)                   = 818732
+0: The total amount of wall time                        = 345.714471
+0: The maximum resident set size (KB)                   = 825072
 
 Test 031 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c192
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c192
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_c192
 Checking test 032 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1663,14 +1663,14 @@ Checking test 032 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 527.406606
-  0: The maximum resident set size (KB)                   = 758872
+  0: The total amount of wall time                        = 523.254767
+  0: The maximum resident set size (KB)                   = 772504
 
 Test 032 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_c384
 Checking test 033 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1681,14 +1681,14 @@ Checking test 033 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 718.128948
-  0: The maximum resident set size (KB)                   = 1082108
+  0: The total amount of wall time                        = 677.635469
+  0: The maximum resident set size (KB)                   = 1083748
 
 Test 033 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384gdas
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384gdas
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_c384gdas
 Checking test 034 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1731,14 +1731,14 @@ Checking test 034 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 578.808667
-  0: The maximum resident set size (KB)                   = 1239940
+  0: The total amount of wall time                        = 573.808275
+  0: The maximum resident set size (KB)                   = 1246272
 
 Test 034 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384_progsigma
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_c384_progsigma
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384_progsigma
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_c384_progsigma
 Checking test 035 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1749,14 +1749,14 @@ Checking test 035 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 684.270431
-  0: The maximum resident set size (KB)                   = 1078548
+  0: The total amount of wall time                        = 694.680509
+  0: The maximum resident set size (KB)                   = 1076484
 
 Test 035 control_c384_progsigma PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_stochy
 Checking test 036 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1767,28 +1767,28 @@ Checking test 036 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 87.910077
-  0: The maximum resident set size (KB)                   = 637124
+  0: The total amount of wall time                        = 87.641543
+  0: The maximum resident set size (KB)                   = 634160
 
 Test 036 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_stochy_restart
 Checking test 037 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.586073
-  0: The maximum resident set size (KB)                   = 483368
+  0: The total amount of wall time                        = 46.419384
+  0: The maximum resident set size (KB)                   = 480188
 
 Test 037 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_lndp
 Checking test 038 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 038 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 79.954195
-  0: The maximum resident set size (KB)                   = 630596
+  0: The total amount of wall time                        = 81.594774
+  0: The maximum resident set size (KB)                   = 629216
 
 Test 038 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr4
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr4
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_iovr4
 Checking test 039 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1821,14 +1821,14 @@ Checking test 039 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.898818
-  0: The maximum resident set size (KB)                   = 630348
+  0: The total amount of wall time                        = 133.322647
+  0: The maximum resident set size (KB)                   = 630252
 
 Test 039 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr5
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr5
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_iovr5
 Checking test 040 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1843,14 +1843,14 @@ Checking test 040 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.615291
-  0: The maximum resident set size (KB)                   = 628144
+  0: The total amount of wall time                        = 135.183959
+  0: The maximum resident set size (KB)                   = 628268
 
 Test 040 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_p8
 Checking test 041 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1897,14 +1897,14 @@ Checking test 041 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.809793
-  0: The maximum resident set size (KB)                   = 1601384
+  0: The total amount of wall time                        = 165.581775
+  0: The maximum resident set size (KB)                   = 1604776
 
 Test 041 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_lndp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_p8_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_lndp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_p8_lndp
 Checking test 042 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1923,14 +1923,14 @@ Checking test 042 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 310.222678
-  0: The maximum resident set size (KB)                   = 1603900
+  0: The total amount of wall time                        = 311.143736
+  0: The maximum resident set size (KB)                   = 1564004
 
 Test 042 control_p8_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_restart_p8
 Checking test 043 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1969,14 +1969,14 @@ Checking test 043 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.160623
-  0: The maximum resident set size (KB)                   = 867608
+  0: The total amount of wall time                        = 85.689783
+  0: The maximum resident set size (KB)                   = 858916
 
 Test 043 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_decomp_p8
 Checking test 044 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2019,14 +2019,14 @@ Checking test 044 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.740746
-  0: The maximum resident set size (KB)                   = 1589360
+  0: The total amount of wall time                        = 172.050967
+  0: The maximum resident set size (KB)                   = 1592056
 
 Test 044 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_2threads_p8
 Checking test 045 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2069,14 +2069,14 @@ Checking test 045 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 195.563262
- 0: The maximum resident set size (KB)                   = 1667980
+ 0: The total amount of wall time                        = 205.245268
+ 0: The maximum resident set size (KB)                   = 1669296
 
 Test 045 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_p8_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_rrtmgp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_p8_rrtmgp
 Checking test 046 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2123,14 +2123,14 @@ Checking test 046 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.647290
-  0: The maximum resident set size (KB)                   = 1727636
+  0: The total amount of wall time                        = 197.219985
+  0: The maximum resident set size (KB)                   = 1733208
 
 Test 046 control_p8_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/merra2_thompson
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/merra2_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/merra2_thompson
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2177,14 +2177,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.333686
-  0: The maximum resident set size (KB)                   = 1607320
+  0: The total amount of wall time                        = 168.290533
+  0: The maximum resident set size (KB)                   = 1609920
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2195,28 +2195,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 348.999941
- 0: The maximum resident set size (KB)                   = 844224
+ 0: The total amount of wall time                        = 348.842886
+ 0: The maximum resident set size (KB)                   = 844396
 
 Test 048 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 195.461456
- 0: The maximum resident set size (KB)                   = 831500
+ 0: The total amount of wall time                        = 191.828847
+ 0: The maximum resident set size (KB)                   = 832312
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_control_2dwrtdecomp
 Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2227,14 +2227,14 @@ Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 348.111230
- 0: The maximum resident set size (KB)                   = 841664
+ 0: The total amount of wall time                        = 348.899917
+ 0: The maximum resident set size (KB)                   = 840164
 
 Test 050 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_noquilt
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2242,14 +2242,14 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 373.428384
- 0: The maximum resident set size (KB)                   = 831476
+ 0: The total amount of wall time                        = 364.788181
+ 0: The maximum resident set size (KB)                   = 831676
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2260,28 +2260,28 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 249.536802
- 0: The maximum resident set size (KB)                   = 770716
+ 0: The total amount of wall time                        = 246.552300
+ 0: The maximum resident set size (KB)                   = 768852
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_netcdf_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_netcdf_parallel
 Checking test 053 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 349.021627
- 0: The maximum resident set size (KB)                   = 838228
+ 0: The total amount of wall time                        = 345.485677
+ 0: The maximum resident set size (KB)                   = 833548
 
 Test 053 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_3km
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_3km
 Checking test 054 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 054 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 254.217836
-  0: The maximum resident set size (KB)                   = 854600
+  0: The total amount of wall time                        = 251.846160
+  0: The maximum resident set size (KB)                   = 856476
 
 Test 054 regional_3km PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_3km_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_3km_decomp
 Checking test 055 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2310,14 +2310,14 @@ Checking test 055 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 271.118319
-  0: The maximum resident set size (KB)                   = 857404
+  0: The total amount of wall time                        = 271.643317
+  0: The maximum resident set size (KB)                   = 857268
 
 Test 055 regional_3km_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_control
 Checking test 056 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2364,14 +2364,14 @@ Checking test 056 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 444.017448
-  0: The maximum resident set size (KB)                   = 1060816
+  0: The total amount of wall time                        = 443.198215
+  0: The maximum resident set size (KB)                   = 1059684
 
 Test 056 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_rrtmgp
 Checking test 057 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2418,14 +2418,14 @@ Checking test 057 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 470.208281
-  0: The maximum resident set size (KB)                   = 1215172
+  0: The total amount of wall time                        = 469.520609
+  0: The maximum resident set size (KB)                   = 1211616
 
 Test 057 rap_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_spp_sppt_shum_skeb
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_spp_sppt_shum_skeb
 Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2436,14 +2436,14 @@ Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 294.867285
-  0: The maximum resident set size (KB)                   = 1175932
+  0: The total amount of wall time                        = 284.751573
+  0: The maximum resident set size (KB)                   = 1177516
 
 Test 058 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_decomp
 Checking test 059 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2490,14 +2490,14 @@ Checking test 059 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 465.529476
-  0: The maximum resident set size (KB)                   = 1003836
+  0: The total amount of wall time                        = 465.637147
+  0: The maximum resident set size (KB)                   = 1004092
 
 Test 059 rap_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_2threads
 Checking test 060 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2544,14 +2544,14 @@ Checking test 060 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 509.303260
- 0: The maximum resident set size (KB)                   = 1057768
+ 0: The total amount of wall time                        = 515.310665
+ 0: The maximum resident set size (KB)                   = 1066252
 
 Test 060 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_restart
 Checking test 061 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2590,14 +2590,14 @@ Checking test 061 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.399196
-  0: The maximum resident set size (KB)                   = 961152
+  0: The total amount of wall time                        = 224.866851
+  0: The maximum resident set size (KB)                   = 961804
 
 Test 061 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_sfcdiff
 Checking test 062 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2644,14 +2644,14 @@ Checking test 062 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 436.918287
-  0: The maximum resident set size (KB)                   = 1057824
+  0: The total amount of wall time                        = 436.776488
+  0: The maximum resident set size (KB)                   = 1061636
 
 Test 062 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_sfcdiff_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_sfcdiff_decomp
 Checking test 063 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2698,14 +2698,14 @@ Checking test 063 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.733825
-  0: The maximum resident set size (KB)                   = 958896
+  0: The total amount of wall time                        = 461.344381
+  0: The maximum resident set size (KB)                   = 1000160
 
 Test 063 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_sfcdiff_restart
 Checking test 064 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2744,14 +2744,14 @@ Checking test 064 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.823049
-  0: The maximum resident set size (KB)                   = 988752
+  0: The total amount of wall time                        = 330.639400
+  0: The maximum resident set size (KB)                   = 987140
 
 Test 064 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control
 Checking test 065 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2798,14 +2798,14 @@ Checking test 065 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 422.999814
-  0: The maximum resident set size (KB)                   = 1050248
+  0: The total amount of wall time                        = 419.984994
+  0: The maximum resident set size (KB)                   = 1052696
 
 Test 065 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_decomp
 Checking test 066 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2852,14 +2852,14 @@ Checking test 066 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 442.886326
-  0: The maximum resident set size (KB)                   = 999980
+  0: The total amount of wall time                        = 446.887636
+  0: The maximum resident set size (KB)                   = 1000256
 
 Test 066 hrrr_control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_2threads
 Checking test 067 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2906,14 +2906,14 @@ Checking test 067 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 478.265835
- 0: The maximum resident set size (KB)                   = 1010260
+ 0: The total amount of wall time                        = 479.035167
+ 0: The maximum resident set size (KB)                   = 1055216
 
 Test 067 hrrr_control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_restart
 Checking test 068 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 068 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 319.105705
-  0: The maximum resident set size (KB)                   = 923728
+  0: The total amount of wall time                        = 319.830280
+  0: The maximum resident set size (KB)                   = 976688
 
 Test 068 hrrr_control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_v1beta
 Checking test 069 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3006,14 +3006,14 @@ Checking test 069 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 435.583714
-  0: The maximum resident set size (KB)                   = 1055172
+  0: The total amount of wall time                        = 436.942607
+  0: The maximum resident set size (KB)                   = 1050152
 
 Test 069 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_v1nssl
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_v1nssl
 Checking test 070 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3028,14 +3028,14 @@ Checking test 070 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 512.778006
-  0: The maximum resident set size (KB)                   = 687260
+  0: The total amount of wall time                        = 515.628877
+  0: The maximum resident set size (KB)                   = 689412
 
 Test 070 rrfs_v1nssl PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_v1nssl_nohailnoccn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_v1nssl_nohailnoccn
 Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3050,14 +3050,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 502.451153
-  0: The maximum resident set size (KB)                   = 750168
+  0: The total amount of wall time                        = 500.378781
+  0: The maximum resident set size (KB)                   = 752836
 
 Test 071 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_conus13km_hrrr_warm
 Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3066,14 +3066,14 @@ Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 172.795385
-  0: The maximum resident set size (KB)                   = 890524
+  0: The total amount of wall time                        = 171.452263
+  0: The maximum resident set size (KB)                   = 934664
 
 Test 072 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_conus13km_radar_tten_warm
 Checking test 073 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3082,14 +3082,14 @@ Checking test 073 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 173.020708
-  0: The maximum resident set size (KB)                   = 935020
+  0: The total amount of wall time                        = 172.714072
+  0: The maximum resident set size (KB)                   = 934072
 
 Test 073 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_smoke_conus13km_hrrr_warm
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3098,14 +3098,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 191.070027
-  0: The maximum resident set size (KB)                   = 967588
+  0: The total amount of wall time                        = 190.855236
+  0: The maximum resident set size (KB)                   = 958712
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_csawmg
 Checking test 075 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3116,14 +3116,14 @@ Checking test 075 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 339.305456
-  0: The maximum resident set size (KB)                   = 731432
+  0: The total amount of wall time                        = 339.832828
+  0: The maximum resident set size (KB)                   = 727248
 
 Test 075 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_csawmgt
 Checking test 076 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3134,14 +3134,14 @@ Checking test 076 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 335.219036
-  0: The maximum resident set size (KB)                   = 731820
+  0: The total amount of wall time                        = 336.305824
+  0: The maximum resident set size (KB)                   = 735156
 
 Test 076 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_ras
 Checking test 077 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3152,54 +3152,54 @@ Checking test 077 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 178.650353
-  0: The maximum resident set size (KB)                   = 721748
+  0: The total amount of wall time                        = 178.971656
+  0: The maximum resident set size (KB)                   = 713000
 
 Test 077 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_wam
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_wam
 Checking test 078 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 108.195708
-  0: The maximum resident set size (KB)                   = 637624
+  0: The total amount of wall time                        = 108.255706
+  0: The maximum resident set size (KB)                   = 636400
 
 Test 078 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_debug
 Checking test 079 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.815267
-  0: The maximum resident set size (KB)                   = 796500
+  0: The total amount of wall time                        = 156.211847
+  0: The maximum resident set size (KB)                   = 790136
 
 Test 079 control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_2threads_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_2threads_debug
 Checking test 080 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 230.855824
- 0: The maximum resident set size (KB)                   = 830120
+ 0: The total amount of wall time                        = 233.819852
+ 0: The maximum resident set size (KB)                   = 830708
 
 Test 080 control_2threads_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_CubedSphereGrid_debug
 Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3226,348 +3226,348 @@ Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.310437
-  0: The maximum resident set size (KB)                   = 795308
+  0: The total amount of wall time                        = 179.152916
+  0: The maximum resident set size (KB)                   = 789836
 
 Test 081 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_wrtGauss_netcdf_parallel_debug
 Checking test 082 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.770058
-  0: The maximum resident set size (KB)                   = 793716
+  0: The total amount of wall time                        = 161.683725
+  0: The maximum resident set size (KB)                   = 792700
 
 Test 082 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_stochy_debug
 Checking test 083 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.980044
-  0: The maximum resident set size (KB)                   = 802564
+  0: The total amount of wall time                        = 179.151181
+  0: The maximum resident set size (KB)                   = 802812
 
 Test 083 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_lndp_debug
 Checking test 084 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.664020
-  0: The maximum resident set size (KB)                   = 799436
+  0: The total amount of wall time                        = 166.053795
+  0: The maximum resident set size (KB)                   = 794244
 
 Test 084 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_csawmg_debug
 Checking test 085 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 243.431072
-  0: The maximum resident set size (KB)                   = 848508
+  0: The total amount of wall time                        = 240.720812
+  0: The maximum resident set size (KB)                   = 850952
 
 Test 085 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_csawmgt_debug
 Checking test 086 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 243.780550
-  0: The maximum resident set size (KB)                   = 852120
+  0: The total amount of wall time                        = 240.694303
+  0: The maximum resident set size (KB)                   = 842352
 
 Test 086 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_ras_debug
 Checking test 087 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.765388
-  0: The maximum resident set size (KB)                   = 812244
+  0: The total amount of wall time                        = 165.532090
+  0: The maximum resident set size (KB)                   = 806616
 
 Test 087 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_diag_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_diag_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_diag_debug
 Checking test 088 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.809418
-  0: The maximum resident set size (KB)                   = 850992
+  0: The total amount of wall time                        = 169.212084
+  0: The maximum resident set size (KB)                   = 847668
 
 Test 088 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_debug_p8
 Checking test 089 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.773621
-  0: The maximum resident set size (KB)                   = 1617972
+  0: The total amount of wall time                        = 177.329565
+  0: The maximum resident set size (KB)                   = 1626532
 
 Test 089 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 267.721808
- 0: The maximum resident set size (KB)                   = 855536
+ 0: The total amount of wall time                        = 258.025235
+ 0: The maximum resident set size (KB)                   = 859732
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.248757
-  0: The maximum resident set size (KB)                   = 1175724
+  0: The total amount of wall time                        = 276.819904
+  0: The maximum resident set size (KB)                   = 1175180
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_debug
 Checking test 092 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.433312
-  0: The maximum resident set size (KB)                   = 1176724
+  0: The total amount of wall time                        = 278.378738
+  0: The maximum resident set size (KB)                   = 1172568
 
 Test 092 hrrr_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_unified_drag_suite_debug
 Checking test 093 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.487136
-  0: The maximum resident set size (KB)                   = 1176204
+  0: The total amount of wall time                        = 284.665754
+  0: The maximum resident set size (KB)                   = 1174740
 
 Test 093 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_diag_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_diag_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_diag_debug
 Checking test 094 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 304.602156
-  0: The maximum resident set size (KB)                   = 1261800
+  0: The total amount of wall time                        = 300.616147
+  0: The maximum resident set size (KB)                   = 1258348
 
 Test 094 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_cires_ugwp_debug
 Checking test 095 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 314.861127
-  0: The maximum resident set size (KB)                   = 1170452
+  0: The total amount of wall time                        = 289.378290
+  0: The maximum resident set size (KB)                   = 1174128
 
 Test 095 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_unified_ugwp_debug
 Checking test 096 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.729402
-  0: The maximum resident set size (KB)                   = 1175956
+  0: The total amount of wall time                        = 292.415448
+  0: The maximum resident set size (KB)                   = 1176512
 
 Test 096 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_lndp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_lndp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_lndp_debug
 Checking test 097 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.507881
-  0: The maximum resident set size (KB)                   = 1171688
+  0: The total amount of wall time                        = 287.791682
+  0: The maximum resident set size (KB)                   = 1172044
 
 Test 097 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_flake_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_flake_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_flake_debug
 Checking test 098 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.503193
-  0: The maximum resident set size (KB)                   = 1176420
+  0: The total amount of wall time                        = 282.107536
+  0: The maximum resident set size (KB)                   = 1176936
 
 Test 098 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_progcld_thompson_debug
 Checking test 099 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.950366
-  0: The maximum resident set size (KB)                   = 1179300
+  0: The total amount of wall time                        = 287.171731
+  0: The maximum resident set size (KB)                   = 1172028
 
 Test 099 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_noah_debug
 Checking test 100 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.630188
-  0: The maximum resident set size (KB)                   = 1176004
+  0: The total amount of wall time                        = 285.950627
+  0: The maximum resident set size (KB)                   = 1173000
 
 Test 100 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_rrtmgp_debug
 Checking test 101 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 477.128555
-  0: The maximum resident set size (KB)                   = 1310048
+  0: The total amount of wall time                        = 475.985922
+  0: The maximum resident set size (KB)                   = 1304732
 
 Test 101 rap_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_sfcdiff_debug
 Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.872111
-  0: The maximum resident set size (KB)                   = 1173600
+  0: The total amount of wall time                        = 287.435297
+  0: The maximum resident set size (KB)                   = 1176708
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 471.488090
-  0: The maximum resident set size (KB)                   = 1176380
+  0: The total amount of wall time                        = 467.029491
+  0: The maximum resident set size (KB)                   = 1178520
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rrfs_v1beta_debug
 Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.804543
-  0: The maximum resident set size (KB)                   = 1170656
+  0: The total amount of wall time                        = 338.039389
+  0: The maximum resident set size (KB)                   = 1173104
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 291.666662
-  0: The maximum resident set size (KB)                   = 519344
+  0: The total amount of wall time                        = 289.219405
+  0: The maximum resident set size (KB)                   = 517464
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3578,14 +3578,14 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 262.639085
-  0: The maximum resident set size (KB)                   = 1031604
+  0: The total amount of wall time                        = 261.468335
+  0: The maximum resident set size (KB)                   = 1075028
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_control_dyn32_phy32
 Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3632,14 +3632,14 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 355.284015
-  0: The maximum resident set size (KB)                   = 1000896
+  0: The total amount of wall time                        = 356.830672
+  0: The maximum resident set size (KB)                   = 996512
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_dyn32_phy32
 Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3686,14 +3686,14 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 185.322901
-  0: The maximum resident set size (KB)                   = 953184
+  0: The total amount of wall time                        = 185.268055
+  0: The maximum resident set size (KB)                   = 955668
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_2threads_dyn32_phy32
 Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3740,14 +3740,14 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 414.898290
- 0: The maximum resident set size (KB)                   = 926780
+ 0: The total amount of wall time                        = 418.717075
+ 0: The maximum resident set size (KB)                   = 930244
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_2threads_dyn32_phy32
 Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3794,14 +3794,14 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 215.991667
- 0: The maximum resident set size (KB)                   = 923164
+ 0: The total amount of wall time                        = 216.996106
+ 0: The maximum resident set size (KB)                   = 921548
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_decomp_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_decomp_dyn32_phy32
 Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3848,14 +3848,14 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.911371
-  0: The maximum resident set size (KB)                   = 898568
+  0: The total amount of wall time                        = 199.181546
+  0: The maximum resident set size (KB)                   = 902792
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_restart_dyn32_phy32
 Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3894,14 +3894,14 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 283.006641
-  0: The maximum resident set size (KB)                   = 950080
+  0: The total amount of wall time                        = 269.788953
+  0: The maximum resident set size (KB)                   = 952708
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_restart_dyn32_phy32
 Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3940,14 +3940,14 @@ Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 96.017033
-  0: The maximum resident set size (KB)                   = 864712
+  0: The total amount of wall time                        = 96.089601
+  0: The maximum resident set size (KB)                   = 858312
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn64_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_control_dyn64_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn64_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_control_dyn64_phy32
 Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3994,81 +3994,81 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 230.280997
-  0: The maximum resident set size (KB)                   = 971920
+  0: The total amount of wall time                        = 231.609327
+  0: The maximum resident set size (KB)                   = 964620
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_control_debug_dyn32_phy32
 Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.879796
-  0: The maximum resident set size (KB)                   = 1064728
+  0: The total amount of wall time                        = 274.655863
+  0: The maximum resident set size (KB)                   = 1056500
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hrrr_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hrrr_control_debug_dyn32_phy32
 Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.556820
-  0: The maximum resident set size (KB)                   = 1059968
+  0: The total amount of wall time                        = 274.846081
+  0: The maximum resident set size (KB)                   = 1063864
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/rap_control_dyn64_phy32_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/rap_control_dyn64_phy32_debug
 Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.116880
-  0: The maximum resident set size (KB)                   = 1095484
+  0: The total amount of wall time                        = 277.206734
+  0: The maximum resident set size (KB)                   = 1103416
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_atm
 Checking test 118 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 300.522681
-  0: The maximum resident set size (KB)                   = 938836
+  0: The total amount of wall time                        = 299.737040
+  0: The maximum resident set size (KB)                   = 974740
 
 Test 118 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_atm_thompson_gfdlsf
 Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 404.423291
-  0: The maximum resident set size (KB)                   = 1358268
+  0: The total amount of wall time                        = 405.383871
+  0: The maximum resident set size (KB)                   = 1351704
 
 Test 119 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_atm_ocn
 Checking test 120 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4077,14 +4077,14 @@ Checking test 120 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 400.052184
-  0: The maximum resident set size (KB)                   = 1205020
+  0: The total amount of wall time                        = 388.584773
+  0: The maximum resident set size (KB)                   = 1202324
 
 Test 120 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_atm_wav
 Checking test 121 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4093,14 +4093,14 @@ Checking test 121 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 713.350773
-  0: The maximum resident set size (KB)                   = 1223616
+  0: The total amount of wall time                        = 714.173366
+  0: The maximum resident set size (KB)                   = 1230756
 
 Test 121 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_atm_ocn_wav
 Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4111,28 +4111,28 @@ Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 811.425423
-  0: The maximum resident set size (KB)                   = 1243216
+  0: The total amount of wall time                        = 809.910123
+  0: The maximum resident set size (KB)                   = 1244160
 
 Test 122 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_1nest_atm
 Checking test 123 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 453.921971
-  0: The maximum resident set size (KB)                   = 542304
+  0: The total amount of wall time                        = 454.551987
+  0: The maximum resident set size (KB)                   = 525480
 
 Test 123 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_telescopic_2nests_atm
 Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4141,28 +4141,28 @@ Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 501.346468
-  0: The maximum resident set size (KB)                   = 538012
+  0: The total amount of wall time                        = 509.026899
+  0: The maximum resident set size (KB)                   = 537608
 
 Test 124 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_global_1nest_atm
 Checking test 125 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 206.284101
-  0: The maximum resident set size (KB)                   = 379784
+  0: The total amount of wall time                        = 211.293984
+  0: The maximum resident set size (KB)                   = 377204
 
 Test 125 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_global_multiple_4nests_atm
 Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4180,14 +4180,14 @@ Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 571.380020
-  0: The maximum resident set size (KB)                   = 390772
+  0: The total amount of wall time                        = 587.566956
+  0: The maximum resident set size (KB)                   = 390680
 
 Test 126 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_specified_moving_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_specified_moving_1nest_atm
 Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4196,28 +4196,28 @@ Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 271.895938
-  0: The maximum resident set size (KB)                   = 532368
+  0: The total amount of wall time                        = 275.797713
+  0: The maximum resident set size (KB)                   = 532356
 
 Test 127 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_storm_following_1nest_atm
 Checking test 128 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 258.177690
-  0: The maximum resident set size (KB)                   = 532420
+  0: The total amount of wall time                        = 262.234170
+  0: The maximum resident set size (KB)                   = 533492
 
 Test 128 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4226,14 +4226,14 @@ Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 266.737219
-  0: The maximum resident set size (KB)                   = 531364
+  0: The total amount of wall time                        = 269.020926
+  0: The maximum resident set size (KB)                   = 579032
 
 Test 129 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4244,28 +4244,28 @@ Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 617.350899
-  0: The maximum resident set size (KB)                   = 563736
+  0: The total amount of wall time                        = 614.892279
+  0: The maximum resident set size (KB)                   = 564700
 
 Test 130 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_global_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_global_storm_following_1nest_atm
 Checking test 131 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 79.774848
-  0: The maximum resident set size (KB)                   = 401560
+  0: The total amount of wall time                        = 80.040715
+  0: The maximum resident set size (KB)                   = 397440
 
 Test 131 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_docn
 Checking test 132 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4273,14 +4273,14 @@ Checking test 132 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 381.708643
-  0: The maximum resident set size (KB)                   = 1225460
+  0: The total amount of wall time                        = 385.269059
+  0: The maximum resident set size (KB)                   = 1215752
 
 Test 132 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_docn_oisst
 Checking test 133 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4288,131 +4288,131 @@ Checking test 133 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 382.078515
-  0: The maximum resident set size (KB)                   = 1202316
+  0: The total amount of wall time                        = 405.846423
+  0: The maximum resident set size (KB)                   = 1203532
 
 Test 133 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/hafs_regional_datm_cdeps
 Checking test 134 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 925.551692
-  0: The maximum resident set size (KB)                   = 1042336
+  0: The total amount of wall time                        = 921.083274
+  0: The maximum resident set size (KB)                   = 1041844
 
 Test 134 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_control_cfsr
 Checking test 135 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.272517
- 0: The maximum resident set size (KB)                   = 1048532
+ 0: The total amount of wall time                        = 144.980476
+ 0: The maximum resident set size (KB)                   = 1086400
 
 Test 135 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_restart_cfsr
 Checking test 136 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 88.813954
- 0: The maximum resident set size (KB)                   = 1029788
+ 0: The total amount of wall time                        = 89.126331
+ 0: The maximum resident set size (KB)                   = 1003520
 
 Test 136 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_control_gefs
 Checking test 137 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.575903
- 0: The maximum resident set size (KB)                   = 970704
+ 0: The total amount of wall time                        = 140.456614
+ 0: The maximum resident set size (KB)                   = 964204
 
 Test 137 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_iau_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_iau_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_iau_gefs
 Checking test 138 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.574605
- 0: The maximum resident set size (KB)                   = 959624
+ 0: The total amount of wall time                        = 145.538438
+ 0: The maximum resident set size (KB)                   = 970452
 
 Test 138 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_stochy_gefs
 Checking test 139 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.813087
- 0: The maximum resident set size (KB)                   = 964388
+ 0: The total amount of wall time                        = 144.308852
+ 0: The maximum resident set size (KB)                   = 968648
 
 Test 139 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_ciceC_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_ciceC_cfsr
 Checking test 140 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.267504
- 0: The maximum resident set size (KB)                   = 1081824
+ 0: The total amount of wall time                        = 147.064931
+ 0: The maximum resident set size (KB)                   = 1060196
 
 Test 140 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_bulk_cfsr
 Checking test 141 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.738637
- 0: The maximum resident set size (KB)                   = 1055108
+ 0: The total amount of wall time                        = 145.684552
+ 0: The maximum resident set size (KB)                   = 1058608
 
 Test 141 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_bulk_gefs
 Checking test 142 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.498093
- 0: The maximum resident set size (KB)                   = 968184
+ 0: The total amount of wall time                        = 143.011602
+ 0: The maximum resident set size (KB)                   = 974808
 
 Test 142 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_mx025_cfsr
 Checking test 143 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4421,14 +4421,14 @@ Checking test 143 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 431.822247
-  0: The maximum resident set size (KB)                   = 877564
+  0: The total amount of wall time                        = 446.294213
+  0: The maximum resident set size (KB)                   = 885660
 
 Test 143 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_mx025_gefs
 Checking test 144 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4437,64 +4437,64 @@ Checking test 144 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 433.734776
-  0: The maximum resident set size (KB)                   = 903792
+  0: The total amount of wall time                        = 432.402925
+  0: The maximum resident set size (KB)                   = 933740
 
 Test 144 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_multiple_files_cfsr
 Checking test 145 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.139863
- 0: The maximum resident set size (KB)                   = 1059580
+ 0: The total amount of wall time                        = 144.542834
+ 0: The maximum resident set size (KB)                   = 1064168
 
 Test 145 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_3072x1536_cfsr
 Checking test 146 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 196.289514
- 0: The maximum resident set size (KB)                   = 2369588
+ 0: The total amount of wall time                        = 195.991782
+ 0: The maximum resident set size (KB)                   = 2366692
 
 Test 146 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_gfs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_gfs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_gfs
 Checking test 147 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 194.348919
- 0: The maximum resident set size (KB)                   = 2362912
+ 0: The total amount of wall time                        = 196.313770
+ 0: The maximum resident set size (KB)                   = 2342352
 
 Test 147 datm_cdeps_gfs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/datm_cdeps_debug_cfsr
 Checking test 148 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 452.024791
- 0: The maximum resident set size (KB)                   = 985172
+ 0: The total amount of wall time                        = 443.631523
+ 0: The maximum resident set size (KB)                   = 1001548
 
 Test 148 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/control_atmwav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/control_atmwav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/control_atmwav
 Checking test 149 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4538,14 +4538,14 @@ Checking test 149 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 86.124863
-  0: The maximum resident set size (KB)                   = 660688
+  0: The total amount of wall time                        = 85.341295
+  0: The maximum resident set size (KB)                   = 658092
 
 Test 149 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/atmaero_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/atmaero_control_p8
 Checking test 150 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4589,14 +4589,14 @@ Checking test 150 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 222.707762
-  0: The maximum resident set size (KB)                   = 2972612
+  0: The total amount of wall time                        = 223.570463
+  0: The maximum resident set size (KB)                   = 2981620
 
 Test 150 atmaero_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/atmaero_control_p8_rad
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/atmaero_control_p8_rad
 Checking test 151 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4640,14 +4640,14 @@ Checking test 151 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.230955
-  0: The maximum resident set size (KB)                   = 3046112
+  0: The total amount of wall time                        = 276.908312
+  0: The maximum resident set size (KB)                   = 3044864
 
 Test 151 atmaero_control_p8_rad PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/atmaero_control_p8_rad_micro
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/atmaero_control_p8_rad_micro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/atmaero_control_p8_rad_micro
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/atmaero_control_p8_rad_micro
 Checking test 152 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4691,14 +4691,14 @@ Checking test 152 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 285.242052
-  0: The maximum resident set size (KB)                   = 3060652
+  0: The total amount of wall time                        = 281.290776
+  0: The maximum resident set size (KB)                   = 3054996
 
 Test 152 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_atmaq
-working dir  = /work/noaa/epic-ps/jongkim/rt-1445/stmp/jongkim/FV3_RT/rt_299093/regional_atmaq
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_atmaq
+working dir  = /work/noaa/epic-ps/jongkim/rt-1451/stmp/jongkim/FV3_RT/rt_4366/regional_atmaq
 Checking test 153 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4714,12 +4714,12 @@ Checking test 153 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 627.342340
-  0: The maximum resident set size (KB)                   = 1082340
+  0: The total amount of wall time                        = 629.263031
+  0: The maximum resident set size (KB)                   = 1085716
 
 Test 153 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct  5 13:39:36 CDT 2022
-Elapsed time: 01h:20m:15s. Have a nice day!
+Sun Oct  9 10:01:48 CDT 2022
+Elapsed time: 01h:15m:25s. Have a nice day!

--- a/tests/RegressionTests_wcoss2.intel.log
+++ b/tests/RegressionTests_wcoss2.intel.log
@@ -1,24 +1,24 @@
-Wed Oct  5 19:08:52 UTC 2022
+Fri Oct  7 20:10:19 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 522 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 863 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 543 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 439 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 763 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 452 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 1088 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 470 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 614 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 307 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 400 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 303 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 744 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 634 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 549 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 356 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 891 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 961 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 619 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 431 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 429 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 629 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 446 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 590 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 473 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 433 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 583 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 435 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/cpld_control_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/cpld_control_noaero_p8
 Checking test 001 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 269.480664
-The maximum resident set size (KB)                   = 1576032
+The total amount of wall time                        = 283.785487
+The maximum resident set size (KB)                   = 1578236
 
 Test 001 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/cpld_control_nowave_noaero_p8
 Checking test 002 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -151,14 +151,14 @@ Checking test 002 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 314.430159
-The maximum resident set size (KB)                   = 1629804
+The total amount of wall time                        = 319.030784
+The maximum resident set size (KB)                   = 1628320
 
 Test 002 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/cpld_control_noaero_p8_agrid
 Checking test 003 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -220,14 +220,14 @@ Checking test 003 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 319.897172
-The maximum resident set size (KB)                   = 1625080
+The total amount of wall time                        = 315.433251
+The maximum resident set size (KB)                   = 1628344
 
 Test 003 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control
 Checking test 004 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -274,14 +274,14 @@ Checking test 004 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 143.553435
-The maximum resident set size (KB)                   = 518608
+The total amount of wall time                        = 161.410065
+The maximum resident set size (KB)                   = 514968
 
 Test 004 control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_decomp
 Checking test 005 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -324,14 +324,14 @@ Checking test 005 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 145.009144
-The maximum resident set size (KB)                   = 515068
+The total amount of wall time                        = 159.798364
+The maximum resident set size (KB)                   = 517168
 
 Test 005 control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_2dwrtdecomp
 Checking test 006 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -342,14 +342,14 @@ Checking test 006 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.750523
-The maximum resident set size (KB)                   = 517664
+The total amount of wall time                        = 150.525508
+The maximum resident set size (KB)                   = 515732
 
 Test 006 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_2threads
 Checking test 007 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -392,14 +392,14 @@ Checking test 007 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 404.292228
-The maximum resident set size (KB)                   = 560992
+The total amount of wall time                        = 407.820600
+The maximum resident set size (KB)                   = 565704
 
 Test 007 control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_restart
 Checking test 008 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -438,14 +438,14 @@ Checking test 008 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 72.795533
-The maximum resident set size (KB)                   = 273356
+The total amount of wall time                        = 72.084946
+The maximum resident set size (KB)                   = 258476
 
 Test 008 control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_fhzero
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_fhzero
 Checking test 009 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -488,14 +488,14 @@ Checking test 009 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 137.730355
-The maximum resident set size (KB)                   = 517416
+The total amount of wall time                        = 129.532278
+The maximum resident set size (KB)                   = 518060
 
 Test 009 control_fhzero PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_CubedSphereGrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_CubedSphereGrid
 Checking test 010 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -522,14 +522,14 @@ Checking test 010 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 132.591627
-The maximum resident set size (KB)                   = 513676
+The total amount of wall time                        = 137.439296
+The maximum resident set size (KB)                   = 512728
 
 Test 010 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_latlon
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_latlon
 Checking test 011 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -540,14 +540,14 @@ Checking test 011 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.777042
-The maximum resident set size (KB)                   = 514740
+The total amount of wall time                        = 142.016920
+The maximum resident set size (KB)                   = 513880
 
 Test 011 control_latlon PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_wrtGauss_netcdf_parallel
 Checking test 012 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -558,14 +558,14 @@ Checking test 012 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.971504
-The maximum resident set size (KB)                   = 515360
+The total amount of wall time                        = 145.578481
+The maximum resident set size (KB)                   = 513584
 
 Test 012 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_c48
 Checking test 013 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -604,14 +604,14 @@ Checking test 013 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 326.626823
-The maximum resident set size (KB)                   = 666596
+The total amount of wall time                        = 326.762628
+The maximum resident set size (KB)                   = 668804
 
 Test 013 control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_c192
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_c192
 Checking test 014 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -622,14 +622,14 @@ Checking test 014 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 544.907371
-The maximum resident set size (KB)                   = 614516
+The total amount of wall time                        = 544.914893
+The maximum resident set size (KB)                   = 610892
 
 Test 014 control_c192 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_c384
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_c384
 Checking test 015 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -640,14 +640,14 @@ Checking test 015 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1649.949685
-The maximum resident set size (KB)                   = 883716
+The total amount of wall time                        = 1661.642833
+The maximum resident set size (KB)                   = 887220
 
 Test 015 control_c384 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_c384gdas
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_c384gdas
 Checking test 016 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -690,14 +690,14 @@ Checking test 016 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1465.520863
-The maximum resident set size (KB)                   = 1017780
+The total amount of wall time                        = 1455.603073
+The maximum resident set size (KB)                   = 1017336
 
 Test 016 control_c384gdas PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_c384_progsigma
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_c384_progsigma
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_c384_progsigma
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_c384_progsigma
 Checking test 017 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -708,14 +708,14 @@ Checking test 017 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1685.709711
-The maximum resident set size (KB)                   = 900040
+The total amount of wall time                        = 1691.686681
+The maximum resident set size (KB)                   = 910116
 
 Test 017 control_c384_progsigma PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_stochy
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_stochy
 Checking test 018 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -726,28 +726,28 @@ Checking test 018 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 92.412629
-The maximum resident set size (KB)                   = 521592
+The total amount of wall time                        = 96.346468
+The maximum resident set size (KB)                   = 519788
 
 Test 018 control_stochy PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_stochy_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_stochy_restart
 Checking test 019 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 49.683081
-The maximum resident set size (KB)                   = 289816
+The total amount of wall time                        = 46.521005
+The maximum resident set size (KB)                   = 289304
 
 Test 019 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_lndp
 Checking test 020 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -758,14 +758,14 @@ Checking test 020 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 88.975395
-The maximum resident set size (KB)                   = 519536
+The total amount of wall time                        = 83.310813
+The maximum resident set size (KB)                   = 521200
 
 Test 020 control_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_iovr4
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_iovr4
 Checking test 021 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -780,14 +780,14 @@ Checking test 021 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 142.780974
-The maximum resident set size (KB)                   = 518792
+The total amount of wall time                        = 146.153812
+The maximum resident set size (KB)                   = 519304
 
 Test 021 control_iovr4 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_iovr5
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_iovr5
 Checking test 022 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -802,14 +802,14 @@ Checking test 022 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 143.824538
-The maximum resident set size (KB)                   = 516856
+The total amount of wall time                        = 145.443697
+The maximum resident set size (KB)                   = 517224
 
 Test 022 control_iovr5 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_p8
 Checking test 023 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -856,14 +856,14 @@ Checking test 023 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 183.818208
-The maximum resident set size (KB)                   = 1487904
+The total amount of wall time                        = 181.561484
+The maximum resident set size (KB)                   = 1484472
 
 Test 023 control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_p8_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_p8_lndp
 Checking test 024 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -882,14 +882,14 @@ Checking test 024 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 329.898935
-The maximum resident set size (KB)                   = 1484396
+The total amount of wall time                        = 321.150997
+The maximum resident set size (KB)                   = 1481136
 
 Test 024 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_restart_p8
 Checking test 025 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -928,14 +928,14 @@ Checking test 025 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 102.829073
-The maximum resident set size (KB)                   = 649460
+The total amount of wall time                        = 99.865289
+The maximum resident set size (KB)                   = 646436
 
 Test 025 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_decomp_p8
 Checking test 026 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -978,14 +978,14 @@ Checking test 026 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 184.276151
-The maximum resident set size (KB)                   = 1474404
+The total amount of wall time                        = 184.354205
+The maximum resident set size (KB)                   = 1473368
 
 Test 026 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_2threads_p8
 Checking test 027 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1028,14 +1028,14 @@ Checking test 027 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 492.826044
-The maximum resident set size (KB)                   = 1567248
+The total amount of wall time                        = 489.105201
+The maximum resident set size (KB)                   = 1561660
 
 Test 027 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_p8_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_p8_rrtmgp
 Checking test 028 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1082,14 +1082,14 @@ Checking test 028 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 265.193781
-The maximum resident set size (KB)                   = 1596984
+The total amount of wall time                        = 260.933525
+The maximum resident set size (KB)                   = 1596680
 
 Test 028 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/merra2_thompson
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/merra2_thompson
 Checking test 029 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1136,14 +1136,14 @@ Checking test 029 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 194.567844
-The maximum resident set size (KB)                   = 1491604
+The total amount of wall time                        = 184.504923
+The maximum resident set size (KB)                   = 1490244
 
 Test 029 merra2_thompson PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_control
 Checking test 030 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1154,28 +1154,28 @@ Checking test 030 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 326.536761
-The maximum resident set size (KB)                   = 598656
+The total amount of wall time                        = 311.974157
+The maximum resident set size (KB)                   = 601520
 
 Test 030 regional_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_restart
 Checking test 031 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 178.729497
-The maximum resident set size (KB)                   = 596268
+The total amount of wall time                        = 173.598547
+The maximum resident set size (KB)                   = 598176
 
 Test 031 regional_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_control_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_control_2dwrtdecomp
 Checking test 032 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1186,14 +1186,14 @@ Checking test 032 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 314.451665
-The maximum resident set size (KB)                   = 600036
+The total amount of wall time                        = 315.587125
+The maximum resident set size (KB)                   = 596688
 
 Test 032 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_noquilt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_noquilt
 Checking test 033 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1201,14 +1201,14 @@ Checking test 033 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 335.947895
-The maximum resident set size (KB)                   = 597616
+The total amount of wall time                        = 330.792582
+The maximum resident set size (KB)                   = 596768
 
 Test 033 regional_noquilt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_2threads
 Checking test 034 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1219,28 +1219,28 @@ Checking test 034 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 624.060418
-The maximum resident set size (KB)                   = 648212
+The total amount of wall time                        = 624.264915
+The maximum resident set size (KB)                   = 651396
 
 Test 034 regional_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_netcdf_parallel
 Checking test 035 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 328.234900
-The maximum resident set size (KB)                   = 597364
+The total amount of wall time                        = 313.139994
+The maximum resident set size (KB)                   = 594912
 
 Test 035 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_3km
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_3km
 Checking test 036 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1251,14 +1251,14 @@ Checking test 036 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 273.991530
-The maximum resident set size (KB)                   = 643000
+The total amount of wall time                        = 260.570686
+The maximum resident set size (KB)                   = 645480
 
 Test 036 regional_3km PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_3km_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_3km_decomp
 Checking test 037 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1269,14 +1269,14 @@ Checking test 037 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 284.442789
-The maximum resident set size (KB)                   = 651296
+The total amount of wall time                        = 275.804263
+The maximum resident set size (KB)                   = 658580
 
 Test 037 regional_3km_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_control
 Checking test 038 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1323,14 +1323,14 @@ Checking test 038 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 410.528104
-The maximum resident set size (KB)                   = 891368
+The total amount of wall time                        = 419.266866
+The maximum resident set size (KB)                   = 894604
 
 Test 038 rap_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_rrtmgp
 Checking test 039 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1377,14 +1377,14 @@ Checking test 039 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 492.862983
-The maximum resident set size (KB)                   = 1011368
+The total amount of wall time                        = 507.740916
+The maximum resident set size (KB)                   = 1009840
 
 Test 039 rap_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_spp_sppt_shum_skeb
 Checking test 040 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1395,14 +1395,14 @@ Checking test 040 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 724.226519
-The maximum resident set size (KB)                   = 965564
+The total amount of wall time                        = 751.765971
+The maximum resident set size (KB)                   = 969412
 
 Test 040 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_decomp
 Checking test 041 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1449,14 +1449,14 @@ Checking test 041 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 430.376784
-The maximum resident set size (KB)                   = 892892
+The total amount of wall time                        = 451.587463
+The maximum resident set size (KB)                   = 892308
 
 Test 041 rap_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_2threads
 Checking test 042 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1503,14 +1503,14 @@ Checking test 042 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1298.740886
-The maximum resident set size (KB)                   = 951924
+The total amount of wall time                        = 1269.836452
+The maximum resident set size (KB)                   = 951920
 
 Test 042 rap_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_restart
 Checking test 043 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1549,14 +1549,14 @@ Checking test 043 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 219.720122
-The maximum resident set size (KB)                   = 640740
+The total amount of wall time                        = 205.499574
+The maximum resident set size (KB)                   = 638644
 
 Test 043 rap_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_sfcdiff
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_sfcdiff
 Checking test 044 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1603,14 +1603,14 @@ Checking test 044 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 412.920158
-The maximum resident set size (KB)                   = 893620
+The total amount of wall time                        = 428.000093
+The maximum resident set size (KB)                   = 891448
 
 Test 044 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_sfcdiff_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_sfcdiff_decomp
 Checking test 045 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1657,14 +1657,14 @@ Checking test 045 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 432.030078
-The maximum resident set size (KB)                   = 893184
+The total amount of wall time                        = 445.276536
+The maximum resident set size (KB)                   = 892860
 
 Test 045 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_sfcdiff_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_sfcdiff_restart
 Checking test 046 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1703,14 +1703,14 @@ Checking test 046 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 304.071588
-The maximum resident set size (KB)                   = 638516
+The total amount of wall time                        = 301.785670
+The maximum resident set size (KB)                   = 640120
 
 Test 046 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control
 Checking test 047 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1757,14 +1757,14 @@ Checking test 047 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 391.296951
-The maximum resident set size (KB)                   = 890712
+The total amount of wall time                        = 413.948803
+The maximum resident set size (KB)                   = 885984
 
 Test 047 hrrr_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_decomp
 Checking test 048 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1811,14 +1811,14 @@ Checking test 048 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 407.776564
-The maximum resident set size (KB)                   = 888336
+The total amount of wall time                        = 417.424537
+The maximum resident set size (KB)                   = 889352
 
 Test 048 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_2threads
 Checking test 049 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1865,14 +1865,14 @@ Checking test 049 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1225.090508
-The maximum resident set size (KB)                   = 954404
+The total amount of wall time                        = 1235.404016
+The maximum resident set size (KB)                   = 946388
 
 Test 049 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_restart
 Checking test 050 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1911,14 +1911,14 @@ Checking test 050 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 291.258620
-The maximum resident set size (KB)                   = 632840
+The total amount of wall time                        = 286.429081
+The maximum resident set size (KB)                   = 633988
 
 Test 050 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_v1beta
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_v1beta
 Checking test 051 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1965,14 +1965,14 @@ Checking test 051 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 408.093350
-The maximum resident set size (KB)                   = 886780
+The total amount of wall time                        = 427.957362
+The maximum resident set size (KB)                   = 886464
 
 Test 051 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_v1nssl
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_v1nssl
 Checking test 052 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1987,14 +1987,14 @@ Checking test 052 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 465.834136
-The maximum resident set size (KB)                   = 574956
+The total amount of wall time                        = 490.984084
+The maximum resident set size (KB)                   = 577552
 
 Test 052 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_v1nssl_nohailnoccn
 Checking test 053 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2009,14 +2009,14 @@ Checking test 053 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 454.753312
-The maximum resident set size (KB)                   = 567628
+The total amount of wall time                        = 480.038994
+The maximum resident set size (KB)                   = 566656
 
 Test 053 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2025,14 +2025,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 173.714699
-The maximum resident set size (KB)                   = 770216
+The total amount of wall time                        = 174.580446
+The maximum resident set size (KB)                   = 765520
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2041,14 +2041,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 173.889788
-The maximum resident set size (KB)                   = 770700
+The total amount of wall time                        = 177.608512
+The maximum resident set size (KB)                   = 766880
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_smoke_conus13km_hrrr_warm
 Checking test 056 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2057,14 +2057,14 @@ Checking test 056 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 190.286435
-The maximum resident set size (KB)                   = 783460
+The total amount of wall time                        = 191.875450
+The maximum resident set size (KB)                   = 781828
 
 Test 056 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_csawmg
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_csawmg
 Checking test 057 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2075,14 +2075,14 @@ Checking test 057 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 350.272869
-The maximum resident set size (KB)                   = 588176
+The total amount of wall time                        = 355.602420
+The maximum resident set size (KB)                   = 586968
 
 Test 057 control_csawmg PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_csawmgt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_csawmgt
 Checking test 058 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2093,14 +2093,14 @@ Checking test 058 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 345.739357
-The maximum resident set size (KB)                   = 588408
+The total amount of wall time                        = 356.094537
+The maximum resident set size (KB)                   = 583720
 
 Test 058 control_csawmgt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_ras
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_ras
 Checking test 059 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2111,54 +2111,54 @@ Checking test 059 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 183.044861
-The maximum resident set size (KB)                   = 553612
+The total amount of wall time                        = 183.099573
+The maximum resident set size (KB)                   = 552052
 
 Test 059 control_ras PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_wam
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_wam
 Checking test 060 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 114.854556
-The maximum resident set size (KB)                   = 334384
+The total amount of wall time                        = 113.682047
+The maximum resident set size (KB)                   = 264384
 
 Test 060 control_wam PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_debug
 Checking test 061 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 154.740837
-The maximum resident set size (KB)                   = 677276
+The total amount of wall time                        = 158.116316
+The maximum resident set size (KB)                   = 676016
 
 Test 061 control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_2threads_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_2threads_debug
 Checking test 062 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 450.257213
-The maximum resident set size (KB)                   = 726684
+The total amount of wall time                        = 454.313564
+The maximum resident set size (KB)                   = 728136
 
 Test 062 control_2threads_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_CubedSphereGrid_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_CubedSphereGrid_debug
 Checking test 063 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2185,348 +2185,348 @@ Checking test 063 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 157.945692
-The maximum resident set size (KB)                   = 673340
+The total amount of wall time                        = 159.667175
+The maximum resident set size (KB)                   = 674716
 
 Test 063 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_wrtGauss_netcdf_parallel_debug
 Checking test 064 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 158.243286
-The maximum resident set size (KB)                   = 674552
+The total amount of wall time                        = 159.859201
+The maximum resident set size (KB)                   = 677928
 
 Test 064 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_stochy_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_stochy_debug
 Checking test 065 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.656884
-The maximum resident set size (KB)                   = 682540
+The total amount of wall time                        = 181.382865
+The maximum resident set size (KB)                   = 682552
 
 Test 065 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_lndp_debug
 Checking test 066 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.810903
-The maximum resident set size (KB)                   = 682140
+The total amount of wall time                        = 164.694501
+The maximum resident set size (KB)                   = 680292
 
 Test 066 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_csawmg_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_csawmg_debug
 Checking test 067 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 256.565845
-The maximum resident set size (KB)                   = 717456
+The total amount of wall time                        = 260.062131
+The maximum resident set size (KB)                   = 716168
 
 Test 067 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_csawmgt_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_csawmgt_debug
 Checking test 068 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 257.145666
-The maximum resident set size (KB)                   = 719520
+The total amount of wall time                        = 265.687053
+The maximum resident set size (KB)                   = 717876
 
 Test 068 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_ras_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_ras_debug
 Checking test 069 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 164.332923
-The maximum resident set size (KB)                   = 690924
+The total amount of wall time                        = 162.956642
+The maximum resident set size (KB)                   = 688132
 
 Test 069 control_ras_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_diag_debug
 Checking test 070 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.242298
-The maximum resident set size (KB)                   = 736608
+The total amount of wall time                        = 171.762755
+The maximum resident set size (KB)                   = 733656
 
 Test 070 control_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_debug_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_debug_p8
 Checking test 071 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 192.656705
-The maximum resident set size (KB)                   = 1501704
+The total amount of wall time                        = 194.041633
+The maximum resident set size (KB)                   = 1495840
 
 Test 071 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/fv3_regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/fv3_regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_debug
 Checking test 072 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 258.731235
-The maximum resident set size (KB)                   = 622288
+The total amount of wall time                        = 260.922585
+The maximum resident set size (KB)                   = 625480
 
 Test 072 regional_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_control_debug
 Checking test 073 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.815566
-The maximum resident set size (KB)                   = 1052700
+The total amount of wall time                        = 299.684154
+The maximum resident set size (KB)                   = 1051664
 
 Test 073 rap_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_debug
 Checking test 074 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.708479
-The maximum resident set size (KB)                   = 1046724
+The total amount of wall time                        = 296.259902
+The maximum resident set size (KB)                   = 1046296
 
 Test 074 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_unified_drag_suite_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_unified_drag_suite_debug
 Checking test 075 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.241798
-The maximum resident set size (KB)                   = 1051028
+The total amount of wall time                        = 300.337631
+The maximum resident set size (KB)                   = 1051500
 
 Test 075 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_diag_debug
 Checking test 076 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 313.440630
-The maximum resident set size (KB)                   = 1132668
+The total amount of wall time                        = 309.931947
+The maximum resident set size (KB)                   = 1132904
 
 Test 076 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_cires_ugwp_debug
 Checking test 077 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 308.133813
-The maximum resident set size (KB)                   = 1048548
+The total amount of wall time                        = 307.020511
+The maximum resident set size (KB)                   = 1051500
 
 Test 077 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_unified_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_unified_ugwp_debug
 Checking test 078 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.879864
-The maximum resident set size (KB)                   = 1051764
+The total amount of wall time                        = 307.029684
+The maximum resident set size (KB)                   = 1053236
 
 Test 078 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_lndp_debug
 Checking test 079 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.875029
-The maximum resident set size (KB)                   = 1051888
+The total amount of wall time                        = 307.325469
+The maximum resident set size (KB)                   = 1048188
 
 Test 079 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_flake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_flake_debug
 Checking test 080 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.973705
-The maximum resident set size (KB)                   = 1047704
+The total amount of wall time                        = 296.940100
+The maximum resident set size (KB)                   = 1052492
 
 Test 080 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_progcld_thompson_debug
 Checking test 081 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.743396
-The maximum resident set size (KB)                   = 1047624
+The total amount of wall time                        = 295.691121
+The maximum resident set size (KB)                   = 1051836
 
 Test 081 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_noah_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_noah_debug
 Checking test 082 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 287.878756
-The maximum resident set size (KB)                   = 1050624
+The total amount of wall time                        = 291.314562
+The maximum resident set size (KB)                   = 1046820
 
 Test 082 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_rrtmgp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_rrtmgp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_rrtmgp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_rrtmgp_debug
 Checking test 083 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 494.788093
-The maximum resident set size (KB)                   = 1168264
+The total amount of wall time                        = 502.430881
+The maximum resident set size (KB)                   = 1168172
 
 Test 083 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_sfcdiff_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_sfcdiff_debug
 Checking test 084 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.778034
-The maximum resident set size (KB)                   = 1053564
+The total amount of wall time                        = 298.173571
+The maximum resident set size (KB)                   = 1051696
 
 Test 084 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 085 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 489.592875
-The maximum resident set size (KB)                   = 1049080
+The total amount of wall time                        = 489.146336
+The maximum resident set size (KB)                   = 1048876
 
 Test 085 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rrfs_v1beta_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rrfs_v1beta_debug
 Checking test 086 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.427706
-The maximum resident set size (KB)                   = 1041952
+The total amount of wall time                        = 290.585374
+The maximum resident set size (KB)                   = 1046868
 
 Test 086 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/control_wam_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/control_wam_debug
 Checking test 087 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 299.816613
-The maximum resident set size (KB)                   = 293692
+The total amount of wall time                        = 299.476872
+The maximum resident set size (KB)                   = 294696
 
 Test 087 control_wam_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 088 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2537,14 +2537,14 @@ Checking test 088 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 656.562409
-The maximum resident set size (KB)                   = 873628
+The total amount of wall time                        = 660.404381
+The maximum resident set size (KB)                   = 874788
 
 Test 088 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_control_dyn32_phy32
 Checking test 089 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2591,14 +2591,14 @@ Checking test 089 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 330.718910
-The maximum resident set size (KB)                   = 774228
+The total amount of wall time                        = 330.962822
+The maximum resident set size (KB)                   = 772048
 
 Test 089 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_dyn32_phy32
 Checking test 090 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2645,14 +2645,14 @@ Checking test 090 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 177.243953
-The maximum resident set size (KB)                   = 772016
+The total amount of wall time                        = 175.186241
+The maximum resident set size (KB)                   = 775860
 
 Test 090 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_2threads_dyn32_phy32
 Checking test 091 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2699,14 +2699,14 @@ Checking test 091 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1037.053188
-The maximum resident set size (KB)                   = 820128
+The total amount of wall time                        = 1061.983862
+The maximum resident set size (KB)                   = 823052
 
 Test 091 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_2threads_dyn32_phy32
 Checking test 092 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2753,14 +2753,14 @@ Checking test 092 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 530.785579
-The maximum resident set size (KB)                   = 823420
+The total amount of wall time                        = 528.725981
+The maximum resident set size (KB)                   = 817128
 
 Test 092 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_decomp_dyn32_phy32
 Checking test 093 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2807,14 +2807,14 @@ Checking test 093 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 186.465838
-The maximum resident set size (KB)                   = 774760
+The total amount of wall time                        = 184.140257
+The maximum resident set size (KB)                   = 775160
 
 Test 093 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_restart_dyn32_phy32
 Checking test 094 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2853,14 +2853,14 @@ Checking test 094 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 246.339113
-The maximum resident set size (KB)                   = 605424
+The total amount of wall time                        = 244.516596
+The maximum resident set size (KB)                   = 607748
 
 Test 094 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_restart_dyn32_phy32
 Checking test 095 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2899,14 +2899,14 @@ Checking test 095 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 90.160394
-The maximum resident set size (KB)                   = 603636
+The total amount of wall time                        = 89.868090
+The maximum resident set size (KB)                   = 603452
 
 Test 095 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_control_dyn64_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_control_dyn64_phy32
 Checking test 096 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2953,81 +2953,81 @@ Checking test 096 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 226.500500
-The maximum resident set size (KB)                   = 799656
+The total amount of wall time                        = 226.611025
+The maximum resident set size (KB)                   = 795724
 
 Test 096 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_control_debug_dyn32_phy32
 Checking test 097 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 286.391824
-The maximum resident set size (KB)                   = 939844
+The total amount of wall time                        = 284.935786
+The maximum resident set size (KB)                   = 939716
 
 Test 097 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hrrr_control_debug_dyn32_phy32
 Checking test 098 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 283.914460
-The maximum resident set size (KB)                   = 935252
+The total amount of wall time                        = 282.591888
+The maximum resident set size (KB)                   = 936996
 
 Test 098 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/rap_control_dyn64_phy32_debug
 Checking test 099 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.841532
-The maximum resident set size (KB)                   = 960232
+The total amount of wall time                        = 294.162161
+The maximum resident set size (KB)                   = 954160
 
 Test 099 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_atm
 Checking test 100 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 700.988285
-The maximum resident set size (KB)                   = 792940
+The total amount of wall time                        = 703.825022
+The maximum resident set size (KB)                   = 793116
 
 Test 100 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_atm_thompson_gfdlsf
 Checking test 101 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 818.397028
-The maximum resident set size (KB)                   = 1159096
+The total amount of wall time                        = 816.579724
+The maximum resident set size (KB)                   = 1146568
 
 Test 101 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_atm_ocn
 Checking test 102 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3036,14 +3036,14 @@ Checking test 102 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 433.020207
-The maximum resident set size (KB)                   = 833928
+The total amount of wall time                        = 435.368320
+The maximum resident set size (KB)                   = 832688
 
 Test 102 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_atm_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_atm_wav
 Checking test 103 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3052,14 +3052,14 @@ Checking test 103 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 700.928959
-The maximum resident set size (KB)                   = 863804
+The total amount of wall time                        = 708.128015
+The maximum resident set size (KB)                   = 867024
 
 Test 103 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_atm_ocn_wav
 Checking test 104 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3070,28 +3070,28 @@ Checking test 104 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 910.254329
-The maximum resident set size (KB)                   = 885860
+The total amount of wall time                        = 905.011378
+The maximum resident set size (KB)                   = 888212
 
 Test 104 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_1nest_atm
 Checking test 105 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 1107.275670
-The maximum resident set size (KB)                   = 373388
+The total amount of wall time                        = 1109.781848
+The maximum resident set size (KB)                   = 373484
 
 Test 105 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_telescopic_2nests_atm
 Checking test 106 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3100,28 +3100,28 @@ Checking test 106 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 1264.090669
-The maximum resident set size (KB)                   = 390080
+The total amount of wall time                        = 1265.678813
+The maximum resident set size (KB)                   = 391144
 
 Test 106 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_global_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_global_1nest_atm
 Checking test 107 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 532.855117
-The maximum resident set size (KB)                   = 247892
+The total amount of wall time                        = 532.989124
+The maximum resident set size (KB)                   = 245776
 
 Test 107 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_global_multiple_4nests_atm
 Checking test 108 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3139,14 +3139,14 @@ Checking test 108 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 1415.244626
-The maximum resident set size (KB)                   = 310924
+The total amount of wall time                        = 1457.253920
+The maximum resident set size (KB)                   = 333116
 
 Test 108 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_specified_moving_1nest_atm
 Checking test 109 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3155,28 +3155,28 @@ Checking test 109 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 661.253141
-The maximum resident set size (KB)                   = 382732
+The total amount of wall time                        = 678.892280
+The maximum resident set size (KB)                   = 382564
 
 Test 109 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_storm_following_1nest_atm
 Checking test 110 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 636.431740
-The maximum resident set size (KB)                   = 386100
+The total amount of wall time                        = 636.304644
+The maximum resident set size (KB)                   = 384244
 
 Test 110 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 111 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3185,14 +3185,14 @@ Checking test 111 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 660.478866
-The maximum resident set size (KB)                   = 410464
+The total amount of wall time                        = 668.807906
+The maximum resident set size (KB)                   = 410576
 
 Test 111 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 112 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3203,28 +3203,28 @@ Checking test 112 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 1323.931621
-The maximum resident set size (KB)                   = 478296
+The total amount of wall time                        = 1330.912368
+The maximum resident set size (KB)                   = 475736
 
 Test 112 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/hafs_global_storm_following_1nest_atm
 Checking test 113 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 211.986332
-The maximum resident set size (KB)                   = 270984
+The total amount of wall time                        = 215.814295
+The maximum resident set size (KB)                   = 258196
 
 Test 113 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20220929/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_106268/regional_atmaq
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221007/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174289/regional_atmaq
 Checking test 114 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3240,12 +3240,12 @@ Checking test 114 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 706.643266
-The maximum resident set size (KB)                   = 1045640
+The total amount of wall time                        = 709.043058
+The maximum resident set size (KB)                   = 1041924
 
 Test 114 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct  5 20:11:09 UTC 2022
-Elapsed time: 01h:02m:22s. Have a nice day!
+Fri Oct  7 21:11:09 UTC 2022
+Elapsed time: 01h:00m:51s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -443,7 +443,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20220929
+BL_DATE=20221007
 
 RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR
are specified below.

- [x] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsibility to keep the PR up-to-date with the develop branch of ufs-weather-model.

## Description

This PR corrects a bug when using the prognostic closure (progsigma = true) to compute the q-tendency due to microphysics even if the diagnostic flags are false. It also optimizes the cloudbase massflux value for shallow and deep convection to work with the overall P8 physics suite.

New baselines are needed for the test: control_c384_progsigma

This update does not change the results in the control tests.

###issues
It addresses the issue: https://github.com/NCAR/ccpp-physics/issues/960

## Testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel
- [x] cheyenne.gnu
- [x] gaea.intel
- [x] jet.intel
- [x] wcoss2.intel
- [ ] acorn.intel
- [ ] opnReqTest for newly added/changed feature
- [x] CI

###dependencies
https://github.com/NCAR/ccpp-physics/pull/967
https://github.com/ufs-community/ccpp-physics/pull/13

@lisa-bengtsson 
