### PR TITLE
Improve radiative fluxes and cloud cover in FV3 for HR1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-#  url = https://github.com/NOAA-EMC/fv3atm
-#  branch = develop
-  url = https://github.com/ChunxiZhang-NOAA/fv3atm
-  branch = feature/mp_cloud
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+#  url = https://github.com/NOAA-EMC/fv3atm
+#  branch = develop
+  url = https://github.com/ChunxiZhang-NOAA/fv3atm
+  branch = feature/mp_cloud
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_acorn.intel.log
+++ b/tests/RegressionTests_acorn.intel.log
@@ -1,31 +1,31 @@
-Wed Nov  2 16:44:43 UTC 2022
+Tue Nov  8 13:16:26 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 502 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 472 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 377 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 354 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 434 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 444 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 347 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 338 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 819 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 229 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 459 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 429 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 319 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 477 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 475 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 478 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 182 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 018 elapsed time 79 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 327 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 471 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 343 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 352 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 512 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 469 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1103 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 349 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 332 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1016 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 756 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 319 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 952 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 556 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 700 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 399 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 604 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 635 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 509 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 537 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 469 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 018 elapsed time 314 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 466 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 457 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 341 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 501 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -90,14 +90,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 376.263992
-The maximum resident set size (KB)                   = 2979100
+The total amount of wall time                        = 376.424026
+The maximum resident set size (KB)                   = 2983844
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -150,14 +150,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 222.237851
-The maximum resident set size (KB)                   = 2865692
+The total amount of wall time                        = 222.726202
+The maximum resident set size (KB)                   = 2865220
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -210,14 +210,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 734.129539
-The maximum resident set size (KB)                   = 3264020
+The total amount of wall time                        = 737.993167
+The maximum resident set size (KB)                   = 3266116
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_esmfthreads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -270,14 +270,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 362.262571
-The maximum resident set size (KB)                   = 3281572
+The total amount of wall time                        = 363.634976
+The maximum resident set size (KB)                   = 3283400
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -330,14 +330,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 369.654722
-The maximum resident set size (KB)                   = 2978972
+The total amount of wall time                        = 370.486482
+The maximum resident set size (KB)                   = 2978412
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_mpi_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -390,14 +390,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 311.885898
-The maximum resident set size (KB)                   = 2911864
+The total amount of wall time                        = 314.172139
+The maximum resident set size (KB)                   = 2910152
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_control_ciceC_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -462,21 +462,15 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 377.524972
-The maximum resident set size (KB)                   = 2978680
+The total amount of wall time                        = 376.509767
+The maximum resident set size (KB)                   = 2979324
 
 Test 007 cpld_control_ciceC_p8 PASS
 
-Test 008 cpld_control_c192_p8 FAIL
 
-Test 010 cpld_bmark_p8 FAIL
-
-Test 012 cpld_bmark_esmfthreads_p8 FAIL
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_control_noaero_p8
-Checking test 013 cpld_control_noaero_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_control_noaero_p8
+Checking test 008 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -539,15 +533,15 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 249.610202
-The maximum resident set size (KB)                   = 1573744
+The total amount of wall time                        = 251.617278
+The maximum resident set size (KB)                   = 1569492
 
-Test 013 cpld_control_noaero_p8 PASS
+Test 008 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_control_nowave_noaero_p8
-Checking test 014 cpld_control_nowave_noaero_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_control_nowave_noaero_p8
+Checking test 009 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -608,15 +602,15 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 284.005529
-The maximum resident set size (KB)                   = 1627776
+The total amount of wall time                        = 283.848061
+The maximum resident set size (KB)                   = 1628704
 
-Test 014 cpld_control_nowave_noaero_p8 PASS
+Test 009 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_control_noaero_p8_agrid
-Checking test 015 cpld_control_noaero_p8_agrid results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_control_noaero_p8_agrid
+Checking test 010 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -677,15 +671,15 @@ Checking test 015 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 292.392001
-The maximum resident set size (KB)                   = 1624316
+The total amount of wall time                        = 297.076730
+The maximum resident set size (KB)                   = 1624620
 
-Test 015 cpld_control_noaero_p8_agrid PASS
+Test 010 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_control_c48
-Checking test 016 cpld_control_c48 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_control_c48
+Checking test 011 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
  Comparing sfcf024.tile3.nc .........OK
@@ -734,15 +728,15 @@ Checking test 016 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 426.756101
-The maximum resident set size (KB)                   = 2624952
+The total amount of wall time                        = 432.784432
+The maximum resident set size (KB)                   = 2626328
 
-Test 016 cpld_control_c48 PASS
+Test 011 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_warmstart_c48
-Checking test 017 cpld_warmstart_c48 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_warmstart_c48
+Checking test 012 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
  Comparing sfcf006.tile3.nc .........OK
@@ -791,15 +785,15 @@ Checking test 017 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 114.303517
-The maximum resident set size (KB)                   = 2647452
+The total amount of wall time                        = 115.371149
+The maximum resident set size (KB)                   = 2646376
 
-Test 017 cpld_warmstart_c48 PASS
+Test 012 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/cpld_restart_c48
-Checking test 018 cpld_restart_c48 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/cpld_restart_c48
+Checking test 013 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
  Comparing sfcf006.tile3.nc .........OK
@@ -848,15 +842,15 @@ Checking test 018 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 59.943546
-The maximum resident set size (KB)                   = 2057912
+The total amount of wall time                        = 61.889979
+The maximum resident set size (KB)                   = 2063028
 
-Test 018 cpld_restart_c48 PASS
+Test 013 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control
-Checking test 019 control results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control
+Checking test 014 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -902,15 +896,15 @@ Checking test 019 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 133.289644
-The maximum resident set size (KB)                   = 514096
+The total amount of wall time                        = 133.119885
+The maximum resident set size (KB)                   = 511212
 
-Test 019 control PASS
+Test 014 control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_decomp
-Checking test 020 control_decomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_decomp
+Checking test 015 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -952,15 +946,15 @@ Checking test 020 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 134.939235
-The maximum resident set size (KB)                   = 512012
+The total amount of wall time                        = 135.410576
+The maximum resident set size (KB)                   = 509384
 
-Test 020 control_decomp PASS
+Test 015 control_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_2dwrtdecomp
-Checking test 021 control_2dwrtdecomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_2dwrtdecomp
+Checking test 016 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -970,15 +964,15 @@ Checking test 021 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 130.652711
-The maximum resident set size (KB)                   = 508480
+The total amount of wall time                        = 130.714530
+The maximum resident set size (KB)                   = 513524
 
-Test 021 control_2dwrtdecomp PASS
+Test 016 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_2threads
-Checking test 022 control_2threads results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_2threads
+Checking test 017 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1020,15 +1014,15 @@ Checking test 022 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 283.493288
-The maximum resident set size (KB)                   = 555408
+The total amount of wall time                        = 284.715213
+The maximum resident set size (KB)                   = 561412
 
-Test 022 control_2threads PASS
+Test 017 control_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_restart
-Checking test 023 control_restart results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_restart
+Checking test 018 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -1066,15 +1060,15 @@ Checking test 023 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 67.607772
-The maximum resident set size (KB)                   = 269700
+The total amount of wall time                        = 67.532994
+The maximum resident set size (KB)                   = 269600
 
-Test 023 control_restart PASS
+Test 018 control_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_fhzero
-Checking test 024 control_fhzero results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_fhzero
+Checking test 019 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
@@ -1116,15 +1110,15 @@ Checking test 024 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 126.954451
-The maximum resident set size (KB)                   = 514740
+The total amount of wall time                        = 125.806568
+The maximum resident set size (KB)                   = 513920
 
-Test 024 control_fhzero PASS
+Test 019 control_fhzero PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_CubedSphereGrid
-Checking test 025 control_CubedSphereGrid results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_CubedSphereGrid
+Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -1150,15 +1144,15 @@ Checking test 025 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 126.916404
-The maximum resident set size (KB)                   = 509608
+The total amount of wall time                        = 127.359774
+The maximum resident set size (KB)                   = 510068
 
-Test 025 control_CubedSphereGrid PASS
+Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_latlon
-Checking test 026 control_latlon results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_latlon
+Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1168,15 +1162,15 @@ Checking test 026 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 129.954238
-The maximum resident set size (KB)                   = 509756
+The total amount of wall time                        = 129.367535
+The maximum resident set size (KB)                   = 510916
 
-Test 026 control_latlon PASS
+Test 021 control_latlon PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_wrtGauss_netcdf_parallel
-Checking test 027 control_wrtGauss_netcdf_parallel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_wrtGauss_netcdf_parallel
+Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1186,15 +1180,15 @@ Checking test 027 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.646988
-The maximum resident set size (KB)                   = 511760
+The total amount of wall time                        = 131.694484
+The maximum resident set size (KB)                   = 508264
 
-Test 027 control_wrtGauss_netcdf_parallel PASS
+Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_c48
-Checking test 028 control_c48 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_c48
+Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1232,15 +1226,15 @@ Checking test 028 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 325.960342
-The maximum resident set size (KB)                   = 665712
+The total amount of wall time                        = 325.486386
+The maximum resident set size (KB)                   = 663292
 
-Test 028 control_c48 PASS
+Test 023 control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_c192
-Checking test 029 control_c192 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_c192
+Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1250,15 +1244,15 @@ Checking test 029 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 525.772865
-The maximum resident set size (KB)                   = 610908
+The total amount of wall time                        = 522.589852
+The maximum resident set size (KB)                   = 610088
 
-Test 029 control_c192 PASS
+Test 024 control_c192 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_c384
-Checking test 030 control_c384 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_c384
+Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1268,15 +1262,15 @@ Checking test 030 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1248.641414
-The maximum resident set size (KB)                   = 874844
+The total amount of wall time                        = 1243.640703
+The maximum resident set size (KB)                   = 878844
 
-Test 030 control_c384 PASS
+Test 025 control_c384 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_c384gdas
-Checking test 031 control_c384gdas results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_c384gdas
+Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1318,15 +1312,15 @@ Checking test 031 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1087.319822
-The maximum resident set size (KB)                   = 1005652
+The total amount of wall time                        = 1088.463319
+The maximum resident set size (KB)                   = 1010348
 
-Test 031 control_c384gdas PASS
+Test 026 control_c384gdas PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_c384_progsigma
-Checking test 032 control_c384_progsigma results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_c384_progsigma
+Checking test 027 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1336,15 +1330,15 @@ Checking test 032 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1271.889693
-The maximum resident set size (KB)                   = 898024
+The total amount of wall time                        = 1268.400737
+The maximum resident set size (KB)                   = 897060
 
-Test 032 control_c384_progsigma PASS
+Test 027 control_c384_progsigma PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_stochy
-Checking test 033 control_stochy results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_stochy
+Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1354,29 +1348,29 @@ Checking test 033 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 89.637513
-The maximum resident set size (KB)                   = 519588
+The total amount of wall time                        = 89.034438
+The maximum resident set size (KB)                   = 518152
 
-Test 033 control_stochy PASS
+Test 028 control_stochy PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_stochy_restart
-Checking test 034 control_stochy_restart results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_stochy_restart
+Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 46.460008
-The maximum resident set size (KB)                   = 278960
+The total amount of wall time                        = 45.976722
+The maximum resident set size (KB)                   = 279624
 
-Test 034 control_stochy_restart PASS
+Test 029 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_lndp
-Checking test 035 control_lndp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_lndp
+Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1386,15 +1380,15 @@ Checking test 035 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 80.650093
-The maximum resident set size (KB)                   = 517144
+The total amount of wall time                        = 80.954177
+The maximum resident set size (KB)                   = 513448
 
-Test 035 control_lndp PASS
+Test 030 control_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_iovr4
-Checking test 036 control_iovr4 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_iovr4
+Checking test 031 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1408,15 +1402,15 @@ Checking test 036 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.594503
-The maximum resident set size (KB)                   = 512232
+The total amount of wall time                        = 133.081967
+The maximum resident set size (KB)                   = 508824
 
-Test 036 control_iovr4 PASS
+Test 031 control_iovr4 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_iovr5
-Checking test 037 control_iovr5 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_iovr5
+Checking test 032 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1430,15 +1424,15 @@ Checking test 037 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.367148
-The maximum resident set size (KB)                   = 514396
+The total amount of wall time                        = 133.647689
+The maximum resident set size (KB)                   = 509684
 
-Test 037 control_iovr5 PASS
+Test 032 control_iovr5 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_p8
-Checking test 038 control_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_p8
+Checking test 033 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1484,15 +1478,15 @@ Checking test 038 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 169.992194
-The maximum resident set size (KB)                   = 1477276
+The total amount of wall time                        = 170.687982
+The maximum resident set size (KB)                   = 1477712
 
-Test 038 control_p8 PASS
+Test 033 control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_p8_lndp
-Checking test 039 control_p8_lndp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_p8_lndp
+Checking test 034 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1510,15 +1504,15 @@ Checking test 039 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 311.643619
-The maximum resident set size (KB)                   = 1480160
+The total amount of wall time                        = 313.690365
+The maximum resident set size (KB)                   = 1484736
 
-Test 039 control_p8_lndp PASS
+Test 034 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_restart_p8
-Checking test 040 control_restart_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_restart_p8
+Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -1556,15 +1550,15 @@ Checking test 040 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 90.486417
-The maximum resident set size (KB)                   = 645948
+The total amount of wall time                        = 89.321180
+The maximum resident set size (KB)                   = 642756
 
-Test 040 control_restart_p8 PASS
+Test 035 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_decomp_p8
-Checking test 041 control_decomp_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_decomp_p8
+Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1606,15 +1600,15 @@ Checking test 041 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 171.288639
-The maximum resident set size (KB)                   = 1473320
+The total amount of wall time                        = 172.284046
+The maximum resident set size (KB)                   = 1481636
 
-Test 041 control_decomp_p8 PASS
+Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_2threads_p8
-Checking test 042 control_2threads_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_2threads_p8
+Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1656,69 +1650,15 @@ Checking test 042 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 348.278118
-The maximum resident set size (KB)                   = 1563168
+The total amount of wall time                        = 350.480151
+The maximum resident set size (KB)                   = 1565160
 
-Test 042 control_2threads_p8 PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_p8_rrtmgp
-Checking test 043 control_p8_rrtmgp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-The total amount of wall time                        = 250.205838
-The maximum resident set size (KB)                   = 1601648
-
-Test 043 control_p8_rrtmgp PASS
+Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/merra2_thompson
-Checking test 044 merra2_thompson results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_p8_rrtmgp
+Checking test 038 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1764,15 +1704,69 @@ Checking test 044 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.334611
-The maximum resident set size (KB)                   = 1487600
+The total amount of wall time                        = 249.506073
+The maximum resident set size (KB)                   = 1604984
 
-Test 044 merra2_thompson PASS
+Test 038 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_control
-Checking test 045 regional_control results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/merra2_thompson
+Checking test 039 merra2_thompson results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+The total amount of wall time                        = 175.030009
+The maximum resident set size (KB)                   = 1494200
+
+Test 039 merra2_thompson PASS
+
+
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_control
+Checking test 040 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1782,29 +1776,29 @@ Checking test 045 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 307.347549
-The maximum resident set size (KB)                   = 599684
+The total amount of wall time                        = 306.040269
+The maximum resident set size (KB)                   = 595504
 
-Test 045 regional_control PASS
+Test 040 regional_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_restart
-Checking test 046 regional_restart results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_restart
+Checking test 041 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 167.625333
-The maximum resident set size (KB)                   = 595392
+The total amount of wall time                        = 167.015770
+The maximum resident set size (KB)                   = 588624
 
-Test 046 regional_restart PASS
+Test 041 regional_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_control_2dwrtdecomp
-Checking test 047 regional_control_2dwrtdecomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_control_2dwrtdecomp
+Checking test 042 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1814,30 +1808,30 @@ Checking test 047 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 309.809374
-The maximum resident set size (KB)                   = 593436
+The total amount of wall time                        = 306.218873
+The maximum resident set size (KB)                   = 593748
 
-Test 047 regional_control_2dwrtdecomp PASS
+Test 042 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_noquilt
-Checking test 048 regional_noquilt results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_noquilt
+Checking test 043 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 325.146228
-The maximum resident set size (KB)                   = 588084
+The total amount of wall time                        = 323.761967
+The maximum resident set size (KB)                   = 588180
 
-Test 048 regional_noquilt PASS
+Test 043 regional_noquilt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_2threads
-Checking test 049 regional_2threads results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_2threads
+Checking test 044 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1847,15 +1841,15 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 427.178698
-The maximum resident set size (KB)                   = 648836
+The total amount of wall time                        = 426.994430
+The maximum resident set size (KB)                   = 644856
 
-Test 049 regional_2threads PASS
+Test 044 regional_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_3km
-Checking test 050 regional_3km results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_3km
+Checking test 045 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1865,15 +1859,15 @@ Checking test 050 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 249.420146
-The maximum resident set size (KB)                   = 647012
+The total amount of wall time                        = 248.866301
+The maximum resident set size (KB)                   = 650984
 
-Test 050 regional_3km PASS
+Test 045 regional_3km PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_3km_decomp
-Checking test 051 regional_3km_decomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_3km_decomp
+Checking test 046 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1883,15 +1877,15 @@ Checking test 051 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 263.590410
-The maximum resident set size (KB)                   = 654544
+The total amount of wall time                        = 264.220250
+The maximum resident set size (KB)                   = 654668
 
-Test 051 regional_3km_decomp PASS
+Test 046 regional_3km_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_3km_wofs
-Checking test 052 regional_3km_wofs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_3km_wofs
+Checking test 047 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1901,15 +1895,15 @@ Checking test 052 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 324.842467
-The maximum resident set size (KB)                   = 329784
+The total amount of wall time                        = 325.903770
+The maximum resident set size (KB)                   = 335152
 
-Test 052 regional_3km_wofs PASS
+Test 047 regional_3km_wofs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_control
-Checking test 053 rap_control results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_control
+Checking test 048 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1955,15 +1949,15 @@ Checking test 053 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 398.518707
-The maximum resident set size (KB)                   = 894556
+The total amount of wall time                        = 399.045055
+The maximum resident set size (KB)                   = 894712
 
-Test 053 rap_control PASS
+Test 048 rap_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_rrtmgp
-Checking test 054 rap_rrtmgp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_rrtmgp
+Checking test 049 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2009,15 +2003,15 @@ Checking test 054 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 477.631238
-The maximum resident set size (KB)                   = 1008256
+The total amount of wall time                        = 478.835107
+The maximum resident set size (KB)                   = 1004276
 
-Test 054 rap_rrtmgp PASS
+Test 049 rap_rrtmgp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_spp_sppt_shum_skeb
-Checking test 055 regional_spp_sppt_shum_skeb results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_spp_sppt_shum_skeb
+Checking test 050 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2027,15 +2021,15 @@ Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 538.032621
-The maximum resident set size (KB)                   = 972740
+The total amount of wall time                        = 537.188094
+The maximum resident set size (KB)                   = 973000
 
-Test 055 regional_spp_sppt_shum_skeb PASS
+Test 050 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_decomp
-Checking test 056 rap_decomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_decomp
+Checking test 051 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2081,15 +2075,15 @@ Checking test 056 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 415.178310
-The maximum resident set size (KB)                   = 888060
+The total amount of wall time                        = 413.398309
+The maximum resident set size (KB)                   = 886612
 
-Test 056 rap_decomp PASS
+Test 051 rap_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_2threads
-Checking test 057 rap_2threads results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_2threads
+Checking test 052 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2135,15 +2129,15 @@ Checking test 057 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 877.467060
-The maximum resident set size (KB)                   = 950880
+The total amount of wall time                        = 877.468446
+The maximum resident set size (KB)                   = 951984
 
-Test 057 rap_2threads PASS
+Test 052 rap_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_restart
-Checking test 058 rap_restart results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_restart
+Checking test 053 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -2181,15 +2175,15 @@ Checking test 058 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.295036
-The maximum resident set size (KB)                   = 632616
+The total amount of wall time                        = 200.212069
+The maximum resident set size (KB)                   = 635884
 
-Test 058 rap_restart PASS
+Test 053 rap_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_sfcdiff
-Checking test 059 rap_sfcdiff results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_sfcdiff
+Checking test 054 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2235,15 +2229,15 @@ Checking test 059 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 392.944479
-The maximum resident set size (KB)                   = 892364
+The total amount of wall time                        = 393.730182
+The maximum resident set size (KB)                   = 890020
 
-Test 059 rap_sfcdiff PASS
+Test 054 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_sfcdiff_decomp
-Checking test 060 rap_sfcdiff_decomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_sfcdiff_decomp
+Checking test 055 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2289,15 +2283,15 @@ Checking test 060 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 417.674943
-The maximum resident set size (KB)                   = 888876
+The total amount of wall time                        = 416.980156
+The maximum resident set size (KB)                   = 889088
 
-Test 060 rap_sfcdiff_decomp PASS
+Test 055 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_sfcdiff_restart
-Checking test 061 rap_sfcdiff_restart results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_sfcdiff_restart
+Checking test 056 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -2335,15 +2329,15 @@ Checking test 061 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 293.630291
-The maximum resident set size (KB)                   = 634416
+The total amount of wall time                        = 292.884859
+The maximum resident set size (KB)                   = 630492
 
-Test 061 rap_sfcdiff_restart PASS
+Test 056 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control
-Checking test 062 hrrr_control results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control
+Checking test 057 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2389,15 +2383,15 @@ Checking test 062 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 384.540939
-The maximum resident set size (KB)                   = 885160
+The total amount of wall time                        = 383.296660
+The maximum resident set size (KB)                   = 883408
 
-Test 062 hrrr_control PASS
+Test 057 hrrr_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_decomp
-Checking test 063 hrrr_control_decomp results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_decomp
+Checking test 058 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2443,15 +2437,15 @@ Checking test 063 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 397.259654
-The maximum resident set size (KB)                   = 884036
+The total amount of wall time                        = 397.816153
+The maximum resident set size (KB)                   = 884900
 
-Test 063 hrrr_control_decomp PASS
+Test 058 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_2threads
-Checking test 064 hrrr_control_2threads results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_2threads
+Checking test 059 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2497,15 +2491,15 @@ Checking test 064 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 834.711048
-The maximum resident set size (KB)                   = 947064
+The total amount of wall time                        = 839.346695
+The maximum resident set size (KB)                   = 945512
 
-Test 064 hrrr_control_2threads PASS
+Test 059 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_restart
-Checking test 065 hrrr_control_restart results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_restart
+Checking test 060 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -2543,15 +2537,15 @@ Checking test 065 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 282.464112
-The maximum resident set size (KB)                   = 626136
+The total amount of wall time                        = 282.648783
+The maximum resident set size (KB)                   = 628596
 
-Test 065 hrrr_control_restart PASS
+Test 060 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_v1beta
-Checking test 066 rrfs_v1beta results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_v1beta
+Checking test 061 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2597,15 +2591,15 @@ Checking test 066 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 395.482098
-The maximum resident set size (KB)                   = 883164
+The total amount of wall time                        = 387.134338
+The maximum resident set size (KB)                   = 879288
 
-Test 066 rrfs_v1beta PASS
+Test 061 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_v1nssl
-Checking test 067 rrfs_v1nssl results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_v1nssl
+Checking test 062 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2619,15 +2613,15 @@ Checking test 067 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 456.585630
-The maximum resident set size (KB)                   = 572840
+The total amount of wall time                        = 456.968301
+The maximum resident set size (KB)                   = 571940
 
-Test 067 rrfs_v1nssl PASS
+Test 062 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_v1nssl_nohailnoccn
-Checking test 068 rrfs_v1nssl_nohailnoccn results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_v1nssl_nohailnoccn
+Checking test 063 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2641,15 +2635,15 @@ Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 447.070866
-The maximum resident set size (KB)                   = 562772
+The total amount of wall time                        = 445.964936
+The maximum resident set size (KB)                   = 564096
 
-Test 068 rrfs_v1nssl_nohailnoccn PASS
+Test 063 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_conus13km_hrrr_warm
-Checking test 069 rrfs_conus13km_hrrr_warm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_conus13km_hrrr_warm
+Checking test 064 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2657,15 +2651,15 @@ Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 110.930998
-The maximum resident set size (KB)                   = 762320
+The total amount of wall time                        = 110.620186
+The maximum resident set size (KB)                   = 761668
 
-Test 069 rrfs_conus13km_hrrr_warm PASS
+Test 064 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_smoke_conus13km_hrrr_warm
-Checking test 070 rrfs_smoke_conus13km_hrrr_warm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_smoke_conus13km_hrrr_warm
+Checking test 065 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2673,15 +2667,15 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 122.587870
-The maximum resident set size (KB)                   = 774456
+The total amount of wall time                        = 125.440119
+The maximum resident set size (KB)                   = 776852
 
-Test 070 rrfs_smoke_conus13km_hrrr_warm PASS
+Test 065 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_conus13km_radar_tten_warm
-Checking test 071 rrfs_conus13km_radar_tten_warm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_conus13km_radar_tten_warm
+Checking test 066 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2689,15 +2683,15 @@ Checking test 071 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 111.037690
-The maximum resident set size (KB)                   = 761068
+The total amount of wall time                        = 113.965049
+The maximum resident set size (KB)                   = 765780
 
-Test 071 rrfs_conus13km_radar_tten_warm PASS
+Test 066 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_conus13km_hrrr_warm_2threads
-Checking test 072 rrfs_conus13km_hrrr_warm_2threads results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_conus13km_hrrr_warm_2threads
+Checking test 067 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2705,15 +2699,15 @@ Checking test 072 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 151.799676
-The maximum resident set size (KB)                   = 754040
+The total amount of wall time                        = 155.998915
+The maximum resident set size (KB)                   = 752080
 
-Test 072 rrfs_conus13km_hrrr_warm_2threads PASS
+Test 067 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_conus13km_radar_tten_warm_2threads
-Checking test 073 rrfs_conus13km_radar_tten_warm_2threads results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_conus13km_radar_tten_warm_2threads
+Checking test 068 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2721,15 +2715,15 @@ Checking test 073 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 152.669154
-The maximum resident set size (KB)                   = 758796
+The total amount of wall time                        = 152.043490
+The maximum resident set size (KB)                   = 753752
 
-Test 073 rrfs_conus13km_radar_tten_warm_2threads PASS
+Test 068 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_csawmg
-Checking test 074 control_csawmg results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_csawmg
+Checking test 069 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2739,15 +2733,15 @@ Checking test 074 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 337.887076
-The maximum resident set size (KB)                   = 584324
+The total amount of wall time                        = 336.024750
+The maximum resident set size (KB)                   = 580748
 
-Test 074 control_csawmg PASS
+Test 069 control_csawmg PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_csawmgt
-Checking test 075 control_csawmgt results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_csawmgt
+Checking test 070 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2757,15 +2751,15 @@ Checking test 075 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 336.173956
-The maximum resident set size (KB)                   = 584228
+The total amount of wall time                        = 334.423739
+The maximum resident set size (KB)                   = 579948
 
-Test 075 control_csawmgt PASS
+Test 070 control_csawmgt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_ras
-Checking test 076 control_ras results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_ras
+Checking test 071 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2775,83 +2769,83 @@ Checking test 076 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 178.911181
-The maximum resident set size (KB)                   = 548916
+The total amount of wall time                        = 177.241906
+The maximum resident set size (KB)                   = 547196
 
-Test 076 control_ras PASS
+Test 071 control_ras PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_wam
-Checking test 077 control_wam results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_wam
+Checking test 072 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 114.385319
-The maximum resident set size (KB)                   = 335032
+The total amount of wall time                        = 113.181629
+The maximum resident set size (KB)                   = 269832
 
-Test 077 control_wam PASS
+Test 072 control_wam PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_conus13km_hrrr_warm_debug
-Checking test 078 rrfs_conus13km_hrrr_warm_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_conus13km_hrrr_warm_debug
+Checking test 073 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 771.836942
-The maximum resident set size (KB)                   = 787812
+The total amount of wall time                        = 767.175230
+The maximum resident set size (KB)                   = 791304
 
-Test 078 rrfs_conus13km_hrrr_warm_debug PASS
+Test 073 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_conus13km_radar_tten_warm_debug
-Checking test 079 rrfs_conus13km_radar_tten_warm_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_conus13km_radar_tten_warm_debug
+Checking test 074 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 773.235963
-The maximum resident set size (KB)                   = 795320
+The total amount of wall time                        = 767.929641
+The maximum resident set size (KB)                   = 791428
 
-Test 079 rrfs_conus13km_radar_tten_warm_debug PASS
+Test 074 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_debug
-Checking test 080 control_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_debug
+Checking test 075 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 156.475138
-The maximum resident set size (KB)                   = 679848
+The total amount of wall time                        = 157.041206
+The maximum resident set size (KB)                   = 679552
 
-Test 080 control_debug PASS
+Test 075 control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_2threads_debug
-Checking test 081 control_2threads_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_2threads_debug
+Checking test 076 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 400.006945
-The maximum resident set size (KB)                   = 727764
+The total amount of wall time                        = 400.928837
+The maximum resident set size (KB)                   = 731016
 
-Test 081 control_2threads_debug PASS
+Test 076 control_2threads_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_CubedSphereGrid_debug
-Checking test 082 control_CubedSphereGrid_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_CubedSphereGrid_debug
+Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2877,349 +2871,349 @@ Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 166.136899
-The maximum resident set size (KB)                   = 674476
+The total amount of wall time                        = 165.765307
+The maximum resident set size (KB)                   = 678644
 
-Test 082 control_CubedSphereGrid_debug PASS
+Test 077 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_wrtGauss_netcdf_parallel_debug
-Checking test 083 control_wrtGauss_netcdf_parallel_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_wrtGauss_netcdf_parallel_debug
+Checking test 078 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.538639
-The maximum resident set size (KB)                   = 680336
+The total amount of wall time                        = 157.479898
+The maximum resident set size (KB)                   = 678752
 
-Test 083 control_wrtGauss_netcdf_parallel_debug PASS
+Test 078 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_stochy_debug
-Checking test 084 control_stochy_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_stochy_debug
+Checking test 079 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.520664
-The maximum resident set size (KB)                   = 686168
+The total amount of wall time                        = 178.727038
+The maximum resident set size (KB)                   = 685084
 
-Test 084 control_stochy_debug PASS
+Test 079 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_lndp_debug
-Checking test 085 control_lndp_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_lndp_debug
+Checking test 080 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.976127
-The maximum resident set size (KB)                   = 685052
+The total amount of wall time                        = 161.198420
+The maximum resident set size (KB)                   = 683168
 
-Test 085 control_lndp_debug PASS
+Test 080 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_csawmg_debug
-Checking test 086 control_csawmg_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_csawmg_debug
+Checking test 081 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 249.666801
-The maximum resident set size (KB)                   = 721252
+The total amount of wall time                        = 249.760766
+The maximum resident set size (KB)                   = 717696
 
-Test 086 control_csawmg_debug PASS
+Test 081 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_csawmgt_debug
-Checking test 087 control_csawmgt_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_csawmgt_debug
+Checking test 082 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 247.532993
-The maximum resident set size (KB)                   = 717556
+The total amount of wall time                        = 245.151971
+The maximum resident set size (KB)                   = 717544
 
-Test 087 control_csawmgt_debug PASS
+Test 082 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_ras_debug
-Checking test 088 control_ras_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_ras_debug
+Checking test 083 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.126336
-The maximum resident set size (KB)                   = 693276
+The total amount of wall time                        = 162.252245
+The maximum resident set size (KB)                   = 693344
 
-Test 088 control_ras_debug PASS
+Test 083 control_ras_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_diag_debug
-Checking test 089 control_diag_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_diag_debug
+Checking test 084 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.223880
-The maximum resident set size (KB)                   = 738228
+The total amount of wall time                        = 162.952646
+The maximum resident set size (KB)                   = 736864
 
-Test 089 control_diag_debug PASS
+Test 084 control_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_debug_p8
-Checking test 090 control_debug_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_debug_p8
+Checking test 085 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.573858
-The maximum resident set size (KB)                   = 1500148
+The total amount of wall time                        = 179.727391
+The maximum resident set size (KB)                   = 1506144
 
-Test 090 control_debug_p8 PASS
+Test 085 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_debug
-Checking test 091 regional_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_debug
+Checking test 086 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 258.288365
-The maximum resident set size (KB)                   = 625164
+The total amount of wall time                        = 260.111440
+The maximum resident set size (KB)                   = 624636
 
-Test 091 regional_debug PASS
+Test 086 regional_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_control_debug
-Checking test 092 rap_control_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_control_debug
+Checking test 087 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.627622
-The maximum resident set size (KB)                   = 1053448
+The total amount of wall time                        = 294.519137
+The maximum resident set size (KB)                   = 1047460
 
-Test 092 rap_control_debug PASS
+Test 087 rap_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_debug
-Checking test 093 hrrr_control_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_debug
+Checking test 088 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.151989
-The maximum resident set size (KB)                   = 1048340
+The total amount of wall time                        = 288.934468
+The maximum resident set size (KB)                   = 1052840
 
-Test 093 hrrr_control_debug PASS
+Test 088 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_unified_drag_suite_debug
-Checking test 094 rap_unified_drag_suite_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_unified_drag_suite_debug
+Checking test 089 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.580798
-The maximum resident set size (KB)                   = 1050700
+The total amount of wall time                        = 293.500860
+The maximum resident set size (KB)                   = 1053736
 
-Test 094 rap_unified_drag_suite_debug PASS
+Test 089 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_diag_debug
-Checking test 095 rap_diag_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_diag_debug
+Checking test 090 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.388547
-The maximum resident set size (KB)                   = 1136528
+The total amount of wall time                        = 307.345483
+The maximum resident set size (KB)                   = 1133416
 
-Test 095 rap_diag_debug PASS
+Test 090 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_cires_ugwp_debug
-Checking test 096 rap_cires_ugwp_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_cires_ugwp_debug
+Checking test 091 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.427553
-The maximum resident set size (KB)                   = 1051996
+The total amount of wall time                        = 301.219510
+The maximum resident set size (KB)                   = 1052004
 
-Test 096 rap_cires_ugwp_debug PASS
+Test 091 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_unified_ugwp_debug
-Checking test 097 rap_unified_ugwp_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_unified_ugwp_debug
+Checking test 092 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.129622
-The maximum resident set size (KB)                   = 1053320
+The total amount of wall time                        = 302.216089
+The maximum resident set size (KB)                   = 1053544
 
-Test 097 rap_unified_ugwp_debug PASS
+Test 092 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_lndp_debug
-Checking test 098 rap_lndp_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_lndp_debug
+Checking test 093 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.451054
-The maximum resident set size (KB)                   = 1053672
+The total amount of wall time                        = 298.316882
+The maximum resident set size (KB)                   = 1052348
 
-Test 098 rap_lndp_debug PASS
+Test 093 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_flake_debug
-Checking test 099 rap_flake_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_flake_debug
+Checking test 094 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.178112
-The maximum resident set size (KB)                   = 1053796
+The total amount of wall time                        = 294.005441
+The maximum resident set size (KB)                   = 1048216
 
-Test 099 rap_flake_debug PASS
+Test 094 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_progcld_thompson_debug
-Checking test 100 rap_progcld_thompson_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_progcld_thompson_debug
+Checking test 095 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.647994
-The maximum resident set size (KB)                   = 1048056
+The total amount of wall time                        = 294.598148
+The maximum resident set size (KB)                   = 1051204
 
-Test 100 rap_progcld_thompson_debug PASS
+Test 095 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_noah_debug
-Checking test 101 rap_noah_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_noah_debug
+Checking test 096 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.776385
-The maximum resident set size (KB)                   = 1049068
+The total amount of wall time                        = 288.698094
+The maximum resident set size (KB)                   = 1053948
 
-Test 101 rap_noah_debug PASS
+Test 096 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_rrtmgp_debug
-Checking test 102 rap_rrtmgp_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_rrtmgp_debug
+Checking test 097 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 495.996959
-The maximum resident set size (KB)                   = 1169140
+The total amount of wall time                        = 495.882464
+The maximum resident set size (KB)                   = 1169624
 
-Test 102 rap_rrtmgp_debug PASS
+Test 097 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_sfcdiff_debug
-Checking test 103 rap_sfcdiff_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_sfcdiff_debug
+Checking test 098 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.729705
-The maximum resident set size (KB)                   = 1053864
+The total amount of wall time                        = 295.164194
+The maximum resident set size (KB)                   = 1052068
 
-Test 103 rap_sfcdiff_debug PASS
+Test 098 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_noah_sfcdiff_cires_ugwp_debug
-Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 099 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 484.052315
-The maximum resident set size (KB)                   = 1050668
+The total amount of wall time                        = 482.775014
+The maximum resident set size (KB)                   = 1052148
 
-Test 104 rap_noah_sfcdiff_cires_ugwp_debug PASS
+Test 099 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rrfs_v1beta_debug
-Checking test 105 rrfs_v1beta_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rrfs_v1beta_debug
+Checking test 100 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.396713
-The maximum resident set size (KB)                   = 1044156
+The total amount of wall time                        = 290.469342
+The maximum resident set size (KB)                   = 1043472
 
-Test 105 rrfs_v1beta_debug PASS
+Test 100 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_wam_debug
-Checking test 106 control_wam_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_wam_debug
+Checking test 101 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 295.894621
-The maximum resident set size (KB)                   = 292928
+The total amount of wall time                        = 295.181075
+The maximum resident set size (KB)                   = 294796
 
-Test 106 control_wam_debug PASS
+Test 101 control_wam_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_spp_sppt_shum_skeb_dyn32_phy32
-Checking test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_spp_sppt_shum_skeb_dyn32_phy32
+Checking test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3229,15 +3223,15 @@ Checking test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 496.648790
-The maximum resident set size (KB)                   = 873120
+The total amount of wall time                        = 497.053992
+The maximum resident set size (KB)                   = 873304
 
-Test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
+Test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_control_dyn32_phy32
-Checking test 108 rap_control_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_control_dyn32_phy32
+Checking test 103 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3283,15 +3277,15 @@ Checking test 108 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 325.707023
-The maximum resident set size (KB)                   = 769052
+The total amount of wall time                        = 326.021262
+The maximum resident set size (KB)                   = 768488
 
-Test 108 rap_control_dyn32_phy32 PASS
+Test 103 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_dyn32_phy32
-Checking test 109 hrrr_control_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_dyn32_phy32
+Checking test 104 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3337,15 +3331,15 @@ Checking test 109 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 169.675540
-The maximum resident set size (KB)                   = 771368
+The total amount of wall time                        = 171.302006
+The maximum resident set size (KB)                   = 770016
 
-Test 109 hrrr_control_dyn32_phy32 PASS
+Test 104 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_2threads_dyn32_phy32
-Checking test 110 rap_2threads_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_2threads_dyn32_phy32
+Checking test 105 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3391,15 +3385,15 @@ Checking test 110 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 747.394112
-The maximum resident set size (KB)                   = 808080
+The total amount of wall time                        = 745.258740
+The maximum resident set size (KB)                   = 813644
 
-Test 110 rap_2threads_dyn32_phy32 PASS
+Test 105 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_2threads_dyn32_phy32
-Checking test 111 hrrr_control_2threads_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_2threads_dyn32_phy32
+Checking test 106 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3445,15 +3439,15 @@ Checking test 111 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 380.143933
-The maximum resident set size (KB)                   = 812244
+The total amount of wall time                        = 380.476867
+The maximum resident set size (KB)                   = 811352
 
-Test 111 hrrr_control_2threads_dyn32_phy32 PASS
+Test 106 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_decomp_dyn32_phy32
-Checking test 112 hrrr_control_decomp_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_decomp_dyn32_phy32
+Checking test 107 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3499,15 +3493,15 @@ Checking test 112 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.173965
-The maximum resident set size (KB)                   = 771332
+The total amount of wall time                        = 179.189977
+The maximum resident set size (KB)                   = 768788
 
-Test 112 hrrr_control_decomp_dyn32_phy32 PASS
+Test 107 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_restart_dyn32_phy32
-Checking test 113 rap_restart_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_restart_dyn32_phy32
+Checking test 108 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3545,15 +3539,15 @@ Checking test 113 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 238.010260
-The maximum resident set size (KB)                   = 606676
+The total amount of wall time                        = 239.156312
+The maximum resident set size (KB)                   = 600444
 
-Test 113 rap_restart_dyn32_phy32 PASS
+Test 108 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_restart_dyn32_phy32
-Checking test 114 hrrr_control_restart_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_restart_dyn32_phy32
+Checking test 109 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3591,15 +3585,15 @@ Checking test 114 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 86.306976
-The maximum resident set size (KB)                   = 597188
+The total amount of wall time                        = 87.878753
+The maximum resident set size (KB)                   = 595748
 
-Test 114 hrrr_control_restart_dyn32_phy32 PASS
+Test 109 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_control_dyn64_phy32
-Checking test 115 rap_control_dyn64_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_control_dyn64_phy32
+Checking test 110 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3645,82 +3639,82 @@ Checking test 115 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 221.935122
-The maximum resident set size (KB)                   = 793564
+The total amount of wall time                        = 221.696212
+The maximum resident set size (KB)                   = 790896
 
-Test 115 rap_control_dyn64_phy32 PASS
+Test 110 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_control_debug_dyn32_phy32
-Checking test 116 rap_control_debug_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_control_debug_dyn32_phy32
+Checking test 111 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.663936
-The maximum resident set size (KB)                   = 933528
+The total amount of wall time                        = 289.458210
+The maximum resident set size (KB)                   = 932124
 
-Test 116 rap_control_debug_dyn32_phy32 PASS
+Test 111 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hrrr_control_debug_dyn32_phy32
-Checking test 117 hrrr_control_debug_dyn32_phy32 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hrrr_control_debug_dyn32_phy32
+Checking test 112 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 284.451423
-The maximum resident set size (KB)                   = 933640
+The total amount of wall time                        = 284.283223
+The maximum resident set size (KB)                   = 934624
 
-Test 117 hrrr_control_debug_dyn32_phy32 PASS
+Test 112 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/rap_control_dyn64_phy32_debug
-Checking test 118 rap_control_dyn64_phy32_debug results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/rap_control_dyn64_phy32_debug
+Checking test 113 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.500369
-The maximum resident set size (KB)                   = 952924
+The total amount of wall time                        = 290.020775
+The maximum resident set size (KB)                   = 952100
 
-Test 118 rap_control_dyn64_phy32_debug PASS
+Test 113 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_atm
-Checking test 119 hafs_regional_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_atm
+Checking test 114 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 507.501017
-The maximum resident set size (KB)                   = 775788
+The total amount of wall time                        = 506.804154
+The maximum resident set size (KB)                   = 779712
 
-Test 119 hafs_regional_atm PASS
+Test 114 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_atm_thompson_gfdlsf
-Checking test 120 hafs_regional_atm_thompson_gfdlsf results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_atm_thompson_gfdlsf
+Checking test 115 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 591.063331
-The maximum resident set size (KB)                   = 1140456
+The total amount of wall time                        = 587.400969
+The maximum resident set size (KB)                   = 1143156
 
-Test 120 hafs_regional_atm_thompson_gfdlsf PASS
+Test 115 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_atm_ocn
-Checking test 121 hafs_regional_atm_ocn results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_atm_ocn
+Checking test 116 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -3728,15 +3722,15 @@ Checking test 121 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 427.881662
-The maximum resident set size (KB)                   = 833288
+The total amount of wall time                        = 424.758426
+The maximum resident set size (KB)                   = 834256
 
-Test 121 hafs_regional_atm_ocn PASS
+Test 116 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_atm_wav
-Checking test 122 hafs_regional_atm_wav results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_atm_wav
+Checking test 117 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
@@ -3744,15 +3738,15 @@ Checking test 122 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 692.393104
-The maximum resident set size (KB)                   = 859384
+The total amount of wall time                        = 692.035927
+The maximum resident set size (KB)                   = 865344
 
-Test 122 hafs_regional_atm_wav PASS
+Test 117 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_atm_ocn_wav
-Checking test 123 hafs_regional_atm_ocn_wav results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_atm_ocn_wav
+Checking test 118 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -3762,29 +3756,29 @@ Checking test 123 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 881.614622
-The maximum resident set size (KB)                   = 888024
+The total amount of wall time                        = 881.469123
+The maximum resident set size (KB)                   = 888452
 
-Test 123 hafs_regional_atm_ocn_wav PASS
+Test 118 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_1nest_atm
-Checking test 124 hafs_regional_1nest_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_1nest_atm
+Checking test 119 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 858.464325
-The maximum resident set size (KB)                   = 373764
+The total amount of wall time                        = 857.303620
+The maximum resident set size (KB)                   = 374848
 
-Test 124 hafs_regional_1nest_atm PASS
+Test 119 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_telescopic_2nests_atm
-Checking test 125 hafs_regional_telescopic_2nests_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_telescopic_2nests_atm
+Checking test 120 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -3792,29 +3786,29 @@ Checking test 125 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 932.583407
-The maximum resident set size (KB)                   = 383188
+The total amount of wall time                        = 928.013394
+The maximum resident set size (KB)                   = 381612
 
-Test 125 hafs_regional_telescopic_2nests_atm PASS
+Test 120 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_global_1nest_atm
-Checking test 126 hafs_global_1nest_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_global_1nest_atm
+Checking test 121 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 396.574010
-The maximum resident set size (KB)                   = 269480
+The total amount of wall time                        = 395.524460
+The maximum resident set size (KB)                   = 323272
 
-Test 126 hafs_global_1nest_atm PASS
+Test 121 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_global_multiple_4nests_atm
-Checking test 127 hafs_global_multiple_4nests_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_global_multiple_4nests_atm
+Checking test 122 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -3831,15 +3825,15 @@ Checking test 127 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 1062.454035
-The maximum resident set size (KB)                   = 327440
+The total amount of wall time                        = 1060.900253
+The maximum resident set size (KB)                   = 306484
 
-Test 127 hafs_global_multiple_4nests_atm PASS
+Test 122 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_specified_moving_1nest_atm
-Checking test 128 hafs_regional_specified_moving_1nest_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_specified_moving_1nest_atm
+Checking test 123 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -3847,29 +3841,29 @@ Checking test 128 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 501.100449
-The maximum resident set size (KB)                   = 380956
+The total amount of wall time                        = 498.356518
+The maximum resident set size (KB)                   = 378836
 
-Test 128 hafs_regional_specified_moving_1nest_atm PASS
+Test 123 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_storm_following_1nest_atm
-Checking test 129 hafs_regional_storm_following_1nest_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_storm_following_1nest_atm
+Checking test 124 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 479.430963
-The maximum resident set size (KB)                   = 377988
+The total amount of wall time                        = 480.178544
+The maximum resident set size (KB)                   = 378820
 
-Test 129 hafs_regional_storm_following_1nest_atm PASS
+Test 124 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_storm_following_1nest_atm_ocn
-Checking test 130 hafs_regional_storm_following_1nest_atm_ocn results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_storm_following_1nest_atm_ocn
+Checking test 125 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -3877,15 +3871,15 @@ Checking test 130 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 497.301027
-The maximum resident set size (KB)                   = 412852
+The total amount of wall time                        = 496.496374
+The maximum resident set size (KB)                   = 411852
 
-Test 130 hafs_regional_storm_following_1nest_atm_ocn PASS
+Test 125 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_storm_following_1nest_atm_ocn_wav
-Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_storm_following_1nest_atm_ocn_wav
+Checking test 126 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -3895,176 +3889,176 @@ Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 1090.341865
-The maximum resident set size (KB)                   = 472316
+The total amount of wall time                        = 1088.647971
+The maximum resident set size (KB)                   = 468144
 
-Test 131 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
+Test 126 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_global_storm_following_1nest_atm
-Checking test 132 hafs_global_storm_following_1nest_atm results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_global_storm_following_1nest_atm
+Checking test 127 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 145.297471
-The maximum resident set size (KB)                   = 257136
+The total amount of wall time                        = 146.847244
+The maximum resident set size (KB)                   = 269840
 
-Test 132 hafs_global_storm_following_1nest_atm PASS
+Test 127 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_docn
-Checking test 133 hafs_regional_docn results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_docn
+Checking test 128 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 392.726828
-The maximum resident set size (KB)                   = 832132
+The total amount of wall time                        = 388.529474
+The maximum resident set size (KB)                   = 840500
 
-Test 133 hafs_regional_docn PASS
+Test 128 hafs_regional_docn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_docn_oisst
-Checking test 134 hafs_regional_docn_oisst results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_docn_oisst
+Checking test 129 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 391.647106
-The maximum resident set size (KB)                   = 826348
+The total amount of wall time                        = 389.027053
+The maximum resident set size (KB)                   = 817624
 
-Test 134 hafs_regional_docn_oisst PASS
+Test 129 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/hafs_regional_datm_cdeps
-Checking test 135 hafs_regional_datm_cdeps results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/hafs_regional_datm_cdeps
+Checking test 130 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 1177.462510
-The maximum resident set size (KB)                   = 871092
+The total amount of wall time                        = 1172.737529
+The maximum resident set size (KB)                   = 837720
 
-Test 135 hafs_regional_datm_cdeps PASS
+Test 130 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_control_cfsr
-Checking test 136 datm_cdeps_control_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_control_cfsr
+Checking test 131 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.374160
-The maximum resident set size (KB)                   = 730888
+The total amount of wall time                        = 143.761042
+The maximum resident set size (KB)                   = 732304
 
-Test 136 datm_cdeps_control_cfsr PASS
+Test 131 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_restart_cfsr
-Checking test 137 datm_cdeps_restart_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_restart_cfsr
+Checking test 132 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 88.718419
-The maximum resident set size (KB)                   = 727972
+The total amount of wall time                        = 90.035315
+The maximum resident set size (KB)                   = 728724
 
-Test 137 datm_cdeps_restart_cfsr PASS
+Test 132 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_control_gefs
-Checking test 138 datm_cdeps_control_gefs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_control_gefs
+Checking test 133 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 135.547282
-The maximum resident set size (KB)                   = 610292
+The total amount of wall time                        = 135.140473
+The maximum resident set size (KB)                   = 618156
 
-Test 138 datm_cdeps_control_gefs PASS
+Test 133 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_iau_gefs
-Checking test 139 datm_cdeps_iau_gefs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_iau_gefs
+Checking test 134 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 137.826969
-The maximum resident set size (KB)                   = 612952
+The total amount of wall time                        = 138.458353
+The maximum resident set size (KB)                   = 612600
 
-Test 139 datm_cdeps_iau_gefs PASS
+Test 134 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_stochy_gefs
-Checking test 140 datm_cdeps_stochy_gefs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_stochy_gefs
+Checking test 135 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 138.778044
-The maximum resident set size (KB)                   = 612096
+The total amount of wall time                        = 139.126130
+The maximum resident set size (KB)                   = 615680
 
-Test 140 datm_cdeps_stochy_gefs PASS
+Test 135 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_ciceC_cfsr
-Checking test 141 datm_cdeps_ciceC_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_ciceC_cfsr
+Checking test 136 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.689676
-The maximum resident set size (KB)                   = 732436
+The total amount of wall time                        = 143.252146
+The maximum resident set size (KB)                   = 731164
 
-Test 141 datm_cdeps_ciceC_cfsr PASS
+Test 136 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_bulk_cfsr
-Checking test 142 datm_cdeps_bulk_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_bulk_cfsr
+Checking test 137 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.697896
-The maximum resident set size (KB)                   = 730944
+The total amount of wall time                        = 144.233329
+The maximum resident set size (KB)                   = 730916
 
-Test 142 datm_cdeps_bulk_cfsr PASS
+Test 137 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_bulk_gefs
-Checking test 143 datm_cdeps_bulk_gefs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_bulk_gefs
+Checking test 138 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 135.247467
-The maximum resident set size (KB)                   = 611248
+The total amount of wall time                        = 136.061011
+The maximum resident set size (KB)                   = 612604
 
-Test 143 datm_cdeps_bulk_gefs PASS
+Test 138 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_mx025_cfsr
-Checking test 144 datm_cdeps_mx025_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_mx025_cfsr
+Checking test 139 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -4072,15 +4066,15 @@ Checking test 144 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 442.714769
-The maximum resident set size (KB)                   = 571420
+The total amount of wall time                        = 440.841521
+The maximum resident set size (KB)                   = 570364
 
-Test 144 datm_cdeps_mx025_cfsr PASS
+Test 139 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_mx025_gefs
-Checking test 145 datm_cdeps_mx025_gefs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_mx025_gefs
+Checking test 140 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -4088,52 +4082,52 @@ Checking test 145 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 448.035009
-The maximum resident set size (KB)                   = 546988
+The total amount of wall time                        = 447.122920
+The maximum resident set size (KB)                   = 547296
 
-Test 145 datm_cdeps_mx025_gefs PASS
+Test 140 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_multiple_files_cfsr
-Checking test 146 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_multiple_files_cfsr
+Checking test 141 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.074761
-The maximum resident set size (KB)                   = 721160
+The total amount of wall time                        = 143.525103
+The maximum resident set size (KB)                   = 733300
 
-Test 146 datm_cdeps_multiple_files_cfsr PASS
+Test 141 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_3072x1536_cfsr
-Checking test 147 datm_cdeps_3072x1536_cfsr results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_3072x1536_cfsr
+Checking test 142 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 266.458232
-The maximum resident set size (KB)                   = 1981632
+The total amount of wall time                        = 256.912589
+The maximum resident set size (KB)                   = 1980628
 
-Test 147 datm_cdeps_3072x1536_cfsr PASS
+Test 142 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_gfs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_gfs
-Checking test 148 datm_cdeps_gfs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_gfs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_gfs
+Checking test 143 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 256.838167
-The maximum resident set size (KB)                   = 1976840
+The total amount of wall time                        = 258.432102
+The maximum resident set size (KB)                   = 1979280
 
-Test 148 datm_cdeps_gfs PASS
+Test 143 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_lnd_gswp3
-Checking test 149 datm_cdeps_lnd_gswp3 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_lnd_gswp3
+Checking test 144 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4141,15 +4135,15 @@ Checking test 149 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 24.787390
-The maximum resident set size (KB)                   = 269492
+The total amount of wall time                        = 22.359306
+The maximum resident set size (KB)                   = 323284
 
-Test 149 datm_cdeps_lnd_gswp3 PASS
+Test 144 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/datm_cdeps_lnd_gswp3_rst
-Checking test 150 datm_cdeps_lnd_gswp3_rst results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/datm_cdeps_lnd_gswp3_rst
+Checking test 145 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4157,15 +4151,15 @@ Checking test 150 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 27.911372
-The maximum resident set size (KB)                   = 269484
+The total amount of wall time                        = 28.608622
+The maximum resident set size (KB)                   = 335492
 
-Test 150 datm_cdeps_lnd_gswp3_rst PASS
+Test 145 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_p8_atmlnd_sbs
-Checking test 151 control_p8_atmlnd_sbs results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_p8_atmlnd_sbs
+Checking test 146 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4249,15 +4243,15 @@ Checking test 151 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 225.786582
-The maximum resident set size (KB)                   = 1536032
+The total amount of wall time                        = 228.919345
+The maximum resident set size (KB)                   = 1547584
 
-Test 151 control_p8_atmlnd_sbs PASS
+Test 146 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_atmwav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/control_atmwav
-Checking test 152 control_atmwav results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_atmwav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/control_atmwav
+Checking test 147 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4300,15 +4294,15 @@ Checking test 152 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 88.316735
-The maximum resident set size (KB)                   = 539660
+The total amount of wall time                        = 87.935782
+The maximum resident set size (KB)                   = 537216
 
-Test 152 control_atmwav PASS
+Test 147 control_atmwav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/atmaero_control_p8
-Checking test 153 atmaero_control_p8 results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/atmaero_control_p8
+Checking test 148 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4351,15 +4345,15 @@ Checking test 153 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 238.195706
-The maximum resident set size (KB)                   = 2814884
+The total amount of wall time                        = 237.032786
+The maximum resident set size (KB)                   = 2810948
 
-Test 153 atmaero_control_p8 PASS
+Test 148 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/atmaero_control_p8_rad
-Checking test 154 atmaero_control_p8_rad results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/atmaero_control_p8_rad
+Checking test 149 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4402,15 +4396,15 @@ Checking test 154 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 279.292584
-The maximum resident set size (KB)                   = 2877328
+The total amount of wall time                        = 279.318980
+The maximum resident set size (KB)                   = 2877012
 
-Test 154 atmaero_control_p8_rad PASS
+Test 149 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/atmaero_control_p8_rad_micro
-Checking test 155 atmaero_control_p8_rad_micro results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/atmaero_control_p8_rad_micro
+Checking test 150 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4453,15 +4447,15 @@ Checking test 155 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 285.168702
-The maximum resident set size (KB)                   = 2886428
+The total amount of wall time                        = 284.612770
+The maximum resident set size (KB)                   = 2886140
 
-Test 155 atmaero_control_p8_rad_micro PASS
+Test 150 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171542/regional_atmaq
-Checking test 156 regional_atmaq results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_199167/regional_atmaq
+Checking test 151 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4476,16 +4470,10 @@ Checking test 156 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 731.236288
-The maximum resident set size (KB)                   = 1033504
+The total amount of wall time                        = 737.357630
+The maximum resident set size (KB)                   = 1034444
 
-Test 156 regional_atmaq PASS
+Test 151 regional_atmaq PASS
 
-FAILED TESTS: 
-Test cpld_control_c192_p8 008 failed in run_test failed 
-Test cpld_bmark_p8 010 failed in run_test failed 
-Test cpld_bmark_esmfthreads_p8 012 failed in run_test failed 
 
-REGRESSION TEST FAILED
-Wed Nov  2 23:50:23 UTC 2022
-Elapsed time: 07h:05m:41s. Have a nice day!
+REGRESSION TEST WAS SUCCESSFUL

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,21 +1,21 @@
-Wed Nov  2 14:12:57 MDT 2022
+Mon Nov  7 20:06:00 MST 2022
 Start Regression test
 
-Compile 001 elapsed time 389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 407 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 822 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 198 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 378 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1057 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 826 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 820 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 609 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 570 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 366 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 302 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 390 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 412 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 836 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 204 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1063 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 842 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 840 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 621 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 580 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 361 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 304 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -62,14 +62,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 276.867060
-0:The maximum resident set size (KB)                   = 434988
+0:The total amount of wall time                        = 270.443438
+0:The maximum resident set size (KB)                   = 435056
 
 Test 001 control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -108,14 +108,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 138.764386
-0:The maximum resident set size (KB)                   = 184856
+0:The total amount of wall time                        = 140.261920
+0:The maximum resident set size (KB)                   = 185348
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_c48
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_c48
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -154,14 +154,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 816.861672
-0:The maximum resident set size (KB)                   = 676684
+0:The total amount of wall time                        = 817.371131
+0:The maximum resident set size (KB)                   = 676676
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -172,14 +172,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 176.629415
-0:The maximum resident set size (KB)                   = 429788
+0:The total amount of wall time                        = 177.055246
+0:The maximum resident set size (KB)                   = 429264
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_ras
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_ras
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_ras
 Checking test 005 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -190,14 +190,14 @@ Checking test 005 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 289.512777
-0:The maximum resident set size (KB)                   = 448140
+0:The total amount of wall time                        = 291.913969
+0:The maximum resident set size (KB)                   = 448268
 
 Test 005 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_p8
 Checking test 006 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -244,14 +244,14 @@ Checking test 006 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 308.464828
-0:The maximum resident set size (KB)                   = 1222300
+0:The total amount of wall time                        = 308.063717
+0:The maximum resident set size (KB)                   = 1222248
 
 Test 006 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_control
 Checking test 007 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -298,14 +298,14 @@ Checking test 007 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 711.209886
-0:The maximum resident set size (KB)                   = 776016
+0:The total amount of wall time                        = 708.958698
+0:The maximum resident set size (KB)                   = 776156
 
 Test 007 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_decomp
 Checking test 008 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 718.570499
-0:The maximum resident set size (KB)                   = 775476
+0:The total amount of wall time                        = 715.765714
+0:The maximum resident set size (KB)                   = 775668
 
 Test 008 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_2threads
 Checking test 009 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1249.837592
-0:The maximum resident set size (KB)                   = 843136
+0:The total amount of wall time                        = 1245.118629
+0:The maximum resident set size (KB)                   = 843140
 
 Test 009 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_restart
 Checking test 010 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -452,14 +452,14 @@ Checking test 010 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.373982
-0:The maximum resident set size (KB)                   = 524596
+0:The total amount of wall time                        = 355.291140
+0:The maximum resident set size (KB)                   = 523852
 
 Test 010 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_sfcdiff
 Checking test 011 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 702.481376
-0:The maximum resident set size (KB)                   = 776044
+0:The total amount of wall time                        = 706.250327
+0:The maximum resident set size (KB)                   = 776060
 
 Test 011 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_sfcdiff_decomp
 Checking test 012 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 715.210228
-0:The maximum resident set size (KB)                   = 775412
+0:The total amount of wall time                        = 711.194943
+0:The maximum resident set size (KB)                   = 775532
 
 Test 012 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_sfcdiff_restart
 Checking test 013 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -606,14 +606,14 @@ Checking test 013 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 527.006221
-0:The maximum resident set size (KB)                   = 523280
+0:The total amount of wall time                        = 524.475654
+0:The maximum resident set size (KB)                   = 523380
 
 Test 013 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control
 Checking test 014 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -660,14 +660,14 @@ Checking test 014 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 676.906580
-0:The maximum resident set size (KB)                   = 773464
+0:The total amount of wall time                        = 680.800332
+0:The maximum resident set size (KB)                   = 773516
 
 Test 014 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_2threads
 Checking test 015 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1183.171903
-0:The maximum resident set size (KB)                   = 838032
+0:The total amount of wall time                        = 1183.188085
+0:The maximum resident set size (KB)                   = 838128
 
 Test 015 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_decomp
 Checking test 016 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 677.265661
-0:The maximum resident set size (KB)                   = 773024
+0:The total amount of wall time                        = 672.457973
+0:The maximum resident set size (KB)                   = 773036
 
 Test 016 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_restart
 Checking test 017 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -814,14 +814,14 @@ Checking test 017 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 510.067636
-0:The maximum resident set size (KB)                   = 519232
+0:The total amount of wall time                        = 507.578819
+0:The maximum resident set size (KB)                   = 519292
 
 Test 017 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_v1beta
 Checking test 018 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -868,14 +868,14 @@ Checking test 018 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 688.141655
-0:The maximum resident set size (KB)                   = 773136
+0:The total amount of wall time                        = 689.788038
+0:The maximum resident set size (KB)                   = 773292
 
 Test 018 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_conus13km_hrrr_warm
 Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -884,14 +884,14 @@ Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 203.524342
+0:The total amount of wall time                        = 203.599150
 0:The maximum resident set size (KB)                   = 593556
 
 Test 019 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_smoke_conus13km_hrrr_warm
 Checking test 020 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -900,14 +900,14 @@ Checking test 020 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 220.033114
-0:The maximum resident set size (KB)                   = 607488
+0:The total amount of wall time                        = 221.358168
+0:The maximum resident set size (KB)                   = 607800
 
 Test 020 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_conus13km_radar_tten_warm
 Checking test 021 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -916,14 +916,14 @@ Checking test 021 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 203.441220
-0:The maximum resident set size (KB)                   = 596352
+0:The total amount of wall time                        = 204.746393
+0:The maximum resident set size (KB)                   = 596756
 
 Test 021 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 022 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -932,222 +932,222 @@ Checking test 022 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 204.815876
-0:The maximum resident set size (KB)                   = 600040
+0:The total amount of wall time                        = 204.400287
+0:The maximum resident set size (KB)                   = 600116
 
 Test 022 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_debug
 Checking test 023 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.185755
-0:The maximum resident set size (KB)                   = 426080
+0:The total amount of wall time                        = 85.125615
+0:The maximum resident set size (KB)                   = 426560
 
 Test 023 control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_diag_debug
 Checking test 024 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 88.365777
-0:The maximum resident set size (KB)                   = 483356
+0:The total amount of wall time                        = 89.024384
+0:The maximum resident set size (KB)                   = 483240
 
 Test 024 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/fv3_regional_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/fv3_regional_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/regional_debug
 Checking test 025 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 131.832863
-0:The maximum resident set size (KB)                   = 537280
+0:The total amount of wall time                        = 131.931761
+0:The maximum resident set size (KB)                   = 537260
 
 Test 025 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_control_debug
 Checking test 026 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 148.355152
-0:The maximum resident set size (KB)                   = 798576
+0:The total amount of wall time                        = 149.589505
+0:The maximum resident set size (KB)                   = 798568
 
 Test 026 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_debug
 Checking test 027 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.704931
-0:The maximum resident set size (KB)                   = 793240
+0:The total amount of wall time                        = 148.129873
+0:The maximum resident set size (KB)                   = 793284
 
 Test 027 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_diag_debug
 Checking test 028 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 162.016167
-0:The maximum resident set size (KB)                   = 882132
+0:The total amount of wall time                        = 158.005484
+0:The maximum resident set size (KB)                   = 882176
 
 Test 028 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 029 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 241.324248
-0:The maximum resident set size (KB)                   = 797132
+0:The total amount of wall time                        = 238.626150
+0:The maximum resident set size (KB)                   = 797096
 
 Test 029 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_progcld_thompson_debug
 Checking test 030 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 149.929239
-0:The maximum resident set size (KB)                   = 798600
+0:The total amount of wall time                        = 148.620716
+0:The maximum resident set size (KB)                   = 798544
 
 Test 030 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_v1beta_debug
 Checking test 031 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 150.863946
-0:The maximum resident set size (KB)                   = 792868
+0:The total amount of wall time                        = 147.204705
+0:The maximum resident set size (KB)                   = 793028
 
 Test 031 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_ras_debug
 Checking test 032 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.655871
-0:The maximum resident set size (KB)                   = 436932
+0:The total amount of wall time                        = 84.112344
+0:The maximum resident set size (KB)                   = 435900
 
 Test 032 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_stochy_debug
 Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.829801
-0:The maximum resident set size (KB)                   = 430428
+0:The total amount of wall time                        = 92.477044
+0:The maximum resident set size (KB)                   = 430416
 
 Test 033 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_debug_p8
 Checking test 034 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 94.703765
-0:The maximum resident set size (KB)                   = 1213788
+0:The total amount of wall time                        = 95.287537
+0:The maximum resident set size (KB)                   = 1213752
 
 Test 034 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_conus13km_hrrr_warm_debug
 Checking test 035 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 388.169526
-0:The maximum resident set size (KB)                   = 601188
+0:The total amount of wall time                        = 385.275405
+0:The maximum resident set size (KB)                   = 601196
 
 Test 035 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rrfs_conus13km_radar_tten_warm_debug
 Checking test 036 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 390.621664
-0:The maximum resident set size (KB)                   = 604312
+0:The total amount of wall time                        = 386.072270
+0:The maximum resident set size (KB)                   = 604276
 
 Test 036 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/control_wam_debug
 Checking test 037 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 144.478153
-0:The maximum resident set size (KB)                   = 172788
+0:The total amount of wall time                        = 143.948087
+0:The maximum resident set size (KB)                   = 172812
 
 Test 037 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_control_dyn32_phy32
 Checking test 038 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 038 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 678.847949
-0:The maximum resident set size (KB)                   = 661524
+0:The total amount of wall time                        = 676.886063
+0:The maximum resident set size (KB)                   = 662036
 
 Test 038 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_dyn32_phy32
 Checking test 039 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 039 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 345.924379
-0:The maximum resident set size (KB)                   = 660048
+0:The total amount of wall time                        = 345.318634
+0:The maximum resident set size (KB)                   = 660132
 
 Test 039 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_2threads_dyn32_phy32
 Checking test 040 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 040 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1190.942874
-0:The maximum resident set size (KB)                   = 702020
+0:The total amount of wall time                        = 1191.831946
+0:The maximum resident set size (KB)                   = 702272
 
 Test 040 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_2threads_dyn32_phy32
 Checking test 041 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 041 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 585.819264
-0:The maximum resident set size (KB)                   = 699368
+0:The total amount of wall time                        = 582.616062
+0:The maximum resident set size (KB)                   = 699328
 
 Test 041 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_decomp_dyn32_phy32
 Checking test 042 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 042 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 344.237434
-0:The maximum resident set size (KB)                   = 659504
+0:The total amount of wall time                        = 344.579896
+0:The maximum resident set size (KB)                   = 659472
 
 Test 042 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_restart_dyn32_phy32
 Checking test 043 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1456,14 +1456,14 @@ Checking test 043 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 510.680869
-0:The maximum resident set size (KB)                   = 499476
+0:The total amount of wall time                        = 508.614351
+0:The maximum resident set size (KB)                   = 499408
 
 Test 043 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_restart_dyn32_phy32
 Checking test 044 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1502,14 +1502,14 @@ Checking test 044 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 175.925023
-0:The maximum resident set size (KB)                   = 497068
+0:The total amount of wall time                        = 175.187014
+0:The maximum resident set size (KB)                   = 497172
 
 Test 044 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_control_dyn64_phy32
 Checking test 045 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1556,56 +1556,56 @@ Checking test 045 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 402.636341
-0:The maximum resident set size (KB)                   = 681700
+0:The total amount of wall time                        = 395.898191
+0:The maximum resident set size (KB)                   = 681732
 
 Test 045 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_control_debug_dyn32_phy32
 Checking test 046 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.979172
-0:The maximum resident set size (KB)                   = 679056
+0:The total amount of wall time                        = 145.814460
+0:The maximum resident set size (KB)                   = 679096
 
 Test 046 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/hrrr_control_debug_dyn32_phy32
 Checking test 047 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.968681
-0:The maximum resident set size (KB)                   = 676084
+0:The total amount of wall time                        = 142.750601
+0:The maximum resident set size (KB)                   = 676056
 
 Test 047 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/rap_control_dyn64_phy32_debug
 Checking test 048 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 151.391088
-0:The maximum resident set size (KB)                   = 698744
+0:The total amount of wall time                        = 151.452341
+0:The maximum resident set size (KB)                   = 698768
 
 Test 048 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/cpld_control_p8
 Checking test 049 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1670,14 +1670,14 @@ Checking test 049 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 495.398667
-0:The maximum resident set size (KB)                   = 3141732
+0:The total amount of wall time                        = 498.157057
+0:The maximum resident set size (KB)                   = 3142460
 
 Test 049 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/cpld_control_nowave_noaero_p8
 Checking test 050 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1739,14 +1739,14 @@ Checking test 050 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 241.771656
-0:The maximum resident set size (KB)                   = 1227784
+0:The total amount of wall time                        = 245.564636
+0:The maximum resident set size (KB)                   = 1225520
 
 Test 050 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/cpld_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/cpld_debug_p8
 Checking test 051 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1799,25 +1799,25 @@ Checking test 051 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 279.339756
-0:The maximum resident set size (KB)                   = 3159064
+0:The total amount of wall time                        = 278.638788
+0:The maximum resident set size (KB)                   = 3159540
 
 Test 051 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-gnu/jongkim/FV3_RT/rt_12693/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/GNU/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-gnu/jongkim/FV3_RT/rt_17401/datm_cdeps_control_cfsr
 Checking test 052 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 181.969642
-0:The maximum resident set size (KB)                   = 686448
+0:The total amount of wall time                        = 179.083029
+0:The maximum resident set size (KB)                   = 685752
 
 Test 052 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 14:47:00 MDT 2022
-Elapsed time: 00h:34m:04s. Have a nice day!
+Mon Nov  7 20:41:52 MST 2022
+Elapsed time: 00h:35m:53s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,34 +1,34 @@
-Wed Nov  2 12:26:17 MDT 2022
+Mon Nov  7 20:05:43 MST 2022
 Start Regression test
 
-Compile 001 elapsed time 1257 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1121 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 451 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 384 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 826 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 825 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 747 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 770 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 685 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 573 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1313 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 241 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 572 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1277 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1149 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 457 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 403 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 847 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 852 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 756 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 781 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 696 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 572 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 1327 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 253 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 570 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 014 elapsed time 571 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 249 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 255 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 912 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 871 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 438 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 200 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 106 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 731 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 798 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 649 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 633 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 250 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 253 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 915 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 868 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 439 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 208 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 108 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 717 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 806 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 631 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 632 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 321.386186
-0:The maximum resident set size (KB)                   = 2718968
+0:The total amount of wall time                        = 321.178592
+0:The maximum resident set size (KB)                   = 2719036
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -153,14 +153,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 188.772901
-0:The maximum resident set size (KB)                   = 2580940
+0:The total amount of wall time                        = 186.259949
+0:The maximum resident set size (KB)                   = 2581064
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -213,14 +213,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 544.050703
-0:The maximum resident set size (KB)                   = 3165152
+0:The total amount of wall time                        = 542.189146
+0:The maximum resident set size (KB)                   = 3164980
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_esmfthreads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 258.478883
-0:The maximum resident set size (KB)                   = 2886524
+0:The total amount of wall time                        = 248.413033
+0:The maximum resident set size (KB)                   = 2886028
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 319.666821
-0:The maximum resident set size (KB)                   = 2723648
+0:The total amount of wall time                        = 313.667199
+0:The maximum resident set size (KB)                   = 2723668
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_mpi_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 270.960887
-0:The maximum resident set size (KB)                   = 2686916
+0:The total amount of wall time                        = 273.023847
+0:The maximum resident set size (KB)                   = 2687156
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_ciceC_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_ciceC_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_ciceC_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 321.050219
-0:The maximum resident set size (KB)                   = 2718896
+0:The total amount of wall time                        = 322.709562
+0:The maximum resident set size (KB)                   = 2719136
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -525,14 +525,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1296.486983
-0:The maximum resident set size (KB)                   = 3023200
+0:The total amount of wall time                        = 1291.965687
+0:The maximum resident set size (KB)                   = 3023504
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_restart_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -585,14 +585,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 694.262422
-0:The maximum resident set size (KB)                   = 2952808
+0:The total amount of wall time                        = 712.016384
+0:The maximum resident set size (KB)                   = 2953208
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_noaero_p8
 Checking test 010 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -656,14 +656,14 @@ Checking test 010 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 274.021512
-0:The maximum resident set size (KB)                   = 1440532
+0:The total amount of wall time                        = 271.444504
+0:The maximum resident set size (KB)                   = 1440404
 
 Test 010 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_nowave_noaero_p8
 Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -725,14 +725,14 @@ Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 189.647754
-0:The maximum resident set size (KB)                   = 1454884
+0:The total amount of wall time                        = 194.624108
+0:The maximum resident set size (KB)                   = 1454972
 
 Test 011 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -785,14 +785,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 480.502201
-0:The maximum resident set size (KB)                   = 2790692
+0:The total amount of wall time                        = 472.638944
+0:The maximum resident set size (KB)                   = 2790756
 
 Test 012 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_debug_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_debug_noaero_p8
 Checking test 013 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -844,14 +844,14 @@ Checking test 013 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 346.573671
-0:The maximum resident set size (KB)                   = 1464788
+0:The total amount of wall time                        = 345.518281
+0:The maximum resident set size (KB)                   = 1464648
 
 Test 013 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_noaero_p8_agrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_noaero_p8_agrid
 Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -913,14 +913,14 @@ Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 260.485392
-0:The maximum resident set size (KB)                   = 1458692
+0:The total amount of wall time                        = 255.782073
+0:The maximum resident set size (KB)                   = 1458728
 
 Test 014 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c48
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c48
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_control_c48
 Checking test 015 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -970,14 +970,14 @@ Checking test 015 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 607.982745
-0:The maximum resident set size (KB)                   = 2582904
+0:The total amount of wall time                        = 602.140712
+0:The maximum resident set size (KB)                   = 2583240
 
 Test 015 cpld_control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_warmstart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_warmstart_c48
 Checking test 016 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1027,14 +1027,14 @@ Checking test 016 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 161.327044
-0:The maximum resident set size (KB)                   = 2599668
+0:The total amount of wall time                        = 164.875251
+0:The maximum resident set size (KB)                   = 2599784
 
 Test 016 cpld_warmstart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/cpld_restart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/cpld_restart_c48
 Checking test 017 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1084,14 +1084,14 @@ Checking test 017 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 86.555936
-0:The maximum resident set size (KB)                   = 2016388
+0:The total amount of wall time                        = 84.286128
+0:The maximum resident set size (KB)                   = 2016488
 
 Test 017 cpld_restart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control
 Checking test 018 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1138,14 +1138,14 @@ Checking test 018 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 148.372236
-0:The maximum resident set size (KB)                   = 456312
+0:The total amount of wall time                        = 148.714466
+0:The maximum resident set size (KB)                   = 456316
 
 Test 018 control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_decomp
 Checking test 019 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1188,14 +1188,14 @@ Checking test 019 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 151.222049
-0:The maximum resident set size (KB)                   = 454404
+0:The total amount of wall time                        = 151.131155
+0:The maximum resident set size (KB)                   = 454316
 
 Test 019 control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_2dwrtdecomp
 Checking test 020 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1206,14 +1206,14 @@ Checking test 020 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.866081
-0:The maximum resident set size (KB)                   = 456812
+0:The total amount of wall time                        = 147.393659
+0:The maximum resident set size (KB)                   = 456852
 
 Test 020 control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_2threads
 Checking test 021 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,14 +1256,14 @@ Checking test 021 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 376.468221
-0:The maximum resident set size (KB)                   = 504092
+0:The total amount of wall time                        = 374.213729
+0:The maximum resident set size (KB)                   = 504472
 
 Test 021 control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_restart
 Checking test 022 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 022 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 77.207990
-0:The maximum resident set size (KB)                   = 196080
+0:The total amount of wall time                        = 75.560570
+0:The maximum resident set size (KB)                   = 196308
 
 Test 022 control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_fhzero
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_fhzero
 Checking test 023 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1352,14 +1352,14 @@ Checking test 023 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 140.552454
-0:The maximum resident set size (KB)                   = 456268
+0:The total amount of wall time                        = 134.883975
+0:The maximum resident set size (KB)                   = 456332
 
 Test 023 control_fhzero PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_CubedSphereGrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_CubedSphereGrid
 Checking test 024 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1386,28 +1386,28 @@ Checking test 024 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 143.238025
-0:The maximum resident set size (KB)                   = 455588
+0:The total amount of wall time                        = 143.119411
+0:The maximum resident set size (KB)                   = 455532
 
 Test 024 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_parallel
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_CubedSphereGrid_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_parallel
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_CubedSphereGrid_parallel
 Checking test 025 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 139.889962
-0:The maximum resident set size (KB)                   = 455588
+0:The total amount of wall time                        = 141.053039
+0:The maximum resident set size (KB)                   = 455284
 
 Test 025 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_latlon
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_latlon
 Checking test 026 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1418,32 +1418,32 @@ Checking test 026 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.229844
-0:The maximum resident set size (KB)                   = 456396
+0:The total amount of wall time                        = 145.836448
+0:The maximum resident set size (KB)                   = 456468
 
 Test 026 control_latlon PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_wrtGauss_netcdf_parallel
 Checking test 027 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.118669
-0:The maximum resident set size (KB)                   = 456284
+0:The total amount of wall time                        = 146.958786
+0:The maximum resident set size (KB)                   = 456268
 
 Test 027 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_c48
 Checking test 028 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1482,14 +1482,14 @@ Checking test 028 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 444.701836
-0:The maximum resident set size (KB)                   = 627952
+0:The total amount of wall time                        = 445.564866
+0:The maximum resident set size (KB)                   = 627992
 
 Test 028 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_c192
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_c192
 Checking test 029 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1500,14 +1500,14 @@ Checking test 029 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 601.860315
-0:The maximum resident set size (KB)                   = 560644
+0:The total amount of wall time                        = 578.526358
+0:The maximum resident set size (KB)                   = 560724
 
 Test 029 control_c192 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_c384
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_c384
 Checking test 030 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1518,14 +1518,14 @@ Checking test 030 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1299.511028
-0:The maximum resident set size (KB)                   = 837280
+0:The total amount of wall time                        = 1303.812852
+0:The maximum resident set size (KB)                   = 837124
 
 Test 030 control_c384 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_c384gdas
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_c384gdas
 Checking test 031 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1568,14 +1568,14 @@ Checking test 031 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1322.337599
-0:The maximum resident set size (KB)                   = 970332
+0:The total amount of wall time                        = 1313.872914
+0:The maximum resident set size (KB)                   = 970744
 
 Test 031 control_c384gdas PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_c384_progsigma
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_c384_progsigma
 Checking test 032 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1586,14 +1586,14 @@ Checking test 032 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1323.142473
-0:The maximum resident set size (KB)                   = 855520
+0:The total amount of wall time                        = 1339.988809
+0:The maximum resident set size (KB)                   = 855664
 
 Test 032 control_c384_progsigma PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_stochy
 Checking test 033 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1604,28 +1604,28 @@ Checking test 033 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 95.969712
-0:The maximum resident set size (KB)                   = 460180
+0:The total amount of wall time                        = 95.845788
+0:The maximum resident set size (KB)                   = 460216
 
 Test 033 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_stochy_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_stochy_restart
 Checking test 034 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 53.343938
-0:The maximum resident set size (KB)                   = 226576
+0:The total amount of wall time                        = 52.165977
+0:The maximum resident set size (KB)                   = 226556
 
 Test 034 control_stochy_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_lndp
 Checking test 035 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1636,14 +1636,14 @@ Checking test 035 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 90.766300
-0:The maximum resident set size (KB)                   = 460224
+0:The total amount of wall time                        = 91.042414
+0:The maximum resident set size (KB)                   = 460408
 
 Test 035 control_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_iovr4
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_iovr4
 Checking test 036 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1658,14 +1658,14 @@ Checking test 036 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.860973
-0:The maximum resident set size (KB)                   = 455912
+0:The total amount of wall time                        = 148.215106
+0:The maximum resident set size (KB)                   = 456388
 
 Test 036 control_iovr4 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_iovr5
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_iovr5
 Checking test 037 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1680,14 +1680,14 @@ Checking test 037 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 149.236852
-0:The maximum resident set size (KB)                   = 456260
+0:The total amount of wall time                        = 143.879562
+0:The maximum resident set size (KB)                   = 456220
 
 Test 037 control_iovr5 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_p8
 Checking test 038 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1734,14 +1734,14 @@ Checking test 038 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 180.273438
-0:The maximum resident set size (KB)                   = 1426172
+0:The total amount of wall time                        = 179.097524
+0:The maximum resident set size (KB)                   = 1426588
 
 Test 038 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_p8_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_p8_lndp
 Checking test 039 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1760,14 +1760,14 @@ Checking test 039 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 331.967589
-0:The maximum resident set size (KB)                   = 1426740
+0:The total amount of wall time                        = 326.403637
+0:The maximum resident set size (KB)                   = 1426768
 
 Test 039 control_p8_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_restart_p8
 Checking test 040 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1806,14 +1806,14 @@ Checking test 040 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 96.867125
-0:The maximum resident set size (KB)                   = 583008
+0:The total amount of wall time                        = 94.547012
+0:The maximum resident set size (KB)                   = 583040
 
 Test 040 control_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_decomp_p8
 Checking test 041 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1856,14 +1856,14 @@ Checking test 041 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 185.058131
-0:The maximum resident set size (KB)                   = 1420400
+0:The total amount of wall time                        = 184.203323
+0:The maximum resident set size (KB)                   = 1420384
 
 Test 041 control_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_2threads_p8
 Checking test 042 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1906,14 +1906,14 @@ Checking test 042 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 496.562275
-0:The maximum resident set size (KB)                   = 1502036
+0:The total amount of wall time                        = 494.015418
+0:The maximum resident set size (KB)                   = 1501840
 
 Test 042 control_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_p8_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_p8_rrtmgp
 Checking test 043 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1960,14 +1960,14 @@ Checking test 043 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 249.782727
-0:The maximum resident set size (KB)                   = 1541904
+0:The total amount of wall time                        = 247.477267
+0:The maximum resident set size (KB)                   = 1541968
 
 Test 043 control_p8_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/merra2_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/merra2_thompson
 Checking test 044 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2014,14 +2014,14 @@ Checking test 044 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 185.576501
-0:The maximum resident set size (KB)                   = 1432656
+0:The total amount of wall time                        = 185.166278
+0:The maximum resident set size (KB)                   = 1432692
 
 Test 044 merra2_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_control
 Checking test 045 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2032,28 +2032,28 @@ Checking test 045 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 368.855415
-0:The maximum resident set size (KB)                   = 566856
+0:The total amount of wall time                        = 373.679110
+0:The maximum resident set size (KB)                   = 566760
 
 Test 045 regional_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_restart
 Checking test 046 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 201.997416
-0:The maximum resident set size (KB)                   = 556816
+0:The total amount of wall time                        = 203.387670
+0:The maximum resident set size (KB)                   = 556840
 
 Test 046 regional_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_control_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_control_2dwrtdecomp
 Checking test 047 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2064,14 +2064,14 @@ Checking test 047 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 364.417370
-0:The maximum resident set size (KB)                   = 565620
+0:The total amount of wall time                        = 372.074751
+0:The maximum resident set size (KB)                   = 565656
 
 Test 047 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_noquilt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_noquilt
 Checking test 048 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2079,14 +2079,14 @@ Checking test 048 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 384.165736
-0:The maximum resident set size (KB)                   = 559100
+0:The total amount of wall time                        = 391.139744
+0:The maximum resident set size (KB)                   = 559132
 
 Test 048 regional_noquilt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_2threads
 Checking test 049 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2097,28 +2097,28 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 1108.615106
-0:The maximum resident set size (KB)                   = 559692
+0:The total amount of wall time                        = 1111.372132
+0:The maximum resident set size (KB)                   = 559628
 
 Test 049 regional_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_netcdf_parallel
 Checking test 050 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 369.663037
-0:The maximum resident set size (KB)                   = 557200
+0:The total amount of wall time                        = 363.000325
+0:The maximum resident set size (KB)                   = 557288
 
 Test 050 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_3km
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_3km
 Checking test 051 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2129,14 +2129,14 @@ Checking test 051 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 302.761003
-0:The maximum resident set size (KB)                   = 592568
+0:The total amount of wall time                        = 290.719030
+0:The maximum resident set size (KB)                   = 592632
 
 Test 051 regional_3km PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_3km_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_3km_decomp
 Checking test 052 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2147,14 +2147,14 @@ Checking test 052 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 317.554997
-0:The maximum resident set size (KB)                   = 602972
+0:The total amount of wall time                        = 318.261391
+0:The maximum resident set size (KB)                   = 603024
 
 Test 052 regional_3km_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_3km_wofs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_3km_wofs
 Checking test 053 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2165,14 +2165,14 @@ Checking test 053 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 400.104474
-0:The maximum resident set size (KB)                   = 274252
+0:The total amount of wall time                        = 391.449410
+0:The maximum resident set size (KB)                   = 274336
 
 Test 053 regional_3km_wofs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_control
 Checking test 054 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2219,14 +2219,14 @@ Checking test 054 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 461.515236
-0:The maximum resident set size (KB)                   = 825752
+0:The total amount of wall time                        = 461.864718
+0:The maximum resident set size (KB)                   = 825724
 
 Test 054 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_rrtmgp
 Checking test 055 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2273,14 +2273,14 @@ Checking test 055 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 525.342382
-0:The maximum resident set size (KB)                   = 951384
+0:The total amount of wall time                        = 519.412170
+0:The maximum resident set size (KB)                   = 951412
 
 Test 055 rap_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_spp_sppt_shum_skeb
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_spp_sppt_shum_skeb
 Checking test 056 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2291,14 +2291,14 @@ Checking test 056 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 709.535516
-0:The maximum resident set size (KB)                   = 933604
+0:The total amount of wall time                        = 703.318055
+0:The maximum resident set size (KB)                   = 933516
 
 Test 056 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_decomp
 Checking test 057 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2345,14 +2345,14 @@ Checking test 057 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 488.557614
-0:The maximum resident set size (KB)                   = 824948
+0:The total amount of wall time                        = 482.857011
+0:The maximum resident set size (KB)                   = 824892
 
 Test 057 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_2threads
 Checking test 058 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2399,14 +2399,14 @@ Checking test 058 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1096.638587
-0:The maximum resident set size (KB)                   = 884340
+0:The total amount of wall time                        = 1091.143758
+0:The maximum resident set size (KB)                   = 884256
 
 Test 058 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_restart
 Checking test 059 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2445,14 +2445,14 @@ Checking test 059 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 231.663611
-0:The maximum resident set size (KB)                   = 571984
+0:The total amount of wall time                        = 232.482869
+0:The maximum resident set size (KB)                   = 571820
 
 Test 059 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_sfcdiff
 Checking test 060 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2499,14 +2499,14 @@ Checking test 060 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 454.872282
-0:The maximum resident set size (KB)                   = 825460
+0:The total amount of wall time                        = 454.182620
+0:The maximum resident set size (KB)                   = 825468
 
 Test 060 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_sfcdiff_decomp
 Checking test 061 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2553,14 +2553,14 @@ Checking test 061 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 483.017076
-0:The maximum resident set size (KB)                   = 824960
+0:The total amount of wall time                        = 480.103775
+0:The maximum resident set size (KB)                   = 824984
 
 Test 061 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_sfcdiff_restart
 Checking test 062 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2599,14 +2599,14 @@ Checking test 062 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 343.196623
-0:The maximum resident set size (KB)                   = 571804
+0:The total amount of wall time                        = 341.954464
+0:The maximum resident set size (KB)                   = 572012
 
 Test 062 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control
 Checking test 063 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2653,14 +2653,14 @@ Checking test 063 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 435.505419
-0:The maximum resident set size (KB)                   = 822448
+0:The total amount of wall time                        = 437.413822
+0:The maximum resident set size (KB)                   = 822116
 
 Test 063 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_decomp
 Checking test 064 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2707,14 +2707,14 @@ Checking test 064 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 455.119279
-0:The maximum resident set size (KB)                   = 823984
+0:The total amount of wall time                        = 456.436014
+0:The maximum resident set size (KB)                   = 824024
 
 Test 064 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_2threads
 Checking test 065 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2761,14 +2761,14 @@ Checking test 065 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1040.912148
-0:The maximum resident set size (KB)                   = 878312
+0:The total amount of wall time                        = 1037.370358
+0:The maximum resident set size (KB)                   = 878332
 
 Test 065 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_restart
 Checking test 066 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2807,14 +2807,14 @@ Checking test 066 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 329.374582
-0:The maximum resident set size (KB)                   = 569032
+0:The total amount of wall time                        = 327.120111
+0:The maximum resident set size (KB)                   = 568996
 
 Test 066 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_v1beta
 Checking test 067 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2861,14 +2861,14 @@ Checking test 067 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 448.683573
-0:The maximum resident set size (KB)                   = 820912
+0:The total amount of wall time                        = 445.943347
+0:The maximum resident set size (KB)                   = 820888
 
 Test 067 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_v1nssl
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_v1nssl
 Checking test 068 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2883,14 +2883,14 @@ Checking test 068 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 555.327979
-0:The maximum resident set size (KB)                   = 509696
+0:The total amount of wall time                        = 554.248197
+0:The maximum resident set size (KB)                   = 509668
 
 Test 068 rrfs_v1nssl PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_v1nssl_nohailnoccn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_v1nssl_nohailnoccn
 Checking test 069 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2905,14 +2905,14 @@ Checking test 069 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 540.697920
-0:The maximum resident set size (KB)                   = 503296
+0:The total amount of wall time                        = 540.094227
+0:The maximum resident set size (KB)                   = 503244
 
 Test 069 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_conus13km_hrrr_warm
 Checking test 070 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2921,14 +2921,14 @@ Checking test 070 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 129.579042
-0:The maximum resident set size (KB)                   = 641332
+0:The total amount of wall time                        = 127.821326
+0:The maximum resident set size (KB)                   = 641228
 
 Test 070 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_smoke_conus13km_hrrr_warm
 Checking test 071 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2937,14 +2937,14 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 145.529616
-0:The maximum resident set size (KB)                   = 657656
+0:The total amount of wall time                        = 142.967980
+0:The maximum resident set size (KB)                   = 657528
 
 Test 071 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_conus13km_radar_tten_warm
 Checking test 072 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2953,14 +2953,14 @@ Checking test 072 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 130.455996
-0:The maximum resident set size (KB)                   = 643012
+0:The total amount of wall time                        = 128.684054
+0:The maximum resident set size (KB)                   = 642920
 
 Test 072 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_conus13km_hrrr_warm_2threads
 Checking test 073 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2969,14 +2969,14 @@ Checking test 073 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 299.628952
-0:The maximum resident set size (KB)                   = 643544
+0:The total amount of wall time                        = 300.924067
+0:The maximum resident set size (KB)                   = 643184
 
 Test 073 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 074 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2985,14 +2985,14 @@ Checking test 074 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 301.832863
-0:The maximum resident set size (KB)                   = 646280
+0:The total amount of wall time                        = 300.608165
+0:The maximum resident set size (KB)                   = 646028
 
 Test 074 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_csawmg
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_csawmg
 Checking test 075 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3003,14 +3003,14 @@ Checking test 075 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 397.988955
-0:The maximum resident set size (KB)                   = 533248
+0:The total amount of wall time                        = 399.266750
+0:The maximum resident set size (KB)                   = 533308
 
 Test 075 control_csawmg PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_csawmgt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_csawmgt
 Checking test 076 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3021,14 +3021,14 @@ Checking test 076 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 392.835448
-0:The maximum resident set size (KB)                   = 533248
+0:The total amount of wall time                        = 376.715109
+0:The maximum resident set size (KB)                   = 533300
 
 Test 076 control_csawmgt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_ras
 Checking test 077 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3039,82 +3039,82 @@ Checking test 077 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 203.720058
-0:The maximum resident set size (KB)                   = 490864
+0:The total amount of wall time                        = 204.649318
+0:The maximum resident set size (KB)                   = 490860
 
 Test 077 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_wam
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_wam
 Checking test 078 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 126.078047
-0:The maximum resident set size (KB)                   = 207476
+0:The total amount of wall time                        = 120.768664
+0:The maximum resident set size (KB)                   = 207456
 
 Test 078 control_wam PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_conus13km_hrrr_warm_debug
 Checking test 079 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 758.958033
-0:The maximum resident set size (KB)                   = 671828
+0:The total amount of wall time                        = 757.056351
+0:The maximum resident set size (KB)                   = 672044
 
 Test 079 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_conus13km_radar_tten_warm_debug
 Checking test 080 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 762.829615
-0:The maximum resident set size (KB)                   = 674916
+0:The total amount of wall time                        = 757.955918
+0:The maximum resident set size (KB)                   = 674976
 
 Test 080 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_debug
 Checking test 081 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 161.861673
-0:The maximum resident set size (KB)                   = 623856
+0:The total amount of wall time                        = 160.594778
+0:The maximum resident set size (KB)                   = 623400
 
 Test 081 control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_2threads_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_2threads_debug
 Checking test 082 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 279.840039
-0:The maximum resident set size (KB)                   = 672496
+0:The total amount of wall time                        = 279.590958
+0:The maximum resident set size (KB)                   = 672468
 
 Test 082 control_2threads_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_CubedSphereGrid_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_CubedSphereGrid_debug
 Checking test 083 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3141,348 +3141,348 @@ Checking test 083 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 174.588392
-0:The maximum resident set size (KB)                   = 623964
+0:The total amount of wall time                        = 174.189501
+0:The maximum resident set size (KB)                   = 624024
 
 Test 083 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_wrtGauss_netcdf_parallel_debug
 Checking test 084 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.939180
-0:The maximum resident set size (KB)                   = 623936
+0:The total amount of wall time                        = 163.259746
+0:The maximum resident set size (KB)                   = 624000
 
 Test 084 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_stochy_debug
 Checking test 085 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.894912
-0:The maximum resident set size (KB)                   = 631388
+0:The total amount of wall time                        = 183.054888
+0:The maximum resident set size (KB)                   = 631440
 
 Test 085 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_lndp_debug
 Checking test 086 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 166.494160
-0:The maximum resident set size (KB)                   = 631340
+0:The total amount of wall time                        = 164.747595
+0:The maximum resident set size (KB)                   = 629672
 
 Test 086 control_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_csawmg_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_csawmg_debug
 Checking test 087 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 259.118650
-0:The maximum resident set size (KB)                   = 675368
+0:The total amount of wall time                        = 255.885833
+0:The maximum resident set size (KB)                   = 675356
 
 Test 087 control_csawmg_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_csawmgt_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_csawmgt_debug
 Checking test 088 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 251.209108
-0:The maximum resident set size (KB)                   = 675388
+0:The total amount of wall time                        = 251.389259
+0:The maximum resident set size (KB)                   = 675360
 
 Test 088 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_ras_debug
 Checking test 089 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 166.325034
-0:The maximum resident set size (KB)                   = 637148
+0:The total amount of wall time                        = 167.070553
+0:The maximum resident set size (KB)                   = 637116
 
 Test 089 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_diag_debug
 Checking test 090 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 169.374988
-0:The maximum resident set size (KB)                   = 681388
+0:The total amount of wall time                        = 169.654233
+0:The maximum resident set size (KB)                   = 681232
 
 Test 090 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_debug_p8
 Checking test 091 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 183.415569
-0:The maximum resident set size (KB)                   = 1448776
+0:The total amount of wall time                        = 184.071783
+0:The maximum resident set size (KB)                   = 1448788
 
 Test 091 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_debug
 Checking test 092 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 261.869449
-0:The maximum resident set size (KB)                   = 591640
+0:The total amount of wall time                        = 259.905809
+0:The maximum resident set size (KB)                   = 591624
 
 Test 092 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_control_debug
 Checking test 093 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 295.494001
-0:The maximum resident set size (KB)                   = 992080
+0:The total amount of wall time                        = 292.331266
+0:The maximum resident set size (KB)                   = 992120
 
 Test 093 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_debug
 Checking test 094 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 290.072635
-0:The maximum resident set size (KB)                   = 988624
+0:The total amount of wall time                        = 287.597763
+0:The maximum resident set size (KB)                   = 988572
 
 Test 094 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_unified_drag_suite_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_unified_drag_suite_debug
 Checking test 095 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.923367
-0:The maximum resident set size (KB)                   = 991980
+0:The total amount of wall time                        = 291.823945
+0:The maximum resident set size (KB)                   = 991780
 
 Test 095 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_diag_debug
 Checking test 096 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 306.216310
-0:The maximum resident set size (KB)                   = 1075312
+0:The total amount of wall time                        = 306.530046
+0:The maximum resident set size (KB)                   = 1075300
 
 Test 096 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_cires_ugwp_debug
 Checking test 097 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 299.923547
-0:The maximum resident set size (KB)                   = 990228
+0:The total amount of wall time                        = 297.703758
+0:The maximum resident set size (KB)                   = 990404
 
 Test 097 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_unified_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_unified_ugwp_debug
 Checking test 098 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 302.059933
-0:The maximum resident set size (KB)                   = 991976
+0:The total amount of wall time                        = 298.579495
+0:The maximum resident set size (KB)                   = 991964
 
 Test 098 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_lndp_debug
 Checking test 099 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 297.563534
-0:The maximum resident set size (KB)                   = 993032
+0:The total amount of wall time                        = 294.183005
+0:The maximum resident set size (KB)                   = 992932
 
 Test 099 rap_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_flake_debug
 Checking test 100 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 294.705318
-0:The maximum resident set size (KB)                   = 991612
+0:The total amount of wall time                        = 295.589610
+0:The maximum resident set size (KB)                   = 991592
 
 Test 100 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_progcld_thompson_debug
 Checking test 101 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 294.411314
-0:The maximum resident set size (KB)                   = 991976
+0:The total amount of wall time                        = 292.256900
+0:The maximum resident set size (KB)                   = 992148
 
 Test 101 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_noah_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_noah_debug
 Checking test 102 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.357007
-0:The maximum resident set size (KB)                   = 990552
+0:The total amount of wall time                        = 286.856500
+0:The maximum resident set size (KB)                   = 990456
 
 Test 102 rap_noah_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_rrtmgp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_rrtmgp_debug
 Checking test 103 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 488.461513
-0:The maximum resident set size (KB)                   = 1121316
+0:The total amount of wall time                        = 488.655568
+0:The maximum resident set size (KB)                   = 1121344
 
 Test 103 rap_rrtmgp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_sfcdiff_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_sfcdiff_debug
 Checking test 104 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.391270
-0:The maximum resident set size (KB)                   = 991456
+0:The total amount of wall time                        = 291.854368
+0:The maximum resident set size (KB)                   = 991716
 
 Test 104 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 105 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 475.792723
-0:The maximum resident set size (KB)                   = 990584
+0:The total amount of wall time                        = 475.741589
+0:The maximum resident set size (KB)                   = 990596
 
 Test 105 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rrfs_v1beta_debug
 Checking test 106 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.399029
-0:The maximum resident set size (KB)                   = 987924
+0:The total amount of wall time                        = 287.558988
+0:The maximum resident set size (KB)                   = 987856
 
 Test 106 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_wam_debug
 Checking test 107 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 299.305696
-0:The maximum resident set size (KB)                   = 239204
+0:The total amount of wall time                        = 296.095136
+0:The maximum resident set size (KB)                   = 241308
 
 Test 107 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 108 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3493,14 +3493,14 @@ Checking test 108 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 664.996474
-0:The maximum resident set size (KB)                   = 831828
+0:The total amount of wall time                        = 662.029049
+0:The maximum resident set size (KB)                   = 832080
 
 Test 108 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_control_dyn32_phy32
 Checking test 109 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3547,14 +3547,14 @@ Checking test 109 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 370.344372
-0:The maximum resident set size (KB)                   = 709440
+0:The total amount of wall time                        = 374.705755
+0:The maximum resident set size (KB)                   = 709364
 
 Test 109 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_dyn32_phy32
 Checking test 110 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3601,14 +3601,14 @@ Checking test 110 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 197.640297
-0:The maximum resident set size (KB)                   = 707668
+0:The total amount of wall time                        = 195.630892
+0:The maximum resident set size (KB)                   = 707480
 
 Test 110 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_2threads_dyn32_phy32
 Checking test 111 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3655,14 +3655,14 @@ Checking test 111 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 912.728731
-0:The maximum resident set size (KB)                   = 750976
+0:The total amount of wall time                        = 913.035374
+0:The maximum resident set size (KB)                   = 751072
 
 Test 111 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_2threads_dyn32_phy32
 Checking test 112 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3709,14 +3709,14 @@ Checking test 112 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 481.587114
-0:The maximum resident set size (KB)                   = 744776
+0:The total amount of wall time                        = 473.701961
+0:The maximum resident set size (KB)                   = 744808
 
 Test 112 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_decomp_dyn32_phy32
 Checking test 113 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3763,14 +3763,14 @@ Checking test 113 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 206.731137
-0:The maximum resident set size (KB)                   = 706856
+0:The total amount of wall time                        = 205.616347
+0:The maximum resident set size (KB)                   = 706664
 
 Test 113 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_restart_dyn32_phy32
 Checking test 114 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3809,14 +3809,14 @@ Checking test 114 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 278.044536
-0:The maximum resident set size (KB)                   = 543572
+0:The total amount of wall time                        = 278.874273
+0:The maximum resident set size (KB)                   = 543696
 
 Test 114 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_restart_dyn32_phy32
 Checking test 115 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3855,14 +3855,14 @@ Checking test 115 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 100.950833
-0:The maximum resident set size (KB)                   = 540840
+0:The total amount of wall time                        = 100.369906
+0:The maximum resident set size (KB)                   = 540776
 
 Test 115 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_control_dyn64_phy32
 Checking test 116 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3909,81 +3909,81 @@ Checking test 116 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 258.395553
-0:The maximum resident set size (KB)                   = 727836
+0:The total amount of wall time                        = 256.150695
+0:The maximum resident set size (KB)                   = 727800
 
 Test 116 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_control_debug_dyn32_phy32
 Checking test 117 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.028758
-0:The maximum resident set size (KB)                   = 877624
+0:The total amount of wall time                        = 287.496559
+0:The maximum resident set size (KB)                   = 877780
 
 Test 117 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hrrr_control_debug_dyn32_phy32
 Checking test 118 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 282.585197
-0:The maximum resident set size (KB)                   = 875008
+0:The total amount of wall time                        = 281.448181
+0:The maximum resident set size (KB)                   = 875088
 
 Test 118 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/rap_control_dyn64_phy32_debug
 Checking test 119 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.459620
-0:The maximum resident set size (KB)                   = 894244
+0:The total amount of wall time                        = 291.015217
+0:The maximum resident set size (KB)                   = 894188
 
 Test 119 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_atm
 Checking test 120 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 635.030422
-0:The maximum resident set size (KB)                   = 691304
+0:The total amount of wall time                        = 641.307923
+0:The maximum resident set size (KB)                   = 691188
 
 Test 120 hafs_regional_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_atm_thompson_gfdlsf
 Checking test 121 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 674.969413
-0:The maximum resident set size (KB)                   = 1050832
+0:The total amount of wall time                        = 683.446260
+0:The maximum resident set size (KB)                   = 1049688
 
 Test 121 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_atm_ocn
 Checking test 122 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3992,14 +3992,14 @@ Checking test 122 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 446.163356
-0:The maximum resident set size (KB)                   = 722076
+0:The total amount of wall time                        = 457.342995
+0:The maximum resident set size (KB)                   = 721952
 
 Test 122 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_atm_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_atm_wav
 Checking test 123 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4008,14 +4008,14 @@ Checking test 123 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1009.432772
-0:The maximum resident set size (KB)                   = 752396
+0:The total amount of wall time                        = 1029.634122
+0:The maximum resident set size (KB)                   = 752380
 
 Test 123 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_atm_ocn_wav
 Checking test 124 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4026,28 +4026,28 @@ Checking test 124 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1069.928486
-0:The maximum resident set size (KB)                   = 767912
+0:The total amount of wall time                        = 1147.985988
+0:The maximum resident set size (KB)                   = 767760
 
 Test 124 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_1nest_atm
 Checking test 125 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 1267.402331
-0:The maximum resident set size (KB)                   = 279064
+0:The total amount of wall time                        = 1268.803453
+0:The maximum resident set size (KB)                   = 279024
 
 Test 125 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_telescopic_2nests_atm
 Checking test 126 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4056,28 +4056,28 @@ Checking test 126 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 1362.857926
-0:The maximum resident set size (KB)                   = 289136
+0:The total amount of wall time                        = 1366.723303
+0:The maximum resident set size (KB)                   = 289208
 
 Test 126 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_global_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_global_1nest_atm
 Checking test 127 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 834.694473
-0:The maximum resident set size (KB)                   = 186948
+0:The total amount of wall time                        = 836.937261
+0:The maximum resident set size (KB)                   = 186868
 
 Test 127 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_global_multiple_4nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_global_multiple_4nests_atm
 Checking test 128 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4095,14 +4095,14 @@ Checking test 128 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-0:The total amount of wall time                        = 1494.377133
-0:The maximum resident set size (KB)                   = 265276
+0:The total amount of wall time                        = 1485.310536
+0:The maximum resident set size (KB)                   = 265680
 
 Test 128 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_specified_moving_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_specified_moving_1nest_atm
 Checking test 129 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4111,28 +4111,28 @@ Checking test 129 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 720.506084
-0:The maximum resident set size (KB)                   = 287988
+0:The total amount of wall time                        = 714.981238
+0:The maximum resident set size (KB)                   = 287912
 
 Test 129 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_storm_following_1nest_atm
 Checking test 130 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 687.211668
-0:The maximum resident set size (KB)                   = 287916
+0:The total amount of wall time                        = 690.626536
+0:The maximum resident set size (KB)                   = 287952
 
 Test 130 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 131 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4141,14 +4141,14 @@ Checking test 131 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 705.090804
-0:The maximum resident set size (KB)                   = 320040
+0:The total amount of wall time                        = 712.024336
+0:The maximum resident set size (KB)                   = 320032
 
 Test 131 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4159,28 +4159,28 @@ Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1337.020250
-0:The maximum resident set size (KB)                   = 384912
+0:The total amount of wall time                        = 1334.584957
+0:The maximum resident set size (KB)                   = 385028
 
 Test 132 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_global_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_global_storm_following_1nest_atm
 Checking test 133 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 417.473495
-0:The maximum resident set size (KB)                   = 204916
+0:The total amount of wall time                        = 420.913087
+0:The maximum resident set size (KB)                   = 205080
 
 Test 133 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_docn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_docn
 Checking test 134 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4188,14 +4188,14 @@ Checking test 134 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 421.661790
-0:The maximum resident set size (KB)                   = 738576
+0:The total amount of wall time                        = 425.326343
+0:The maximum resident set size (KB)                   = 738232
 
 Test 134 hafs_regional_docn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_docn_oisst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_docn_oisst
 Checking test 135 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4203,131 +4203,131 @@ Checking test 135 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 420.896711
-0:The maximum resident set size (KB)                   = 717612
+0:The total amount of wall time                        = 425.657790
+0:The maximum resident set size (KB)                   = 717516
 
 Test 135 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/hafs_regional_datm_cdeps
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/hafs_regional_datm_cdeps
 Checking test 136 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1281.095460
-0:The maximum resident set size (KB)                   = 891696
+0:The total amount of wall time                        = 1280.495609
+0:The maximum resident set size (KB)                   = 891676
 
 Test 136 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_control_cfsr
 Checking test 137 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.363238
-0:The maximum resident set size (KB)                   = 720356
+0:The total amount of wall time                        = 167.799347
+0:The maximum resident set size (KB)                   = 731448
 
 Test 137 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_restart_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_restart_cfsr
 Checking test 138 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 101.838853
-0:The maximum resident set size (KB)                   = 720032
+0:The total amount of wall time                        = 100.244532
+0:The maximum resident set size (KB)                   = 719752
 
 Test 138 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_control_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_control_gefs
 Checking test 139 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.438238
-0:The maximum resident set size (KB)                   = 610780
+0:The total amount of wall time                        = 156.963543
+0:The maximum resident set size (KB)                   = 610828
 
 Test 139 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_iau_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_iau_gefs
 Checking test 140 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.944389
-0:The maximum resident set size (KB)                   = 610828
+0:The total amount of wall time                        = 166.481796
+0:The maximum resident set size (KB)                   = 610824
 
 Test 140 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_stochy_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_stochy_gefs
 Checking test 141 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 164.245003
-0:The maximum resident set size (KB)                   = 610796
+0:The total amount of wall time                        = 165.655948
+0:The maximum resident set size (KB)                   = 610776
 
 Test 141 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_ciceC_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_ciceC_cfsr
 Checking test 142 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.086475
-0:The maximum resident set size (KB)                   = 720400
+0:The total amount of wall time                        = 170.335017
+0:The maximum resident set size (KB)                   = 720408
 
 Test 142 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_bulk_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_bulk_cfsr
 Checking test 143 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 169.625183
-0:The maximum resident set size (KB)                   = 732276
+0:The total amount of wall time                        = 168.818119
+0:The maximum resident set size (KB)                   = 720392
 
 Test 143 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_bulk_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_bulk_gefs
 Checking test 144 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.998291
-0:The maximum resident set size (KB)                   = 610820
+0:The total amount of wall time                        = 162.190764
+0:The maximum resident set size (KB)                   = 610808
 
 Test 144 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_mx025_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_mx025_cfsr
 Checking test 145 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4336,14 +4336,14 @@ Checking test 145 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 427.783256
-0:The maximum resident set size (KB)                   = 516352
+0:The total amount of wall time                        = 419.429717
+0:The maximum resident set size (KB)                   = 517508
 
 Test 145 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_mx025_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_mx025_gefs
 Checking test 146 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4352,64 +4352,64 @@ Checking test 146 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 421.042942
+0:The total amount of wall time                        = 792.314753
 0:The maximum resident set size (KB)                   = 497500
 
 Test 146 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_multiple_files_cfsr
 Checking test 147 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.758407
-0:The maximum resident set size (KB)                   = 720392
+0:The total amount of wall time                        = 162.670969
+0:The maximum resident set size (KB)                   = 720396
 
 Test 147 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_3072x1536_cfsr
 Checking test 148 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 258.139434
-0:The maximum resident set size (KB)                   = 1943884
+0:The total amount of wall time                        = 255.358137
+0:The maximum resident set size (KB)                   = 1943892
 
 Test 148 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_gfs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_gfs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_gfs
 Checking test 149 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 255.671745
-0:The maximum resident set size (KB)                   = 1945564
+0:The total amount of wall time                        = 241.368625
+0:The maximum resident set size (KB)                   = 1944648
 
 Test 149 datm_cdeps_gfs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_debug_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_debug_cfsr
 Checking test 150 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 460.768045
-0:The maximum resident set size (KB)                   = 721616
+0:The total amount of wall time                        = 461.113487
+0:The maximum resident set size (KB)                   = 710464
 
 Test 150 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_lnd_gswp3
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_lnd_gswp3
 Checking test 151 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4418,14 +4418,14 @@ Checking test 151 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 10.648157
-0:The maximum resident set size (KB)                   = 214244
+0:The total amount of wall time                        = 11.182516
+0:The maximum resident set size (KB)                   = 212428
 
 Test 151 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/datm_cdeps_lnd_gswp3_rst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/datm_cdeps_lnd_gswp3_rst
 Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4434,14 +4434,14 @@ Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 16.536698
-0:The maximum resident set size (KB)                   = 212352
+0:The total amount of wall time                        = 16.339804
+0:The maximum resident set size (KB)                   = 210536
 
 Test 152 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_p8_atmlnd_sbs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_p8_atmlnd_sbs
 Checking test 153 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4526,14 +4526,14 @@ Checking test 153 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-0:The total amount of wall time                        = 233.557201
-0:The maximum resident set size (KB)                   = 1465572
+0:The total amount of wall time                        = 235.528487
+0:The maximum resident set size (KB)                   = 1465184
 
 Test 153 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/control_atmwav
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/control_atmwav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/control_atmwav
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/control_atmwav
 Checking test 154 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4577,14 +4577,14 @@ Checking test 154 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 99.281016
-0:The maximum resident set size (KB)                   = 476440
+0:The total amount of wall time                        = 99.521873
+0:The maximum resident set size (KB)                   = 476408
 
 Test 154 control_atmwav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/atmaero_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/atmaero_control_p8
 Checking test 155 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4628,14 +4628,14 @@ Checking test 155 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 250.204302
-0:The maximum resident set size (KB)                   = 2705532
+0:The total amount of wall time                        = 248.997565
+0:The maximum resident set size (KB)                   = 2705880
 
 Test 155 atmaero_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/atmaero_control_p8_rad
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/atmaero_control_p8_rad
 Checking test 156 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4679,14 +4679,14 @@ Checking test 156 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 302.374123
-0:The maximum resident set size (KB)                   = 2760660
+0:The total amount of wall time                        = 305.204587
+0:The maximum resident set size (KB)                   = 2760984
 
 Test 156 atmaero_control_p8_rad PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad_micro
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/atmaero_control_p8_rad_micro
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad_micro
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/atmaero_control_p8_rad_micro
 Checking test 157 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4730,14 +4730,14 @@ Checking test 157 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 307.050363
-0:The maximum resident set size (KB)                   = 2766768
+0:The total amount of wall time                        = 306.732766
+0:The maximum resident set size (KB)                   = 2766736
 
 Test 157 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /glade/scratch/jongkim/rt-1456-intel/jongkim/FV3_RT/rt_54669/regional_atmaq
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /glade/scratch/jongkim/rt-1481-intel/jongkim/FV3_RT/rt_71411/regional_atmaq
 Checking test 158 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4753,12 +4753,12 @@ Checking test 158 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 1034.373390
-0:The maximum resident set size (KB)                   = 795388
+0:The total amount of wall time                        = 1070.226216
+0:The maximum resident set size (KB)                   = 795360
 
 Test 158 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 14:07:45 MDT 2022
-Elapsed time: 01h:41m:29s. Have a nice day!
+Mon Nov  7 21:30:57 MST 2022
+Elapsed time: 01h:25m:15s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,34 +1,34 @@
-Wed Nov  2 13:32:41 EDT 2022
+Mon Nov  7 20:23:00 EST 2022
 Start Regression test
 
-Compile 001 elapsed time 751 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 719 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 258 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 238 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 539 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 530 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 479 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 484 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 439 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 443 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 680 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 429 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 206 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 600 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 627 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 266 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 163 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 101 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 497 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 612 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 423 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 426 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 705 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 653 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 255 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 253 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 497 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 521 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 489 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 472 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 390 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 693 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 178 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 385 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 406 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 199 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 181 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 582 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 629 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 267 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 161 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 89 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 440 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 597 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 414 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 403 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 374.442570
-  0: The maximum resident set size (KB)                   = 1586056
+  0: The total amount of wall time                        = 382.922438
+  0: The maximum resident set size (KB)                   = 1599872
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -153,14 +153,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 234.205932
-  0: The maximum resident set size (KB)                   = 1021968
+  0: The total amount of wall time                        = 236.152697
+  0: The maximum resident set size (KB)                   = 1022052
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -213,14 +213,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 479.135986
-  0: The maximum resident set size (KB)                   = 1782616
+  0: The total amount of wall time                        = 485.138963
+  0: The maximum resident set size (KB)                   = 1763296
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_esmfthreads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 385.913905
-  0: The maximum resident set size (KB)                   = 1776476
+  0: The total amount of wall time                        = 400.772712
+  0: The maximum resident set size (KB)                   = 1777240
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 384.454332
-  0: The maximum resident set size (KB)                   = 1595620
+  0: The total amount of wall time                        = 386.686970
+  0: The maximum resident set size (KB)                   = 1591576
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 305.929313
-  0: The maximum resident set size (KB)                   = 1559748
+  0: The total amount of wall time                        = 325.706048
+  0: The maximum resident set size (KB)                   = 1559184
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_ciceC_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_ciceC_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_ciceC_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 379.750568
-  0: The maximum resident set size (KB)                   = 1599584
+  0: The total amount of wall time                        = 393.720113
+  0: The maximum resident set size (KB)                   = 1590948
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -525,14 +525,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 816.516200
-  0: The maximum resident set size (KB)                   = 1764692
+  0: The total amount of wall time                        = 789.496848
+  0: The maximum resident set size (KB)                   = 1765348
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_restart_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -585,14 +585,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 524.320034
-  0: The maximum resident set size (KB)                   = 1934824
+  0: The total amount of wall time                        = 517.537265
+  0: The maximum resident set size (KB)                   = 1934692
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -640,14 +640,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 979.256196
-  0: The maximum resident set size (KB)                   = 2495280
+  0: The total amount of wall time                        = 949.634301
+  0: The maximum resident set size (KB)                   = 2497548
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_restart_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -695,14 +695,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 611.384244
-  0: The maximum resident set size (KB)                   = 2321500
+  0: The total amount of wall time                        = 649.502680
+  0: The maximum resident set size (KB)                   = 2325648
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_bmark_esmfthreads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_bmark_esmfthreads_p8
 Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -750,14 +750,14 @@ Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 833.611619
-   0: The maximum resident set size (KB)                   = 2519472
+   0: The total amount of wall time                        = 829.694159
+   0: The maximum resident set size (KB)                   = 2535420
 
 Test 012 cpld_bmark_esmfthreads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -821,14 +821,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 242.581903
-  0: The maximum resident set size (KB)                   = 1466028
+  0: The total amount of wall time                        = 244.272619
+  0: The maximum resident set size (KB)                   = 1452064
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_nowave_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -890,14 +890,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 288.197492
-  0: The maximum resident set size (KB)                   = 1499108
+  0: The total amount of wall time                        = 305.098168
+  0: The maximum resident set size (KB)                   = 1498936
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -950,14 +950,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 585.978604
-  0: The maximum resident set size (KB)                   = 1616712
+  0: The total amount of wall time                        = 581.933599
+  0: The maximum resident set size (KB)                   = 1627336
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_noaero_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_debug_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_noaero_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 389.638873
-  0: The maximum resident set size (KB)                   = 1488944
+  0: The total amount of wall time                        = 390.816116
+  0: The maximum resident set size (KB)                   = 1489384
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_noaero_p8_agrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1078,14 +1078,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 292.951838
-  0: The maximum resident set size (KB)                   = 1501948
+  0: The total amount of wall time                        = 299.486350
+  0: The maximum resident set size (KB)                   = 1501740
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1135,14 +1135,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 592.779722
- 0: The maximum resident set size (KB)                   = 2568296
+ 0: The total amount of wall time                        = 594.196523
+ 0: The maximum resident set size (KB)                   = 2556428
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_warmstart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1192,14 +1192,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 155.340236
- 0: The maximum resident set size (KB)                   = 2571940
+ 0: The total amount of wall time                        = 156.439065
+ 0: The maximum resident set size (KB)                   = 2582452
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/cpld_restart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1249,14 +1249,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 82.104783
- 0: The maximum resident set size (KB)                   = 1991440
+ 0: The total amount of wall time                        = 81.568748
+ 0: The maximum resident set size (KB)                   = 1999804
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control
 Checking test 021 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1303,14 +1303,14 @@ Checking test 021 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.434603
-  0: The maximum resident set size (KB)                   = 436228
+  0: The total amount of wall time                        = 142.008401
+  0: The maximum resident set size (KB)                   = 436436
 
 Test 021 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_decomp
 Checking test 022 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 022 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.585074
-  0: The maximum resident set size (KB)                   = 435856
+  0: The total amount of wall time                        = 148.732097
+  0: The maximum resident set size (KB)                   = 435984
 
 Test 022 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_2dwrtdecomp
 Checking test 023 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1371,14 +1371,14 @@ Checking test 023 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 142.000644
-  0: The maximum resident set size (KB)                   = 436296
+  0: The total amount of wall time                        = 142.545806
+  0: The maximum resident set size (KB)                   = 436356
 
 Test 023 control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_2threads
 Checking test 024 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1421,14 +1421,14 @@ Checking test 024 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 184.652672
- 0: The maximum resident set size (KB)                   = 491732
+ 0: The total amount of wall time                        = 185.094570
+ 0: The maximum resident set size (KB)                   = 492652
 
 Test 024 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_restart
 Checking test 025 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1467,14 +1467,14 @@ Checking test 025 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 74.459159
-  0: The maximum resident set size (KB)                   = 174508
+  0: The total amount of wall time                        = 75.141633
+  0: The maximum resident set size (KB)                   = 174428
 
 Test 025 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_fhzero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_fhzero
 Checking test 026 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1517,14 +1517,14 @@ Checking test 026 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 134.698818
-  0: The maximum resident set size (KB)                   = 436316
+  0: The total amount of wall time                        = 133.788197
+  0: The maximum resident set size (KB)                   = 436364
 
 Test 026 control_fhzero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_CubedSphereGrid
 Checking test 027 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1551,28 +1551,28 @@ Checking test 027 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 136.929824
-  0: The maximum resident set size (KB)                   = 436604
+  0: The total amount of wall time                        = 139.125968
+  0: The maximum resident set size (KB)                   = 436864
 
 Test 027 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_CubedSphereGrid_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_CubedSphereGrid_parallel
 Checking test 028 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 141.746660
-  0: The maximum resident set size (KB)                   = 436580
+  0: The total amount of wall time                        = 141.000181
+  0: The maximum resident set size (KB)                   = 436552
 
 Test 028 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_latlon
 Checking test 029 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1583,14 +1583,14 @@ Checking test 029 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.128850
-  0: The maximum resident set size (KB)                   = 436340
+  0: The total amount of wall time                        = 140.426619
+  0: The maximum resident set size (KB)                   = 436336
 
 Test 029 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_wrtGauss_netcdf_parallel
 Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1601,14 +1601,14 @@ Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 145.217484
-  0: The maximum resident set size (KB)                   = 436220
+  0: The total amount of wall time                        = 154.088189
+  0: The maximum resident set size (KB)                   = 436328
 
 Test 030 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_c48
 Checking test 031 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1647,14 +1647,14 @@ Checking test 031 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 370.766226
-0: The maximum resident set size (KB)                   = 631352
+0: The total amount of wall time                        = 371.282391
+0: The maximum resident set size (KB)                   = 631264
 
 Test 031 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_c192
 Checking test 032 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1665,14 +1665,14 @@ Checking test 032 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 576.900882
-  0: The maximum resident set size (KB)                   = 540772
+  0: The total amount of wall time                        = 572.312794
+  0: The maximum resident set size (KB)                   = 540856
 
 Test 032 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_c384
 Checking test 033 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1683,14 +1683,14 @@ Checking test 033 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 798.163661
-  0: The maximum resident set size (KB)                   = 812864
+  0: The total amount of wall time                        = 807.477949
+  0: The maximum resident set size (KB)                   = 812768
 
 Test 033 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_c384gdas
 Checking test 034 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1733,14 +1733,14 @@ Checking test 034 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 687.355447
-  0: The maximum resident set size (KB)                   = 932160
+  0: The total amount of wall time                        = 711.024393
+  0: The maximum resident set size (KB)                   = 931760
 
 Test 034 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_c384_progsigma
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_c384_progsigma
 Checking test 035 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 035 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 814.584131
-  0: The maximum resident set size (KB)                   = 830028
+  0: The total amount of wall time                        = 832.803425
+  0: The maximum resident set size (KB)                   = 830660
 
 Test 035 control_c384_progsigma PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_stochy
 Checking test 036 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1769,28 +1769,28 @@ Checking test 036 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 100.518858
-  0: The maximum resident set size (KB)                   = 440860
+  0: The total amount of wall time                        = 93.503766
+  0: The maximum resident set size (KB)                   = 440876
 
 Test 036 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_stochy_restart
 Checking test 037 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 49.534411
-  0: The maximum resident set size (KB)                   = 185952
+  0: The total amount of wall time                        = 51.727391
+  0: The maximum resident set size (KB)                   = 191588
 
 Test 037 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_lndp
 Checking test 038 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1801,14 +1801,14 @@ Checking test 038 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 94.935272
-  0: The maximum resident set size (KB)                   = 441268
+  0: The total amount of wall time                        = 85.288611
+  0: The maximum resident set size (KB)                   = 441116
 
 Test 038 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_iovr4
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_iovr4
 Checking test 039 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1823,14 +1823,14 @@ Checking test 039 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 141.512414
-  0: The maximum resident set size (KB)                   = 436260
+  0: The total amount of wall time                        = 143.426946
+  0: The maximum resident set size (KB)                   = 436088
 
 Test 039 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_iovr5
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_iovr5
 Checking test 040 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1845,14 +1845,14 @@ Checking test 040 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 141.947486
-  0: The maximum resident set size (KB)                   = 436316
+  0: The total amount of wall time                        = 141.684298
+  0: The maximum resident set size (KB)                   = 436384
 
 Test 040 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_p8
 Checking test 041 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1899,14 +1899,14 @@ Checking test 041 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.974108
-  0: The maximum resident set size (KB)                   = 1403224
+  0: The total amount of wall time                        = 177.701903
+  0: The maximum resident set size (KB)                   = 1379700
 
 Test 041 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_p8_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_p8_lndp
 Checking test 042 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 042 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 326.699071
-  0: The maximum resident set size (KB)                   = 1380752
+  0: The total amount of wall time                        = 330.831717
+  0: The maximum resident set size (KB)                   = 1380780
 
 Test 042 control_p8_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_restart_p8
 Checking test 043 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 043 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 117.233752
-  0: The maximum resident set size (KB)                   = 550236
+  0: The total amount of wall time                        = 106.782364
+  0: The maximum resident set size (KB)                   = 550212
 
 Test 043 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_decomp_p8
 Checking test 044 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2021,14 +2021,14 @@ Checking test 044 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 179.446954
-  0: The maximum resident set size (KB)                   = 1373164
+  0: The total amount of wall time                        = 181.086390
+  0: The maximum resident set size (KB)                   = 1396752
 
 Test 044 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_2threads_p8
 Checking test 045 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 045 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 225.999090
- 0: The maximum resident set size (KB)                   = 1478440
+ 0: The total amount of wall time                        = 227.223439
+ 0: The maximum resident set size (KB)                   = 1458448
 
 Test 045 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_p8_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_p8_rrtmgp
 Checking test 046 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 046 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.428678
-  0: The maximum resident set size (KB)                   = 1519100
+  0: The total amount of wall time                        = 255.348513
+  0: The maximum resident set size (KB)                   = 1504720
 
 Test 046 control_p8_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/merra2_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 178.918153
-  0: The maximum resident set size (KB)                   = 1384860
+  0: The total amount of wall time                        = 201.296957
+  0: The maximum resident set size (KB)                   = 1408672
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2197,28 +2197,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 366.013409
- 0: The maximum resident set size (KB)                   = 543812
+ 0: The total amount of wall time                        = 366.076650
+ 0: The maximum resident set size (KB)                   = 543820
 
 Test 048 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 199.324902
- 0: The maximum resident set size (KB)                   = 541576
+ 0: The total amount of wall time                        = 199.983123
+ 0: The maximum resident set size (KB)                   = 541572
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_control_2dwrtdecomp
 Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 365.935789
- 0: The maximum resident set size (KB)                   = 543872
+ 0: The total amount of wall time                        = 366.445036
+ 0: The maximum resident set size (KB)                   = 543924
 
 Test 050 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2244,14 +2244,14 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 387.780060
- 0: The maximum resident set size (KB)                   = 554588
+ 0: The total amount of wall time                        = 385.062549
+ 0: The maximum resident set size (KB)                   = 554628
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2262,28 +2262,28 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 283.147782
- 0: The maximum resident set size (KB)                   = 546840
+ 0: The total amount of wall time                        = 289.392434
+ 0: The maximum resident set size (KB)                   = 546728
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_netcdf_parallel
 Checking test 053 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 361.714771
- 0: The maximum resident set size (KB)                   = 542756
+ 0: The total amount of wall time                        = 364.153350
+ 0: The maximum resident set size (KB)                   = 542704
 
 Test 053 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_3km
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_3km
 Checking test 054 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2294,14 +2294,14 @@ Checking test 054 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 302.651946
-  0: The maximum resident set size (KB)                   = 570724
+  0: The total amount of wall time                        = 298.652428
+  0: The maximum resident set size (KB)                   = 570776
 
 Test 054 regional_3km PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_3km_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_3km_decomp
 Checking test 055 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2312,14 +2312,14 @@ Checking test 055 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 316.333190
-  0: The maximum resident set size (KB)                   = 581736
+  0: The total amount of wall time                        = 313.068528
+  0: The maximum resident set size (KB)                   = 581788
 
 Test 055 regional_3km_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_3km_wofs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_3km_wofs
 Checking test 056 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2330,14 +2330,14 @@ Checking test 056 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 383.725613
-  0: The maximum resident set size (KB)                   = 257792
+  0: The total amount of wall time                        = 386.418383
+  0: The maximum resident set size (KB)                   = 257996
 
 Test 056 regional_3km_wofs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_control
 Checking test 057 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2384,14 +2384,14 @@ Checking test 057 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.850582
-  0: The maximum resident set size (KB)                   = 806396
+  0: The total amount of wall time                        = 459.114333
+  0: The maximum resident set size (KB)                   = 805732
 
 Test 057 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_rrtmgp
 Checking test 058 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2438,14 +2438,14 @@ Checking test 058 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 512.585298
-  0: The maximum resident set size (KB)                   = 923956
+  0: The total amount of wall time                        = 506.005226
+  0: The maximum resident set size (KB)                   = 924076
 
 Test 058 rap_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_spp_sppt_shum_skeb
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_spp_sppt_shum_skeb
 Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2456,14 +2456,14 @@ Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 371.646481
-  0: The maximum resident set size (KB)                   = 889520
+  0: The total amount of wall time                        = 368.610610
+  0: The maximum resident set size (KB)                   = 889612
 
 Test 059 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_decomp
 Checking test 060 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2510,14 +2510,14 @@ Checking test 060 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 484.362350
-  0: The maximum resident set size (KB)                   = 806312
+  0: The total amount of wall time                        = 481.552616
+  0: The maximum resident set size (KB)                   = 806296
 
 Test 060 rap_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_2threads
 Checking test 061 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2564,14 +2564,14 @@ Checking test 061 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 597.318945
- 0: The maximum resident set size (KB)                   = 864648
+ 0: The total amount of wall time                        = 602.676469
+ 0: The maximum resident set size (KB)                   = 871844
 
 Test 061 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_restart
 Checking test 062 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2610,14 +2610,14 @@ Checking test 062 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.660531
-  0: The maximum resident set size (KB)                   = 549624
+  0: The total amount of wall time                        = 234.627309
+  0: The maximum resident set size (KB)                   = 549736
 
 Test 062 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_sfcdiff
 Checking test 063 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2664,14 +2664,14 @@ Checking test 063 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.127117
-  0: The maximum resident set size (KB)                   = 806252
+  0: The total amount of wall time                        = 454.542104
+  0: The maximum resident set size (KB)                   = 806276
 
 Test 063 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_sfcdiff_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_sfcdiff_decomp
 Checking test 064 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2718,14 +2718,14 @@ Checking test 064 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 482.396669
-  0: The maximum resident set size (KB)                   = 806228
+  0: The total amount of wall time                        = 481.401169
+  0: The maximum resident set size (KB)                   = 806244
 
 Test 064 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_sfcdiff_restart
 Checking test 065 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2764,14 +2764,14 @@ Checking test 065 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 343.191889
-  0: The maximum resident set size (KB)                   = 549608
+  0: The total amount of wall time                        = 343.514277
+  0: The maximum resident set size (KB)                   = 549364
 
 Test 065 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control
 Checking test 066 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2818,14 +2818,14 @@ Checking test 066 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 444.096768
-  0: The maximum resident set size (KB)                   = 804924
+  0: The total amount of wall time                        = 437.003605
+  0: The maximum resident set size (KB)                   = 804888
 
 Test 066 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_decomp
 Checking test 067 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2872,14 +2872,14 @@ Checking test 067 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.426762
-  0: The maximum resident set size (KB)                   = 805128
+  0: The total amount of wall time                        = 462.336565
+  0: The maximum resident set size (KB)                   = 805136
 
 Test 067 hrrr_control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_2threads
 Checking test 068 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2926,14 +2926,14 @@ Checking test 068 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 561.203358
- 0: The maximum resident set size (KB)                   = 866936
+ 0: The total amount of wall time                        = 555.677547
+ 0: The maximum resident set size (KB)                   = 860208
 
 Test 068 hrrr_control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_restart
 Checking test 069 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2972,14 +2972,14 @@ Checking test 069 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 328.374848
-  0: The maximum resident set size (KB)                   = 546652
+  0: The total amount of wall time                        = 331.393696
+  0: The maximum resident set size (KB)                   = 546568
 
 Test 069 hrrr_control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_v1beta
 Checking test 070 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3026,14 +3026,14 @@ Checking test 070 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.160991
-  0: The maximum resident set size (KB)                   = 801848
+  0: The total amount of wall time                        = 450.048883
+  0: The maximum resident set size (KB)                   = 801868
 
 Test 070 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_v1nssl
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_v1nssl
 Checking test 071 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3048,14 +3048,14 @@ Checking test 071 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 558.241106
-  0: The maximum resident set size (KB)                   = 492680
+  0: The total amount of wall time                        = 555.503228
+  0: The maximum resident set size (KB)                   = 492904
 
 Test 071 rrfs_v1nssl PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_v1nssl_nohailnoccn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_v1nssl_nohailnoccn
 Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3070,14 +3070,14 @@ Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 552.533157
-  0: The maximum resident set size (KB)                   = 483984
+  0: The total amount of wall time                        = 543.184324
+  0: The maximum resident set size (KB)                   = 483936
 
 Test 072 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_conus13km_hrrr_warm
 Checking test 073 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3086,14 +3086,14 @@ Checking test 073 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 147.044678
-  0: The maximum resident set size (KB)                   = 617216
+  0: The total amount of wall time                        = 146.327960
+  0: The maximum resident set size (KB)                   = 616900
 
 Test 073 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_smoke_conus13km_hrrr_warm
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3102,14 +3102,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 160.546905
-  0: The maximum resident set size (KB)                   = 627720
+  0: The total amount of wall time                        = 155.990273
+  0: The maximum resident set size (KB)                   = 627724
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_conus13km_radar_tten_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_conus13km_radar_tten_warm
 Checking test 075 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3118,14 +3118,14 @@ Checking test 075 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 143.510345
-  0: The maximum resident set size (KB)                   = 621132
+  0: The total amount of wall time                        = 146.350628
+  0: The maximum resident set size (KB)                   = 621000
 
 Test 075 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_conus13km_hrrr_warm_2threads
 Checking test 076 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3134,14 +3134,14 @@ Checking test 076 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 120.512273
-  0: The maximum resident set size (KB)                   = 622296
+  0: The total amount of wall time                        = 122.827236
+  0: The maximum resident set size (KB)                   = 622480
 
 Test 076 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 077 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3150,14 +3150,14 @@ Checking test 077 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 123.632818
-  0: The maximum resident set size (KB)                   = 624852
+  0: The total amount of wall time                        = 125.758532
+  0: The maximum resident set size (KB)                   = 624964
 
 Test 077 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_csawmgt
 Checking test 078 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3168,14 +3168,14 @@ Checking test 078 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 402.392239
-  0: The maximum resident set size (KB)                   = 505792
+  0: The total amount of wall time                        = 377.827795
+  0: The maximum resident set size (KB)                   = 505928
 
 Test 078 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_ras
 Checking test 079 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3186,82 +3186,82 @@ Checking test 079 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 199.222047
-  0: The maximum resident set size (KB)                   = 471496
+  0: The total amount of wall time                        = 195.188196
+  0: The maximum resident set size (KB)                   = 471480
 
 Test 079 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_wam
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_wam
 Checking test 080 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 123.757727
-  0: The maximum resident set size (KB)                   = 186184
+  0: The total amount of wall time                        = 122.702530
+  0: The maximum resident set size (KB)                   = 185992
 
 Test 080 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_conus13km_hrrr_warm_debug
 Checking test 081 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 788.517423
-  0: The maximum resident set size (KB)                   = 648768
+  0: The total amount of wall time                        = 774.177975
+  0: The maximum resident set size (KB)                   = 648632
 
 Test 081 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_conus13km_radar_tten_warm_debug
 Checking test 082 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 779.580021
-  0: The maximum resident set size (KB)                   = 649580
+  0: The total amount of wall time                        = 773.453257
+  0: The maximum resident set size (KB)                   = 649084
 
 Test 082 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_debug
 Checking test 083 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.714265
-  0: The maximum resident set size (KB)                   = 601824
+  0: The total amount of wall time                        = 157.293322
+  0: The maximum resident set size (KB)                   = 602424
 
 Test 083 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_2threads_debug
 Checking test 084 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 270.663277
- 0: The maximum resident set size (KB)                   = 654756
+ 0: The total amount of wall time                        = 268.705083
+ 0: The maximum resident set size (KB)                   = 655548
 
 Test 084 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_CubedSphereGrid_debug
 Checking test 085 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3288,348 +3288,348 @@ Checking test 085 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.100302
-  0: The maximum resident set size (KB)                   = 602152
+  0: The total amount of wall time                        = 167.656357
+  0: The maximum resident set size (KB)                   = 602844
 
 Test 085 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_wrtGauss_netcdf_parallel_debug
 Checking test 086 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.702465
-  0: The maximum resident set size (KB)                   = 602104
+  0: The total amount of wall time                        = 161.310744
+  0: The maximum resident set size (KB)                   = 602684
 
 Test 086 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_stochy_debug
 Checking test 087 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.434352
-  0: The maximum resident set size (KB)                   = 608280
+  0: The total amount of wall time                        = 179.649648
+  0: The maximum resident set size (KB)                   = 608628
 
 Test 087 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_lndp_debug
 Checking test 088 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.167734
-  0: The maximum resident set size (KB)                   = 609308
+  0: The total amount of wall time                        = 161.453940
+  0: The maximum resident set size (KB)                   = 610016
 
 Test 088 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_csawmg_debug
 Checking test 089 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.333560
-  0: The maximum resident set size (KB)                   = 644144
+  0: The total amount of wall time                        = 260.447576
+  0: The maximum resident set size (KB)                   = 644424
 
 Test 089 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_csawmgt_debug
 Checking test 090 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 258.381176
-  0: The maximum resident set size (KB)                   = 643304
+  0: The total amount of wall time                        = 258.209387
+  0: The maximum resident set size (KB)                   = 643748
 
 Test 090 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_ras_debug
 Checking test 091 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.912999
-  0: The maximum resident set size (KB)                   = 615560
+  0: The total amount of wall time                        = 163.573467
+  0: The maximum resident set size (KB)                   = 616216
 
 Test 091 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_diag_debug
 Checking test 092 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.392461
-  0: The maximum resident set size (KB)                   = 659188
+  0: The total amount of wall time                        = 165.027543
+  0: The maximum resident set size (KB)                   = 659848
 
 Test 092 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_debug_p8
 Checking test 093 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 190.363358
-  0: The maximum resident set size (KB)                   = 1424164
+  0: The total amount of wall time                        = 185.710396
+  0: The maximum resident set size (KB)                   = 1380576
 
 Test 093 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_debug
 Checking test 094 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 262.725333
- 0: The maximum resident set size (KB)                   = 572368
+ 0: The total amount of wall time                        = 260.147857
+ 0: The maximum resident set size (KB)                   = 572540
 
 Test 094 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_control_debug
 Checking test 095 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.449950
-  0: The maximum resident set size (KB)                   = 970508
+  0: The total amount of wall time                        = 289.180862
+  0: The maximum resident set size (KB)                   = 970928
 
 Test 095 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_debug
 Checking test 096 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.083084
-  0: The maximum resident set size (KB)                   = 968004
+  0: The total amount of wall time                        = 284.965549
+  0: The maximum resident set size (KB)                   = 968036
 
 Test 096 hrrr_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_unified_drag_suite_debug
 Checking test 097 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.622059
-  0: The maximum resident set size (KB)                   = 970744
+  0: The total amount of wall time                        = 289.218536
+  0: The maximum resident set size (KB)                   = 970716
 
 Test 097 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_diag_debug
 Checking test 098 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 305.783202
-  0: The maximum resident set size (KB)                   = 1054316
+  0: The total amount of wall time                        = 307.181930
+  0: The maximum resident set size (KB)                   = 1054320
 
 Test 098 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_cires_ugwp_debug
 Checking test 099 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 297.794437
-  0: The maximum resident set size (KB)                   = 969608
+  0: The total amount of wall time                        = 295.734456
+  0: The maximum resident set size (KB)                   = 969348
 
 Test 099 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_unified_ugwp_debug
 Checking test 100 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.545106
-  0: The maximum resident set size (KB)                   = 971092
+  0: The total amount of wall time                        = 294.731584
+  0: The maximum resident set size (KB)                   = 970632
 
 Test 100 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_lndp_debug
 Checking test 101 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.112659
-  0: The maximum resident set size (KB)                   = 971828
+  0: The total amount of wall time                        = 291.972780
+  0: The maximum resident set size (KB)                   = 972052
 
 Test 101 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_flake_debug
 Checking test 102 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.324900
-  0: The maximum resident set size (KB)                   = 970828
+  0: The total amount of wall time                        = 288.397130
+  0: The maximum resident set size (KB)                   = 971184
 
 Test 102 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_progcld_thompson_debug
 Checking test 103 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.193766
-  0: The maximum resident set size (KB)                   = 970816
+  0: The total amount of wall time                        = 289.024651
+  0: The maximum resident set size (KB)                   = 970988
 
 Test 103 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_noah_debug
 Checking test 104 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.604013
-  0: The maximum resident set size (KB)                   = 970580
+  0: The total amount of wall time                        = 284.642404
+  0: The maximum resident set size (KB)                   = 969784
 
 Test 104 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_rrtmgp_debug
 Checking test 105 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 482.089369
-  0: The maximum resident set size (KB)                   = 1093120
+  0: The total amount of wall time                        = 487.270864
+  0: The maximum resident set size (KB)                   = 1092788
 
 Test 105 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_sfcdiff_debug
 Checking test 106 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.471893
-  0: The maximum resident set size (KB)                   = 971036
+  0: The total amount of wall time                        = 290.342513
+  0: The maximum resident set size (KB)                   = 970724
 
 Test 106 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 107 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 468.842953
-  0: The maximum resident set size (KB)                   = 969872
+  0: The total amount of wall time                        = 475.978344
+  0: The maximum resident set size (KB)                   = 968976
 
 Test 107 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rrfs_v1beta_debug
 Checking test 108 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.823237
-  0: The maximum resident set size (KB)                   = 967332
+  0: The total amount of wall time                        = 283.034215
+  0: The maximum resident set size (KB)                   = 967712
 
 Test 108 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_wam_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_wam_debug
 Checking test 109 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 297.264109
-  0: The maximum resident set size (KB)                   = 218260
+  0: The total amount of wall time                        = 293.416381
+  0: The maximum resident set size (KB)                   = 218576
 
 Test 109 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3640,14 +3640,14 @@ Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 323.965689
-  0: The maximum resident set size (KB)                   = 790372
+  0: The total amount of wall time                        = 358.192249
+  0: The maximum resident set size (KB)                   = 790520
 
 Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_control_dyn32_phy32
 Checking test 111 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3694,14 +3694,14 @@ Checking test 111 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 375.205546
-  0: The maximum resident set size (KB)                   = 689572
+  0: The total amount of wall time                        = 374.432788
+  0: The maximum resident set size (KB)                   = 689668
 
 Test 111 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_dyn32_phy32
 Checking test 112 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3748,14 +3748,14 @@ Checking test 112 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.713523
-  0: The maximum resident set size (KB)                   = 687632
+  0: The total amount of wall time                        = 198.121580
+  0: The maximum resident set size (KB)                   = 687636
 
 Test 112 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_2threads_dyn32_phy32
 Checking test 113 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3802,14 +3802,14 @@ Checking test 113 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 483.954573
- 0: The maximum resident set size (KB)                   = 740468
+ 0: The total amount of wall time                        = 486.821467
+ 0: The maximum resident set size (KB)                   = 739892
 
 Test 113 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_2threads_dyn32_phy32
 Checking test 114 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3856,14 +3856,14 @@ Checking test 114 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 247.851430
- 0: The maximum resident set size (KB)                   = 732776
+ 0: The total amount of wall time                        = 252.451934
+ 0: The maximum resident set size (KB)                   = 732744
 
 Test 114 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_decomp_dyn32_phy32
 Checking test 115 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3910,14 +3910,14 @@ Checking test 115 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 202.723472
-  0: The maximum resident set size (KB)                   = 687224
+  0: The total amount of wall time                        = 207.868823
+  0: The maximum resident set size (KB)                   = 687400
 
 Test 115 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_restart_dyn32_phy32
 Checking test 116 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3956,14 +3956,14 @@ Checking test 116 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 280.195596
-  0: The maximum resident set size (KB)                   = 521784
+  0: The total amount of wall time                        = 277.797965
+  0: The maximum resident set size (KB)                   = 521860
 
 Test 116 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_restart_dyn32_phy32
 Checking test 117 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4002,14 +4002,14 @@ Checking test 117 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 102.555964
-  0: The maximum resident set size (KB)                   = 510012
+  0: The total amount of wall time                        = 103.499072
+  0: The maximum resident set size (KB)                   = 518880
 
 Test 117 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_control_dyn64_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_control_dyn64_phy32
 Checking test 118 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4056,81 +4056,81 @@ Checking test 118 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 250.275533
-  0: The maximum resident set size (KB)                   = 707444
+  0: The total amount of wall time                        = 252.834877
+  0: The maximum resident set size (KB)                   = 707780
 
 Test 118 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_control_debug_dyn32_phy32
 Checking test 119 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.086721
-  0: The maximum resident set size (KB)                   = 855356
+  0: The total amount of wall time                        = 285.284634
+  0: The maximum resident set size (KB)                   = 855420
 
 Test 119 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hrrr_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hrrr_control_debug_dyn32_phy32
 Checking test 120 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.162037
-  0: The maximum resident set size (KB)                   = 853936
+  0: The total amount of wall time                        = 282.128414
+  0: The maximum resident set size (KB)                   = 853468
 
 Test 120 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/rap_control_dyn64_phy32_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/rap_control_dyn64_phy32_debug
 Checking test 121 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.843935
-  0: The maximum resident set size (KB)                   = 871604
+  0: The total amount of wall time                        = 290.746109
+  0: The maximum resident set size (KB)                   = 871932
 
 Test 121 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_atm
 Checking test 122 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 351.679786
-  0: The maximum resident set size (KB)                   = 665744
+  0: The total amount of wall time                        = 357.710949
+  0: The maximum resident set size (KB)                   = 665488
 
 Test 122 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_atm_thompson_gfdlsf
 Checking test 123 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 395.344232
-  0: The maximum resident set size (KB)                   = 1018952
+  0: The total amount of wall time                        = 400.513851
+  0: The maximum resident set size (KB)                   = 1019056
 
 Test 123 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_atm_ocn
 Checking test 124 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4139,14 +4139,14 @@ Checking test 124 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 434.952511
-  0: The maximum resident set size (KB)                   = 692756
+  0: The total amount of wall time                        = 433.746597
+  0: The maximum resident set size (KB)                   = 692056
 
 Test 124 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_atm_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_atm_wav
 Checking test 125 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4155,14 +4155,14 @@ Checking test 125 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 895.285771
-  0: The maximum resident set size (KB)                   = 727084
+  0: The total amount of wall time                        = 897.881222
+  0: The maximum resident set size (KB)                   = 727712
 
 Test 125 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_atm_ocn_wav
 Checking test 126 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4173,28 +4173,28 @@ Checking test 126 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1000.767392
-  0: The maximum resident set size (KB)                   = 737140
+  0: The total amount of wall time                        = 1002.212858
+  0: The maximum resident set size (KB)                   = 737484
 
 Test 126 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_1nest_atm
 Checking test 127 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 574.152335
-  0: The maximum resident set size (KB)                   = 263408
+  0: The total amount of wall time                        = 572.725234
+  0: The maximum resident set size (KB)                   = 264128
 
 Test 127 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_telescopic_2nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_telescopic_2nests_atm
 Checking test 128 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4203,28 +4203,28 @@ Checking test 128 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 623.424577
-  0: The maximum resident set size (KB)                   = 265376
+  0: The total amount of wall time                        = 624.448197
+  0: The maximum resident set size (KB)                   = 266344
 
 Test 128 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_global_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_global_1nest_atm
 Checking test 129 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 255.461011
-  0: The maximum resident set size (KB)                   = 165680
+  0: The total amount of wall time                        = 263.001474
+  0: The maximum resident set size (KB)                   = 165588
 
 Test 129 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_global_multiple_4nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_global_multiple_4nests_atm
 Checking test 130 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4242,14 +4242,14 @@ Checking test 130 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 736.905048
-  0: The maximum resident set size (KB)                   = 235084
+  0: The total amount of wall time                        = 737.196669
+  0: The maximum resident set size (KB)                   = 219200
 
 Test 130 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_specified_moving_1nest_atm
 Checking test 131 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4258,28 +4258,28 @@ Checking test 131 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 333.354580
-  0: The maximum resident set size (KB)                   = 272760
+  0: The total amount of wall time                        = 336.181063
+  0: The maximum resident set size (KB)                   = 272564
 
 Test 131 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_storm_following_1nest_atm
 Checking test 132 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 321.483513
-  0: The maximum resident set size (KB)                   = 273468
+  0: The total amount of wall time                        = 323.072308
+  0: The maximum resident set size (KB)                   = 272528
 
 Test 132 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 133 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4288,14 +4288,14 @@ Checking test 133 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 338.612977
-  0: The maximum resident set size (KB)                   = 297768
+  0: The total amount of wall time                        = 335.045331
+  0: The maximum resident set size (KB)                   = 297604
 
 Test 133 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 134 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4306,28 +4306,28 @@ Checking test 134 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 872.526047
-  0: The maximum resident set size (KB)                   = 361424
+  0: The total amount of wall time                        = 875.612205
+  0: The maximum resident set size (KB)                   = 361340
 
 Test 134 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_global_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_global_storm_following_1nest_atm
 Checking test 135 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 95.159038
-  0: The maximum resident set size (KB)                   = 183852
+  0: The total amount of wall time                        = 96.513447
+  0: The maximum resident set size (KB)                   = 183616
 
 Test 135 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_docn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_docn
 Checking test 136 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4335,14 +4335,14 @@ Checking test 136 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 420.844044
-  0: The maximum resident set size (KB)                   = 699996
+  0: The total amount of wall time                        = 419.357595
+  0: The maximum resident set size (KB)                   = 699732
 
 Test 136 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_docn_oisst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_docn_oisst
 Checking test 137 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4350,131 +4350,131 @@ Checking test 137 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 421.642908
-  0: The maximum resident set size (KB)                   = 686156
+  0: The total amount of wall time                        = 419.103918
+  0: The maximum resident set size (KB)                   = 686508
 
 Test 137 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/hafs_regional_datm_cdeps
 Checking test 138 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1178.404177
-  0: The maximum resident set size (KB)                   = 809052
+  0: The total amount of wall time                        = 1181.976436
+  0: The maximum resident set size (KB)                   = 809040
 
 Test 138 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_control_cfsr
 Checking test 139 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 159.839529
- 0: The maximum resident set size (KB)                   = 721276
+ 0: The total amount of wall time                        = 158.367680
+ 0: The maximum resident set size (KB)                   = 721196
 
 Test 139 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_restart_cfsr
 Checking test 140 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 95.460803
- 0: The maximum resident set size (KB)                   = 715956
+ 0: The total amount of wall time                        = 98.429707
+ 0: The maximum resident set size (KB)                   = 716212
 
 Test 140 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_control_gefs
 Checking test 141 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.485023
- 0: The maximum resident set size (KB)                   = 601240
+ 0: The total amount of wall time                        = 154.561441
+ 0: The maximum resident set size (KB)                   = 605152
 
 Test 141 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_iau_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_iau_gefs
 Checking test 142 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 158.579732
- 0: The maximum resident set size (KB)                   = 605476
+ 0: The total amount of wall time                        = 158.204872
+ 0: The maximum resident set size (KB)                   = 601384
 
 Test 142 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_stochy_gefs
 Checking test 143 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.946050
- 0: The maximum resident set size (KB)                   = 603464
+ 0: The total amount of wall time                        = 156.045060
+ 0: The maximum resident set size (KB)                   = 603216
 
 Test 143 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_ciceC_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_ciceC_cfsr
 Checking test 144 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.006403
- 0: The maximum resident set size (KB)                   = 721100
+ 0: The total amount of wall time                        = 162.141727
+ 0: The maximum resident set size (KB)                   = 721192
 
 Test 144 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_bulk_cfsr
 Checking test 145 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.652996
- 0: The maximum resident set size (KB)                   = 721328
+ 0: The total amount of wall time                        = 158.128418
+ 0: The maximum resident set size (KB)                   = 721196
 
 Test 145 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_bulk_gefs
 Checking test 146 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.107992
- 0: The maximum resident set size (KB)                   = 605552
+ 0: The total amount of wall time                        = 152.298173
+ 0: The maximum resident set size (KB)                   = 601316
 
 Test 146 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_mx025_cfsr
 Checking test 147 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4483,14 +4483,14 @@ Checking test 147 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 422.342056
-  0: The maximum resident set size (KB)                   = 496804
+  0: The total amount of wall time                        = 460.219568
+  0: The maximum resident set size (KB)                   = 496988
 
 Test 147 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_mx025_gefs
 Checking test 148 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4499,64 +4499,64 @@ Checking test 148 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 438.224754
-  0: The maximum resident set size (KB)                   = 476120
+  0: The total amount of wall time                        = 428.025398
+  0: The maximum resident set size (KB)                   = 476160
 
 Test 148 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_multiple_files_cfsr
 Checking test 149 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.947425
- 0: The maximum resident set size (KB)                   = 707664
+ 0: The total amount of wall time                        = 160.034229
+ 0: The maximum resident set size (KB)                   = 721228
 
 Test 149 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_3072x1536_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_3072x1536_cfsr
 Checking test 150 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 215.142310
- 0: The maximum resident set size (KB)                   = 1963264
+ 0: The total amount of wall time                        = 216.506482
+ 0: The maximum resident set size (KB)                   = 1963308
 
 Test 150 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_gfs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_gfs
 Checking test 151 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 217.171653
- 0: The maximum resident set size (KB)                   = 1963332
+ 0: The total amount of wall time                        = 220.451306
+ 0: The maximum resident set size (KB)                   = 1963320
 
 Test 151 datm_cdeps_gfs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_debug_cfsr
 Checking test 152 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 370.741876
- 0: The maximum resident set size (KB)                   = 715020
+ 0: The total amount of wall time                        = 374.514229
+ 0: The maximum resident set size (KB)                   = 714960
 
 Test 152 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_lnd_gswp3
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_lnd_gswp3
 Checking test 153 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4565,14 +4565,14 @@ Checking test 153 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.716776
-  0: The maximum resident set size (KB)                   = 149932
+  0: The total amount of wall time                        = 12.103904
+  0: The maximum resident set size (KB)                   = 145780
 
 Test 153 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/datm_cdeps_lnd_gswp3_rst
 Checking test 154 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4581,14 +4581,14 @@ Checking test 154 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 17.434930
-  0: The maximum resident set size (KB)                   = 149888
+  0: The total amount of wall time                        = 19.993381
+  0: The maximum resident set size (KB)                   = 150072
 
 Test 154 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_p8_atmlnd_sbs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_p8_atmlnd_sbs
 Checking test 155 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4673,14 +4673,14 @@ Checking test 155 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.129455
-  0: The maximum resident set size (KB)                   = 1423616
+  0: The total amount of wall time                        = 247.580502
+  0: The maximum resident set size (KB)                   = 1424052
 
 Test 155 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/control_atmwav
 Checking test 156 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4724,14 +4724,14 @@ Checking test 156 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 92.842819
-  0: The maximum resident set size (KB)                   = 448668
+  0: The total amount of wall time                        = 99.184112
+  0: The maximum resident set size (KB)                   = 448596
 
 Test 156 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/atmaero_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/atmaero_control_p8
 Checking test 157 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4775,14 +4775,14 @@ Checking test 157 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 245.073218
+  0: The total amount of wall time                        = 257.332171
   0: The maximum resident set size (KB)                   = 1460668
 
 Test 157 atmaero_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/atmaero_control_p8_rad
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/atmaero_control_p8_rad
 Checking test 158 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4826,14 +4826,14 @@ Checking test 158 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 296.710979
-  0: The maximum resident set size (KB)                   = 1498364
+  0: The total amount of wall time                        = 302.093490
+  0: The maximum resident set size (KB)                   = 1481600
 
 Test 158 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/atmaero_control_p8_rad_micro
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/atmaero_control_p8_rad_micro
 Checking test 159 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4877,14 +4877,14 @@ Checking test 159 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 299.159405
-  0: The maximum resident set size (KB)                   = 1485668
+  0: The total amount of wall time                        = 303.494454
+  0: The maximum resident set size (KB)                   = 1502740
 
 Test 159 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_42075/regional_atmaq
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_35729/regional_atmaq
 Checking test 160 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4900,12 +4900,12 @@ Checking test 160 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 697.971990
-  0: The maximum resident set size (KB)                   = 764152
+  0: The total amount of wall time                        = 700.068580
+  0: The maximum resident set size (KB)                   = 764196
 
 Test 160 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 17:08:09 EDT 2022
-Elapsed time: 03h:35m:29s. Have a nice day!
+Tue Nov  8 03:33:38 EST 2022
+Elapsed time: 07h:10m:39s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,21 +1,21 @@
-Wed Nov  2 14:33:24 UTC 2022
+Mon Nov  7 20:21:29 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 296 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 353 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 004 elapsed time 99 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 006 elapsed time 383 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 303 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 307 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 263 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 237 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 307 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 308 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 308 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 274 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 011 elapsed time 153 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 111 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 012 elapsed time 112 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -62,14 +62,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 847.917297
-  0: The maximum resident set size (KB)                   = 477160
+  0: The total amount of wall time                        = 852.960363
+  0: The maximum resident set size (KB)                   = 474004
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -108,14 +108,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 407.111301
-  0: The maximum resident set size (KB)                   = 185720
+  0: The total amount of wall time                        = 403.561531
+  0: The maximum resident set size (KB)                   = 184312
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -154,14 +154,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 675.849989
-0: The maximum resident set size (KB)                   = 705980
+0: The total amount of wall time                        = 673.174302
+0: The maximum resident set size (KB)                   = 701820
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -172,14 +172,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 639.017725
-  0: The maximum resident set size (KB)                   = 479272
+  0: The total amount of wall time                        = 662.299911
+  0: The maximum resident set size (KB)                   = 478532
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_ras
 Checking test 005 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -190,14 +190,14 @@ Checking test 005 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 833.126753
-  0: The maximum resident set size (KB)                   = 487260
+  0: The total amount of wall time                        = 831.120376
+  0: The maximum resident set size (KB)                   = 488016
 
 Test 005 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_p8
 Checking test 006 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -244,14 +244,14 @@ Checking test 006 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 880.295063
-  0: The maximum resident set size (KB)                   = 1233788
+  0: The total amount of wall time                        = 890.904466
+  0: The maximum resident set size (KB)                   = 1237664
 
 Test 006 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_control
 Checking test 007 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -298,14 +298,14 @@ Checking test 007 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1465.271975
-  0: The maximum resident set size (KB)                   = 833860
+  0: The total amount of wall time                        = 1462.603407
+  0: The maximum resident set size (KB)                   = 825404
 
 Test 007 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_decomp
 Checking test 008 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1447.674957
-  0: The maximum resident set size (KB)                   = 832196
+  0: The total amount of wall time                        = 1458.391131
+  0: The maximum resident set size (KB)                   = 825968
 
 Test 008 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_2threads
 Checking test 009 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1449.330638
- 0: The maximum resident set size (KB)                   = 895276
+ 0: The total amount of wall time                        = 1456.145914
+ 0: The maximum resident set size (KB)                   = 896008
 
 Test 009 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_restart
 Checking test 010 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -452,14 +452,14 @@ Checking test 010 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 707.047683
-  0: The maximum resident set size (KB)                   = 540220
+  0: The total amount of wall time                        = 722.645163
+  0: The maximum resident set size (KB)                   = 543912
 
 Test 010 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_sfcdiff
 Checking test 011 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1452.558453
-  0: The maximum resident set size (KB)                   = 836032
+  0: The total amount of wall time                        = 1473.871007
+  0: The maximum resident set size (KB)                   = 830984
 
 Test 011 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_sfcdiff_decomp
 Checking test 012 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1440.048918
-  0: The maximum resident set size (KB)                   = 832620
+  0: The total amount of wall time                        = 1451.866963
+  0: The maximum resident set size (KB)                   = 831380
 
 Test 012 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_sfcdiff_restart
 Checking test 013 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -606,14 +606,14 @@ Checking test 013 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1082.702733
-  0: The maximum resident set size (KB)                   = 542936
+  0: The total amount of wall time                        = 1066.410965
+  0: The maximum resident set size (KB)                   = 542260
 
 Test 013 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control
 Checking test 014 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -660,14 +660,14 @@ Checking test 014 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1406.450548
-  0: The maximum resident set size (KB)                   = 830196
+  0: The total amount of wall time                        = 1466.293131
+  0: The maximum resident set size (KB)                   = 830692
 
 Test 014 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_2threads
 Checking test 015 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1454.183275
- 0: The maximum resident set size (KB)                   = 888948
+ 0: The total amount of wall time                        = 1397.321269
+ 0: The maximum resident set size (KB)                   = 889680
 
 Test 015 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_decomp
 Checking test 016 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1419.047644
-  0: The maximum resident set size (KB)                   = 831160
+  0: The total amount of wall time                        = 1439.665908
+  0: The maximum resident set size (KB)                   = 828300
 
 Test 016 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_restart
 Checking test 017 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -814,14 +814,14 @@ Checking test 017 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1044.373439
-  0: The maximum resident set size (KB)                   = 539296
+  0: The total amount of wall time                        = 1028.897405
+  0: The maximum resident set size (KB)                   = 535508
 
 Test 017 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_v1beta
 Checking test 018 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -868,14 +868,14 @@ Checking test 018 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1461.392788
-  0: The maximum resident set size (KB)                   = 827676
+  0: The total amount of wall time                        = 1453.461239
+  0: The maximum resident set size (KB)                   = 823368
 
 Test 018 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_conus13km_hrrr_warm
 Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -884,14 +884,14 @@ Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 759.648398
-  0: The maximum resident set size (KB)                   = 635236
+  0: The total amount of wall time                        = 713.198701
+  0: The maximum resident set size (KB)                   = 636012
 
 Test 019 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_smoke_conus13km_hrrr_warm
 Checking test 020 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -900,14 +900,14 @@ Checking test 020 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 796.266180
-  0: The maximum resident set size (KB)                   = 649744
+  0: The total amount of wall time                        = 795.059766
+  0: The maximum resident set size (KB)                   = 651188
 
 Test 020 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_conus13km_radar_tten_warm
 Checking test 021 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -916,14 +916,14 @@ Checking test 021 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 778.626626
-  0: The maximum resident set size (KB)                   = 639648
+  0: The total amount of wall time                        = 770.914982
+  0: The maximum resident set size (KB)                   = 638784
 
 Test 021 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 022 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -932,222 +932,222 @@ Checking test 022 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1007.672277
-  0: The maximum resident set size (KB)                   = 634472
+  0: The total amount of wall time                        = 1052.381862
+  0: The maximum resident set size (KB)                   = 634700
 
 Test 022 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_debug
 Checking test 023 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 100.611796
-  0: The maximum resident set size (KB)                   = 471540
+  0: The total amount of wall time                        = 103.803253
+  0: The maximum resident set size (KB)                   = 474632
 
 Test 023 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_diag_debug
 Checking test 024 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 128.102787
-  0: The maximum resident set size (KB)                   = 527044
+  0: The total amount of wall time                        = 129.543537
+  0: The maximum resident set size (KB)                   = 531684
 
 Test 024 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/regional_debug
 Checking test 025 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 129.991159
- 0: The maximum resident set size (KB)                   = 560428
+ 0: The total amount of wall time                        = 127.819463
+ 0: The maximum resident set size (KB)                   = 561708
 
 Test 025 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_control_debug
 Checking test 026 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.510454
-  0: The maximum resident set size (KB)                   = 846484
+  0: The total amount of wall time                        = 174.386721
+  0: The maximum resident set size (KB)                   = 847740
 
 Test 026 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_debug
 Checking test 027 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.707744
-  0: The maximum resident set size (KB)                   = 836892
+  0: The total amount of wall time                        = 170.979998
+  0: The maximum resident set size (KB)                   = 841224
 
 Test 027 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_diag_debug
 Checking test 028 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.240876
-  0: The maximum resident set size (KB)                   = 926152
+  0: The total amount of wall time                        = 214.446622
+  0: The maximum resident set size (KB)                   = 930076
 
 Test 028 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 029 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.099663
-  0: The maximum resident set size (KB)                   = 844672
+  0: The total amount of wall time                        = 276.776600
+  0: The maximum resident set size (KB)                   = 845648
 
 Test 029 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_progcld_thompson_debug
 Checking test 030 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.608435
-  0: The maximum resident set size (KB)                   = 845616
+  0: The total amount of wall time                        = 174.712460
+  0: The maximum resident set size (KB)                   = 841944
 
 Test 030 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_v1beta_debug
 Checking test 031 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.115336
-  0: The maximum resident set size (KB)                   = 841316
+  0: The total amount of wall time                        = 173.137093
+  0: The maximum resident set size (KB)                   = 837556
 
 Test 031 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_ras_debug
 Checking test 032 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 106.081832
-  0: The maximum resident set size (KB)                   = 486228
+  0: The total amount of wall time                        = 107.773553
+  0: The maximum resident set size (KB)                   = 484044
 
 Test 032 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_stochy_debug
 Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 117.826021
-  0: The maximum resident set size (KB)                   = 475384
+  0: The total amount of wall time                        = 123.862866
+  0: The maximum resident set size (KB)                   = 476748
 
 Test 033 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_debug_p8
 Checking test 034 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 118.237134
-  0: The maximum resident set size (KB)                   = 1230344
+  0: The total amount of wall time                        = 116.976078
+  0: The maximum resident set size (KB)                   = 1234224
 
 Test 034 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_conus13km_hrrr_warm_debug
 Checking test 035 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 562.853114
-  0: The maximum resident set size (KB)                   = 644392
+  0: The total amount of wall time                        = 540.864722
+  0: The maximum resident set size (KB)                   = 646704
 
 Test 035 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rrfs_conus13km_radar_tten_warm_debug
 Checking test 036 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 571.912358
-  0: The maximum resident set size (KB)                   = 647952
+  0: The total amount of wall time                        = 525.924249
+  0: The maximum resident set size (KB)                   = 648824
 
 Test 036 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/control_wam_debug
 Checking test 037 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 183.307186
-  0: The maximum resident set size (KB)                   = 193864
+  0: The total amount of wall time                        = 182.857187
+  0: The maximum resident set size (KB)                   = 194496
 
 Test 037 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_control_dyn32_phy32
 Checking test 038 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 038 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1443.228277
-  0: The maximum resident set size (KB)                   = 684492
+  0: The total amount of wall time                        = 1506.364818
+  0: The maximum resident set size (KB)                   = 685604
 
 Test 038 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_dyn32_phy32
 Checking test 039 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 039 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 728.211585
-  0: The maximum resident set size (KB)                   = 685684
+  0: The total amount of wall time                        = 726.244404
+  0: The maximum resident set size (KB)                   = 689608
 
 Test 039 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_2threads_dyn32_phy32
 Checking test 040 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 040 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1442.183352
- 0: The maximum resident set size (KB)                   = 725624
+ 0: The total amount of wall time                        = 1419.534985
+ 0: The maximum resident set size (KB)                   = 725692
 
 Test 040 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_2threads_dyn32_phy32
 Checking test 041 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 041 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 716.449363
- 0: The maximum resident set size (KB)                   = 727144
+ 0: The total amount of wall time                        = 710.312795
+ 0: The maximum resident set size (KB)                   = 725916
 
 Test 041 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_decomp_dyn32_phy32
 Checking test 042 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 042 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 712.690713
-  0: The maximum resident set size (KB)                   = 687956
+  0: The total amount of wall time                        = 714.504232
+  0: The maximum resident set size (KB)                   = 689100
 
 Test 042 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_restart_dyn32_phy32
 Checking test 043 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1456,14 +1456,14 @@ Checking test 043 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1058.817081
-  0: The maximum resident set size (KB)                   = 512844
+  0: The total amount of wall time                        = 1074.065618
+  0: The maximum resident set size (KB)                   = 509532
 
 Test 043 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_restart_dyn32_phy32
 Checking test 044 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1502,14 +1502,14 @@ Checking test 044 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 351.590711
-  0: The maximum resident set size (KB)                   = 508680
+  0: The total amount of wall time                        = 359.016647
+  0: The maximum resident set size (KB)                   = 506136
 
 Test 044 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_control_dyn64_phy32
 Checking test 045 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1556,56 +1556,56 @@ Checking test 045 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1059.457240
-  0: The maximum resident set size (KB)                   = 708000
+  0: The total amount of wall time                        = 1063.913341
+  0: The maximum resident set size (KB)                   = 705992
 
 Test 045 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_control_debug_dyn32_phy32
 Checking test 046 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.700190
-  0: The maximum resident set size (KB)                   = 697604
+  0: The total amount of wall time                        = 174.132837
+  0: The maximum resident set size (KB)                   = 701276
 
 Test 046 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/hrrr_control_debug_dyn32_phy32
 Checking test 047 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.590956
-  0: The maximum resident set size (KB)                   = 698432
+  0: The total amount of wall time                        = 169.370275
+  0: The maximum resident set size (KB)                   = 705744
 
 Test 047 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/rap_control_dyn64_phy32_debug
 Checking test 048 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.373206
-  0: The maximum resident set size (KB)                   = 722896
+  0: The total amount of wall time                        = 201.488532
+  0: The maximum resident set size (KB)                   = 724268
 
 Test 048 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/cpld_control_p8
 Checking test 049 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1670,14 +1670,14 @@ Checking test 049 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1699.427636
-  0: The maximum resident set size (KB)                   = 1430692
+  0: The total amount of wall time                        = 1697.533346
+  0: The maximum resident set size (KB)                   = 1431920
 
 Test 049 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/cpld_control_nowave_noaero_p8
 Checking test 050 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1739,14 +1739,14 @@ Checking test 050 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1198.934149
-  0: The maximum resident set size (KB)                   = 1327328
+  0: The total amount of wall time                        = 1226.534461
+  0: The maximum resident set size (KB)                   = 1327208
 
 Test 050 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/cpld_debug_p8
 Checking test 051 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1799,25 +1799,25 @@ Checking test 051 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 962.100024
-  0: The maximum resident set size (KB)                   = 1442560
+  0: The total amount of wall time                        = 832.450546
+  0: The maximum resident set size (KB)                   = 1441084
 
 Test 051 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_543/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_27264/datm_cdeps_control_cfsr
 Checking test 052 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 172.688213
- 0: The maximum resident set size (KB)                   = 671256
+ 0: The total amount of wall time                        = 174.120484
+ 0: The maximum resident set size (KB)                   = 663796
 
 Test 052 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 15:31:01 UTC 2022
-Elapsed time: 00h:57m:38s. Have a nice day!
+Mon Nov  7 21:18:20 UTC 2022
+Elapsed time: 00h:56m:51s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,34 +1,34 @@
-Wed Nov  2 14:18:34 UTC 2022
+Mon Nov  7 21:04:27 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 585 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 558 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 212 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 201 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 392 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 382 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 581 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 570 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 216 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 199 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 385 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 391 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 007 elapsed time 347 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 345 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 337 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 314 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 664 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 337 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 317 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 153 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 154 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 556 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 561 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 350 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 334 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 313 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 649 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 328 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 351 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 158 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 153 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 543 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 546 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 019 elapsed time 183 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 111 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 54 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 361 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 522 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 339 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 332 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 108 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 68 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 350 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 544 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 344 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 333 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 333.216522
-  0: The maximum resident set size (KB)                   = 3178020
+  0: The total amount of wall time                        = 335.722594
+  0: The maximum resident set size (KB)                   = 3183808
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -153,14 +153,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 190.932986
-  0: The maximum resident set size (KB)                   = 3050456
+  0: The total amount of wall time                        = 190.070716
+  0: The maximum resident set size (KB)                   = 3046220
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -213,14 +213,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 417.214455
-  0: The maximum resident set size (KB)                   = 3448856
+  0: The total amount of wall time                        = 449.224494
+  0: The maximum resident set size (KB)                   = 3449680
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_esmfthreads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 351.394723
-  0: The maximum resident set size (KB)                   = 3514184
+  0: The total amount of wall time                        = 353.649612
+  0: The maximum resident set size (KB)                   = 3512432
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 333.696359
-  0: The maximum resident set size (KB)                   = 3166272
+  0: The total amount of wall time                        = 335.680980
+  0: The maximum resident set size (KB)                   = 3171660
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 275.595067
-  0: The maximum resident set size (KB)                   = 3024576
+  0: The total amount of wall time                        = 274.039841
+  0: The maximum resident set size (KB)                   = 3017000
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_ciceC_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_ciceC_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_ciceC_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 335.615846
-  0: The maximum resident set size (KB)                   = 3181824
+  0: The total amount of wall time                        = 333.893445
+  0: The maximum resident set size (KB)                   = 3180124
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -525,14 +525,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 658.565316
-  0: The maximum resident set size (KB)                   = 3222680
+  0: The total amount of wall time                        = 653.693710
+  0: The maximum resident set size (KB)                   = 3223288
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -585,14 +585,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 419.819885
-  0: The maximum resident set size (KB)                   = 3139940
+  0: The total amount of wall time                        = 409.448996
+  0: The maximum resident set size (KB)                   = 3137304
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -640,14 +640,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 825.197857
-  0: The maximum resident set size (KB)                   = 3996384
+  0: The total amount of wall time                        = 823.745485
+  0: The maximum resident set size (KB)                   = 3981612
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_restart_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -695,14 +695,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 488.553233
-  0: The maximum resident set size (KB)                   = 3942228
+  0: The total amount of wall time                        = 491.190423
+  0: The maximum resident set size (KB)                   = 3944988
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_bmark_esmfthreads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_bmark_esmfthreads_p8
 Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -750,14 +750,14 @@ Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 759.788874
-   0: The maximum resident set size (KB)                   = 4034584
+   0: The total amount of wall time                        = 767.249894
+   0: The maximum resident set size (KB)                   = 4037900
 
 Test 012 cpld_bmark_esmfthreads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -821,14 +821,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 230.836447
-  0: The maximum resident set size (KB)                   = 1730860
+  0: The total amount of wall time                        = 230.167625
+  0: The maximum resident set size (KB)                   = 1734836
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -890,14 +890,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 254.317164
-  0: The maximum resident set size (KB)                   = 1758652
+  0: The total amount of wall time                        = 253.644155
+  0: The maximum resident set size (KB)                   = 1762960
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -950,14 +950,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 655.521440
-  0: The maximum resident set size (KB)                   = 3251860
+  0: The total amount of wall time                        = 652.713214
+  0: The maximum resident set size (KB)                   = 3245836
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_debug_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 397.677455
-  0: The maximum resident set size (KB)                   = 1746652
+  0: The total amount of wall time                        = 395.596006
+  0: The maximum resident set size (KB)                   = 1740788
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_noaero_p8_agrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1078,14 +1078,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 261.407299
-  0: The maximum resident set size (KB)                   = 1756652
+  0: The total amount of wall time                        = 266.277058
+  0: The maximum resident set size (KB)                   = 1754816
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1135,14 +1135,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 501.074005
- 0: The maximum resident set size (KB)                   = 2797656
+ 0: The total amount of wall time                        = 505.757128
+ 0: The maximum resident set size (KB)                   = 2793432
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_warmstart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1192,14 +1192,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 134.675429
- 0: The maximum resident set size (KB)                   = 2800728
+ 0: The total amount of wall time                        = 137.679937
+ 0: The maximum resident set size (KB)                   = 2803016
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/cpld_restart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1249,14 +1249,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 71.673252
- 0: The maximum resident set size (KB)                   = 2238140
+ 0: The total amount of wall time                        = 73.654885
+ 0: The maximum resident set size (KB)                   = 2244188
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control
 Checking test 021 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1303,14 +1303,14 @@ Checking test 021 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.627224
-  0: The maximum resident set size (KB)                   = 631616
+  0: The total amount of wall time                        = 134.638331
+  0: The maximum resident set size (KB)                   = 632132
 
 Test 021 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_decomp
 Checking test 022 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 022 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 140.235886
-  0: The maximum resident set size (KB)                   = 621836
+  0: The total amount of wall time                        = 139.162029
+  0: The maximum resident set size (KB)                   = 621964
 
 Test 022 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_2dwrtdecomp
 Checking test 023 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1371,14 +1371,14 @@ Checking test 023 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 132.729753
-  0: The maximum resident set size (KB)                   = 633972
+  0: The total amount of wall time                        = 132.552229
+  0: The maximum resident set size (KB)                   = 636224
 
 Test 023 control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_2threads
 Checking test 024 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1421,14 +1421,14 @@ Checking test 024 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 162.195424
- 0: The maximum resident set size (KB)                   = 671632
+ 0: The total amount of wall time                        = 163.533068
+ 0: The maximum resident set size (KB)                   = 673500
 
 Test 024 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_restart
 Checking test 025 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1467,14 +1467,14 @@ Checking test 025 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 69.044002
-  0: The maximum resident set size (KB)                   = 472152
+  0: The total amount of wall time                        = 68.930628
+  0: The maximum resident set size (KB)                   = 474692
 
 Test 025 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_fhzero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_fhzero
 Checking test 026 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1517,14 +1517,14 @@ Checking test 026 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.716703
-  0: The maximum resident set size (KB)                   = 631544
+  0: The total amount of wall time                        = 125.215011
+  0: The maximum resident set size (KB)                   = 634304
 
 Test 026 control_fhzero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_CubedSphereGrid
 Checking test 027 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1551,28 +1551,28 @@ Checking test 027 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.371363
-  0: The maximum resident set size (KB)                   = 633572
+  0: The total amount of wall time                        = 129.438558
+  0: The maximum resident set size (KB)                   = 630004
 
 Test 027 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_CubedSphereGrid_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_CubedSphereGrid_parallel
 Checking test 028 control_CubedSphereGrid_parallel results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 127.178272
-  0: The maximum resident set size (KB)                   = 632272
+  0: The total amount of wall time                        = 126.752399
+  0: The maximum resident set size (KB)                   = 635492
 
 Test 028 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_latlon
 Checking test 029 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1583,32 +1583,32 @@ Checking test 029 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.989809
-  0: The maximum resident set size (KB)                   = 635640
+  0: The total amount of wall time                        = 131.731222
+  0: The maximum resident set size (KB)                   = 635436
 
 Test 029 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_wrtGauss_netcdf_parallel
 Checking test 030 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.007361
-  0: The maximum resident set size (KB)                   = 629908
+  0: The total amount of wall time                        = 134.647132
+  0: The maximum resident set size (KB)                   = 630812
 
 Test 030 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_c48
 Checking test 031 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1647,14 +1647,14 @@ Checking test 031 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 348.696969
-0: The maximum resident set size (KB)                   = 824420
+0: The total amount of wall time                        = 350.176564
+0: The maximum resident set size (KB)                   = 820412
 
 Test 031 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_c192
 Checking test 032 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1665,14 +1665,14 @@ Checking test 032 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 523.095761
-  0: The maximum resident set size (KB)                   = 767200
+  0: The total amount of wall time                        = 524.661054
+  0: The maximum resident set size (KB)                   = 770464
 
 Test 032 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_c384
 Checking test 033 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1683,14 +1683,14 @@ Checking test 033 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 691.195449
-  0: The maximum resident set size (KB)                   = 1091996
+  0: The total amount of wall time                        = 693.643644
+  0: The maximum resident set size (KB)                   = 1090412
 
 Test 033 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_c384gdas
 Checking test 034 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1733,14 +1733,14 @@ Checking test 034 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 583.312812
-  0: The maximum resident set size (KB)                   = 1250148
+  0: The total amount of wall time                        = 576.167944
+  0: The maximum resident set size (KB)                   = 1245700
 
 Test 034 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_c384_progsigma
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_c384_progsigma
 Checking test 035 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 035 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 706.618360
-  0: The maximum resident set size (KB)                   = 1082128
+  0: The total amount of wall time                        = 710.294250
+  0: The maximum resident set size (KB)                   = 1075720
 
 Test 035 control_c384_progsigma PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_stochy
 Checking test 036 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1769,28 +1769,28 @@ Checking test 036 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 86.528546
-  0: The maximum resident set size (KB)                   = 637884
+  0: The total amount of wall time                        = 86.314116
+  0: The maximum resident set size (KB)                   = 636820
 
 Test 036 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_stochy_restart
 Checking test 037 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.165387
-  0: The maximum resident set size (KB)                   = 492364
+  0: The total amount of wall time                        = 45.684638
+  0: The maximum resident set size (KB)                   = 486704
 
 Test 037 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_lndp
 Checking test 038 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1801,14 +1801,14 @@ Checking test 038 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 79.853996
-  0: The maximum resident set size (KB)                   = 636148
+  0: The total amount of wall time                        = 78.817038
+  0: The maximum resident set size (KB)                   = 640336
 
 Test 038 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_iovr4
 Checking test 039 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1823,14 +1823,14 @@ Checking test 039 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.788346
-  0: The maximum resident set size (KB)                   = 631812
+  0: The total amount of wall time                        = 133.802119
+  0: The maximum resident set size (KB)                   = 637612
 
 Test 039 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_iovr5
 Checking test 040 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1845,14 +1845,14 @@ Checking test 040 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.646540
-  0: The maximum resident set size (KB)                   = 631344
+  0: The total amount of wall time                        = 133.361649
+  0: The maximum resident set size (KB)                   = 632448
 
 Test 040 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_p8
 Checking test 041 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1899,14 +1899,14 @@ Checking test 041 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.786631
-  0: The maximum resident set size (KB)                   = 1607484
+  0: The total amount of wall time                        = 164.740936
+  0: The maximum resident set size (KB)                   = 1612212
 
 Test 041 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_p8_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_p8_lndp
 Checking test 042 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 042 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 304.965192
-  0: The maximum resident set size (KB)                   = 1606328
+  0: The total amount of wall time                        = 308.245165
+  0: The maximum resident set size (KB)                   = 1609176
 
 Test 042 control_p8_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_restart_p8
 Checking test 043 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 043 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 84.478551
-  0: The maximum resident set size (KB)                   = 870608
+  0: The total amount of wall time                        = 89.377350
+  0: The maximum resident set size (KB)                   = 868996
 
 Test 043 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_decomp_p8
 Checking test 044 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2021,14 +2021,14 @@ Checking test 044 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.858424
-  0: The maximum resident set size (KB)                   = 1601872
+  0: The total amount of wall time                        = 169.940406
+  0: The maximum resident set size (KB)                   = 1588220
 
 Test 044 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_2threads_p8
 Checking test 045 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 045 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 200.680100
- 0: The maximum resident set size (KB)                   = 1672960
+ 0: The total amount of wall time                        = 198.319439
+ 0: The maximum resident set size (KB)                   = 1663992
 
 Test 045 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_p8_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_p8_rrtmgp
 Checking test 046 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 046 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.051770
-  0: The maximum resident set size (KB)                   = 1732128
+  0: The total amount of wall time                        = 198.296218
+  0: The maximum resident set size (KB)                   = 1736120
 
 Test 046 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/merra2_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.493115
-  0: The maximum resident set size (KB)                   = 1617384
+  0: The total amount of wall time                        = 167.126680
+  0: The maximum resident set size (KB)                   = 1619816
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2197,28 +2197,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 344.564721
- 0: The maximum resident set size (KB)                   = 844580
+ 0: The total amount of wall time                        = 344.360306
+ 0: The maximum resident set size (KB)                   = 851176
 
 Test 048 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 189.556339
- 0: The maximum resident set size (KB)                   = 837476
+ 0: The total amount of wall time                        = 188.759166
+ 0: The maximum resident set size (KB)                   = 837696
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_control_2dwrtdecomp
 Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 345.758054
- 0: The maximum resident set size (KB)                   = 842024
+ 0: The total amount of wall time                        = 345.036169
+ 0: The maximum resident set size (KB)                   = 844508
 
 Test 050 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2244,14 +2244,14 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 366.715277
- 0: The maximum resident set size (KB)                   = 830608
+ 0: The total amount of wall time                        = 365.312422
+ 0: The maximum resident set size (KB)                   = 835164
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2262,28 +2262,28 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 252.267701
- 0: The maximum resident set size (KB)                   = 816040
+ 0: The total amount of wall time                        = 246.614116
+ 0: The maximum resident set size (KB)                   = 807936
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_netcdf_parallel
 Checking test 053 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 338.419756
- 0: The maximum resident set size (KB)                   = 836480
+ 0: The total amount of wall time                        = 341.955109
+ 0: The maximum resident set size (KB)                   = 842016
 
 Test 053 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_3km
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_3km
 Checking test 054 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2294,14 +2294,14 @@ Checking test 054 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 258.555386
-  0: The maximum resident set size (KB)                   = 862884
+  0: The total amount of wall time                        = 256.301583
+  0: The maximum resident set size (KB)                   = 861820
 
 Test 054 regional_3km PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_3km_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_3km_decomp
 Checking test 055 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2312,14 +2312,14 @@ Checking test 055 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 274.963562
-  0: The maximum resident set size (KB)                   = 862724
+  0: The total amount of wall time                        = 274.476992
+  0: The maximum resident set size (KB)                   = 865768
 
 Test 055 regional_3km_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_3km_wofs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_3km_wofs
 Checking test 056 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2330,14 +2330,14 @@ Checking test 056 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 342.909579
-  0: The maximum resident set size (KB)                   = 624756
+  0: The total amount of wall time                        = 339.628022
+  0: The maximum resident set size (KB)                   = 623968
 
 Test 056 regional_3km_wofs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_control
 Checking test 057 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2384,14 +2384,14 @@ Checking test 057 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.782453
-  0: The maximum resident set size (KB)                   = 1048800
+  0: The total amount of wall time                        = 441.670375
+  0: The maximum resident set size (KB)                   = 1056756
 
 Test 057 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_rrtmgp
 Checking test 058 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2438,14 +2438,14 @@ Checking test 058 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 471.008060
-  0: The maximum resident set size (KB)                   = 1217840
+  0: The total amount of wall time                        = 473.537762
+  0: The maximum resident set size (KB)                   = 1210108
 
 Test 058 rap_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_spp_sppt_shum_skeb
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_spp_sppt_shum_skeb
 Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2456,14 +2456,14 @@ Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 290.055484
-  0: The maximum resident set size (KB)                   = 1180660
+  0: The total amount of wall time                        = 293.435462
+  0: The maximum resident set size (KB)                   = 1182644
 
 Test 059 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_decomp
 Checking test 060 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2510,14 +2510,14 @@ Checking test 060 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.047258
-  0: The maximum resident set size (KB)                   = 1002760
+  0: The total amount of wall time                        = 460.721499
+  0: The maximum resident set size (KB)                   = 1000372
 
 Test 060 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_2threads
 Checking test 061 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2564,14 +2564,14 @@ Checking test 061 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 524.560457
- 0: The maximum resident set size (KB)                   = 1064508
+ 0: The total amount of wall time                        = 522.331922
+ 0: The maximum resident set size (KB)                   = 1069012
 
 Test 061 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_restart
 Checking test 062 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2610,14 +2610,14 @@ Checking test 062 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 221.302031
-  0: The maximum resident set size (KB)                   = 960252
+  0: The total amount of wall time                        = 223.664395
+  0: The maximum resident set size (KB)                   = 966284
 
 Test 062 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_sfcdiff
 Checking test 063 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2664,14 +2664,14 @@ Checking test 063 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 436.081260
-  0: The maximum resident set size (KB)                   = 1053552
+  0: The total amount of wall time                        = 437.109624
+  0: The maximum resident set size (KB)                   = 1051904
 
 Test 063 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_sfcdiff_decomp
 Checking test 064 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2718,14 +2718,14 @@ Checking test 064 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.855376
-  0: The maximum resident set size (KB)                   = 999664
+  0: The total amount of wall time                        = 464.908378
+  0: The maximum resident set size (KB)                   = 1001200
 
 Test 064 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_sfcdiff_restart
 Checking test 065 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2764,14 +2764,14 @@ Checking test 065 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 326.620946
-  0: The maximum resident set size (KB)                   = 987928
+  0: The total amount of wall time                        = 327.002855
+  0: The maximum resident set size (KB)                   = 988324
 
 Test 065 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control
 Checking test 066 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2818,14 +2818,14 @@ Checking test 066 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 419.686729
-  0: The maximum resident set size (KB)                   = 1060020
+  0: The total amount of wall time                        = 421.441549
+  0: The maximum resident set size (KB)                   = 1052988
 
 Test 066 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_decomp
 Checking test 067 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2872,14 +2872,14 @@ Checking test 067 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.087550
-  0: The maximum resident set size (KB)                   = 1000668
+  0: The total amount of wall time                        = 441.063304
+  0: The maximum resident set size (KB)                   = 1001100
 
 Test 067 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_2threads
 Checking test 068 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2926,14 +2926,14 @@ Checking test 068 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 492.729235
- 0: The maximum resident set size (KB)                   = 1062128
+ 0: The total amount of wall time                        = 495.693134
+ 0: The maximum resident set size (KB)                   = 1058452
 
 Test 068 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_restart
 Checking test 069 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2972,14 +2972,14 @@ Checking test 069 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 314.202383
-  0: The maximum resident set size (KB)                   = 972796
+  0: The total amount of wall time                        = 316.356502
+  0: The maximum resident set size (KB)                   = 983112
 
 Test 069 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_v1beta
 Checking test 070 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3026,14 +3026,14 @@ Checking test 070 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 431.398965
-  0: The maximum resident set size (KB)                   = 1047332
+  0: The total amount of wall time                        = 431.678247
+  0: The maximum resident set size (KB)                   = 1046736
 
 Test 070 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_v1nssl
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_v1nssl
 Checking test 071 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3048,14 +3048,14 @@ Checking test 071 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 514.998964
-  0: The maximum resident set size (KB)                   = 686648
+  0: The total amount of wall time                        = 514.165976
+  0: The maximum resident set size (KB)                   = 690020
 
 Test 071 rrfs_v1nssl PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_v1nssl_nohailnoccn
 Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3070,14 +3070,14 @@ Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 500.724584
-  0: The maximum resident set size (KB)                   = 752684
+  0: The total amount of wall time                        = 502.624617
+  0: The maximum resident set size (KB)                   = 752296
 
 Test 072 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_conus13km_hrrr_warm
 Checking test 073 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3086,14 +3086,14 @@ Checking test 073 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 125.104838
-  0: The maximum resident set size (KB)                   = 927724
+  0: The total amount of wall time                        = 126.205903
+  0: The maximum resident set size (KB)                   = 923788
 
 Test 073 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_smoke_conus13km_hrrr_warm
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3102,14 +3102,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 139.916308
-  0: The maximum resident set size (KB)                   = 956548
+  0: The total amount of wall time                        = 141.183104
+  0: The maximum resident set size (KB)                   = 957840
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_conus13km_radar_tten_warm
 Checking test 075 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3118,14 +3118,14 @@ Checking test 075 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 126.300307
-  0: The maximum resident set size (KB)                   = 935476
+  0: The total amount of wall time                        = 126.637678
+  0: The maximum resident set size (KB)                   = 929392
 
 Test 075 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_conus13km_hrrr_warm_2threads
 Checking test 076 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3134,14 +3134,14 @@ Checking test 076 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 93.735186
-  0: The maximum resident set size (KB)                   = 896896
+  0: The total amount of wall time                        = 93.820465
+  0: The maximum resident set size (KB)                   = 899836
 
 Test 076 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 077 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3150,14 +3150,14 @@ Checking test 077 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 96.643813
-  0: The maximum resident set size (KB)                   = 907560
+  0: The total amount of wall time                        = 96.780037
+  0: The maximum resident set size (KB)                   = 904604
 
 Test 077 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_csawmg
 Checking test 078 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3168,14 +3168,14 @@ Checking test 078 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 342.022939
-  0: The maximum resident set size (KB)                   = 726756
+  0: The total amount of wall time                        = 338.487721
+  0: The maximum resident set size (KB)                   = 731972
 
 Test 078 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_csawmgt
 Checking test 079 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3186,14 +3186,14 @@ Checking test 079 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 335.632776
-  0: The maximum resident set size (KB)                   = 730528
+  0: The total amount of wall time                        = 335.059739
+  0: The maximum resident set size (KB)                   = 719884
 
 Test 079 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_ras
 Checking test 080 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3204,82 +3204,82 @@ Checking test 080 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 179.136096
-  0: The maximum resident set size (KB)                   = 723948
+  0: The total amount of wall time                        = 179.293293
+  0: The maximum resident set size (KB)                   = 717812
 
 Test 080 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_wam
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_wam
 Checking test 081 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 108.114369
-  0: The maximum resident set size (KB)                   = 629716
+  0: The total amount of wall time                        = 107.861568
+  0: The maximum resident set size (KB)                   = 626140
 
 Test 081 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_conus13km_hrrr_warm_debug
 Checking test 082 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 723.494845
-  0: The maximum resident set size (KB)                   = 954452
+  0: The total amount of wall time                        = 701.642242
+  0: The maximum resident set size (KB)                   = 951808
 
 Test 082 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_conus13km_radar_tten_warm_debug
 Checking test 083 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 719.779383
-  0: The maximum resident set size (KB)                   = 960644
+  0: The total amount of wall time                        = 723.543472
+  0: The maximum resident set size (KB)                   = 961408
 
 Test 083 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_debug
 Checking test 084 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.476489
-  0: The maximum resident set size (KB)                   = 792368
+  0: The total amount of wall time                        = 152.883674
+  0: The maximum resident set size (KB)                   = 797764
 
 Test 084 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_2threads_debug
 Checking test 085 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 214.239670
- 0: The maximum resident set size (KB)                   = 830156
+ 0: The total amount of wall time                        = 216.432522
+ 0: The maximum resident set size (KB)                   = 835872
 
 Test 085 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_CubedSphereGrid_debug
 Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3306,348 +3306,348 @@ Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.035419
-  0: The maximum resident set size (KB)                   = 791368
+  0: The total amount of wall time                        = 165.601770
+  0: The maximum resident set size (KB)                   = 794896
 
 Test 086 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_wrtGauss_netcdf_parallel_debug
 Checking test 087 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 154.345245
-  0: The maximum resident set size (KB)                   = 793488
+  0: The total amount of wall time                        = 156.670728
+  0: The maximum resident set size (KB)                   = 801108
 
 Test 087 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_stochy_debug
 Checking test 088 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.206082
-  0: The maximum resident set size (KB)                   = 802812
+  0: The total amount of wall time                        = 173.821154
+  0: The maximum resident set size (KB)                   = 799564
 
 Test 088 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_lndp_debug
 Checking test 089 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.873675
-  0: The maximum resident set size (KB)                   = 798624
+  0: The total amount of wall time                        = 158.038743
+  0: The maximum resident set size (KB)                   = 802188
 
 Test 089 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_csawmg_debug
 Checking test 090 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.642632
-  0: The maximum resident set size (KB)                   = 848720
+  0: The total amount of wall time                        = 240.345210
+  0: The maximum resident set size (KB)                   = 846816
 
 Test 090 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_csawmgt_debug
 Checking test 091 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.489468
-  0: The maximum resident set size (KB)                   = 845604
+  0: The total amount of wall time                        = 229.584304
+  0: The maximum resident set size (KB)                   = 846680
 
 Test 091 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_ras_debug
 Checking test 092 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.261938
-  0: The maximum resident set size (KB)                   = 807468
+  0: The total amount of wall time                        = 155.134081
+  0: The maximum resident set size (KB)                   = 808464
 
 Test 092 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_diag_debug
 Checking test 093 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 163.866688
-  0: The maximum resident set size (KB)                   = 851020
+  0: The total amount of wall time                        = 157.904464
+  0: The maximum resident set size (KB)                   = 851416
 
 Test 093 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_debug_p8
 Checking test 094 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.541898
-  0: The maximum resident set size (KB)                   = 1623952
+  0: The total amount of wall time                        = 171.296983
+  0: The maximum resident set size (KB)                   = 1624120
 
 Test 094 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_debug
 Checking test 095 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 248.381373
- 0: The maximum resident set size (KB)                   = 859952
+ 0: The total amount of wall time                        = 245.401657
+ 0: The maximum resident set size (KB)                   = 852652
 
 Test 095 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_control_debug
 Checking test 096 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.725921
-  0: The maximum resident set size (KB)                   = 1171016
+  0: The total amount of wall time                        = 280.697350
+  0: The maximum resident set size (KB)                   = 1174632
 
 Test 096 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_debug
 Checking test 097 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.987258
-  0: The maximum resident set size (KB)                   = 1168992
+  0: The total amount of wall time                        = 269.922624
+  0: The maximum resident set size (KB)                   = 1163944
 
 Test 097 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_unified_drag_suite_debug
 Checking test 098 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.271088
-  0: The maximum resident set size (KB)                   = 1167576
+  0: The total amount of wall time                        = 272.368715
+  0: The maximum resident set size (KB)                   = 1174540
 
 Test 098 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_diag_debug
 Checking test 099 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.694310
-  0: The maximum resident set size (KB)                   = 1256272
+  0: The total amount of wall time                        = 292.165255
+  0: The maximum resident set size (KB)                   = 1256380
 
 Test 099 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_cires_ugwp_debug
 Checking test 100 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.643556
-  0: The maximum resident set size (KB)                   = 1170176
+  0: The total amount of wall time                        = 276.786987
+  0: The maximum resident set size (KB)                   = 1175068
 
 Test 100 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_unified_ugwp_debug
 Checking test 101 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.299805
-  0: The maximum resident set size (KB)                   = 1167252
+  0: The total amount of wall time                        = 275.922784
+  0: The maximum resident set size (KB)                   = 1174864
 
 Test 101 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_lndp_debug
 Checking test 102 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.106978
-  0: The maximum resident set size (KB)                   = 1172256
+  0: The total amount of wall time                        = 277.960222
+  0: The maximum resident set size (KB)                   = 1172876
 
 Test 102 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_flake_debug
 Checking test 103 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.596414
-  0: The maximum resident set size (KB)                   = 1171504
+  0: The total amount of wall time                        = 278.807842
+  0: The maximum resident set size (KB)                   = 1173384
 
 Test 103 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_progcld_thompson_debug
 Checking test 104 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.373640
-  0: The maximum resident set size (KB)                   = 1171180
+  0: The total amount of wall time                        = 276.541078
+  0: The maximum resident set size (KB)                   = 1174344
 
 Test 104 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_noah_debug
 Checking test 105 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.586843
-  0: The maximum resident set size (KB)                   = 1167848
+  0: The total amount of wall time                        = 275.726874
+  0: The maximum resident set size (KB)                   = 1171708
 
 Test 105 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_rrtmgp_debug
 Checking test 106 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 463.076666
-  0: The maximum resident set size (KB)                   = 1299832
+  0: The total amount of wall time                        = 464.302922
+  0: The maximum resident set size (KB)                   = 1301676
 
 Test 106 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_sfcdiff_debug
 Checking test 107 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.699767
-  0: The maximum resident set size (KB)                   = 1172308
+  0: The total amount of wall time                        = 277.580793
+  0: The maximum resident set size (KB)                   = 1174652
 
 Test 107 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 108 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 454.093077
-  0: The maximum resident set size (KB)                   = 1173504
+  0: The total amount of wall time                        = 452.969533
+  0: The maximum resident set size (KB)                   = 1175244
 
 Test 108 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rrfs_v1beta_debug
 Checking test 109 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.920479
-  0: The maximum resident set size (KB)                   = 1165916
+  0: The total amount of wall time                        = 273.542476
+  0: The maximum resident set size (KB)                   = 1170864
 
 Test 109 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_wam_debug
 Checking test 110 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 281.657176
-  0: The maximum resident set size (KB)                   = 521376
+  0: The total amount of wall time                        = 279.867462
+  0: The maximum resident set size (KB)                   = 528404
 
 Test 110 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3658,14 +3658,14 @@ Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 267.160919
-  0: The maximum resident set size (KB)                   = 1077464
+  0: The total amount of wall time                        = 267.580245
+  0: The maximum resident set size (KB)                   = 1081740
 
 Test 111 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_control_dyn32_phy32
 Checking test 112 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3712,14 +3712,14 @@ Checking test 112 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 355.684535
-  0: The maximum resident set size (KB)                   = 1001352
+  0: The total amount of wall time                        = 355.549031
+  0: The maximum resident set size (KB)                   = 1003388
 
 Test 112 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_dyn32_phy32
 Checking test 113 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3766,14 +3766,14 @@ Checking test 113 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 184.846576
-  0: The maximum resident set size (KB)                   = 958372
+  0: The total amount of wall time                        = 184.027130
+  0: The maximum resident set size (KB)                   = 960544
 
 Test 113 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_2threads_dyn32_phy32
 Checking test 114 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3820,14 +3820,14 @@ Checking test 114 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 427.742271
- 0: The maximum resident set size (KB)                   = 931300
+ 0: The total amount of wall time                        = 432.872797
+ 0: The maximum resident set size (KB)                   = 931960
 
 Test 114 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_2threads_dyn32_phy32
 Checking test 115 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3874,14 +3874,14 @@ Checking test 115 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 216.862417
- 0: The maximum resident set size (KB)                   = 923008
+ 0: The total amount of wall time                        = 219.675093
+ 0: The maximum resident set size (KB)                   = 922532
 
 Test 115 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_decomp_dyn32_phy32
 Checking test 116 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3928,14 +3928,14 @@ Checking test 116 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 194.892656
-  0: The maximum resident set size (KB)                   = 900452
+  0: The total amount of wall time                        = 193.421286
+  0: The maximum resident set size (KB)                   = 891768
 
 Test 116 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_restart_dyn32_phy32
 Checking test 117 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3974,14 +3974,14 @@ Checking test 117 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 265.831643
-  0: The maximum resident set size (KB)                   = 951228
+  0: The total amount of wall time                        = 266.191742
+  0: The maximum resident set size (KB)                   = 953600
 
 Test 117 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_restart_dyn32_phy32
 Checking test 118 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4020,14 +4020,14 @@ Checking test 118 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 94.530345
-  0: The maximum resident set size (KB)                   = 864376
+  0: The total amount of wall time                        = 95.521979
+  0: The maximum resident set size (KB)                   = 861412
 
 Test 118 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_control_dyn64_phy32
 Checking test 119 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4074,81 +4074,81 @@ Checking test 119 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.648990
-  0: The maximum resident set size (KB)                   = 961368
+  0: The total amount of wall time                        = 229.657586
+  0: The maximum resident set size (KB)                   = 963244
 
 Test 119 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_control_debug_dyn32_phy32
 Checking test 120 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.940725
-  0: The maximum resident set size (KB)                   = 1057592
+  0: The total amount of wall time                        = 266.968957
+  0: The maximum resident set size (KB)                   = 1058632
 
 Test 120 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hrrr_control_debug_dyn32_phy32
 Checking test 121 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.220827
-  0: The maximum resident set size (KB)                   = 1058768
+  0: The total amount of wall time                        = 268.001124
+  0: The maximum resident set size (KB)                   = 1062988
 
 Test 121 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/rap_control_dyn64_phy32_debug
 Checking test 122 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.592934
-  0: The maximum resident set size (KB)                   = 1103664
+  0: The total amount of wall time                        = 274.799551
+  0: The maximum resident set size (KB)                   = 1101008
 
 Test 122 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_atm
 Checking test 123 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 304.639575
-  0: The maximum resident set size (KB)                   = 973720
+  0: The total amount of wall time                        = 308.250541
+  0: The maximum resident set size (KB)                   = 967688
 
 Test 123 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_atm_thompson_gfdlsf
 Checking test 124 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 379.025998
-  0: The maximum resident set size (KB)                   = 1340464
+  0: The total amount of wall time                        = 384.488302
+  0: The maximum resident set size (KB)                   = 1345392
 
 Test 124 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_atm_ocn
 Checking test 125 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4157,14 +4157,14 @@ Checking test 125 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 389.402906
-  0: The maximum resident set size (KB)                   = 1199232
+  0: The total amount of wall time                        = 386.307523
+  0: The maximum resident set size (KB)                   = 1192484
 
 Test 125 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_atm_wav
 Checking test 126 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4173,14 +4173,14 @@ Checking test 126 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 710.063657
-  0: The maximum resident set size (KB)                   = 1225956
+  0: The total amount of wall time                        = 717.263647
+  0: The maximum resident set size (KB)                   = 1237512
 
 Test 126 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_atm_ocn_wav
 Checking test 127 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4191,28 +4191,28 @@ Checking test 127 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 813.625329
-  0: The maximum resident set size (KB)                   = 1236284
+  0: The total amount of wall time                        = 817.856457
+  0: The maximum resident set size (KB)                   = 1235584
 
 Test 127 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_1nest_atm
 Checking test 128 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 468.550413
-  0: The maximum resident set size (KB)                   = 532896
+  0: The total amount of wall time                        = 465.793643
+  0: The maximum resident set size (KB)                   = 529328
 
 Test 128 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_telescopic_2nests_atm
 Checking test 129 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4221,28 +4221,28 @@ Checking test 129 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 514.314037
-  0: The maximum resident set size (KB)                   = 584084
+  0: The total amount of wall time                        = 515.106962
+  0: The maximum resident set size (KB)                   = 586412
 
 Test 129 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_global_1nest_atm
 Checking test 130 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 214.380403
-  0: The maximum resident set size (KB)                   = 376548
+  0: The total amount of wall time                        = 213.190188
+  0: The maximum resident set size (KB)                   = 377696
 
 Test 130 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_global_multiple_4nests_atm
 Checking test 131 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4260,14 +4260,14 @@ Checking test 131 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 587.309627
-  0: The maximum resident set size (KB)                   = 417292
+  0: The total amount of wall time                        = 590.100502
+  0: The maximum resident set size (KB)                   = 414948
 
 Test 131 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_specified_moving_1nest_atm
 Checking test 132 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4276,28 +4276,28 @@ Checking test 132 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 277.258843
-  0: The maximum resident set size (KB)                   = 544192
+  0: The total amount of wall time                        = 277.787302
+  0: The maximum resident set size (KB)                   = 554072
 
 Test 132 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_storm_following_1nest_atm
 Checking test 133 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 269.218613
-  0: The maximum resident set size (KB)                   = 541808
+  0: The total amount of wall time                        = 264.749295
+  0: The maximum resident set size (KB)                   = 542336
 
 Test 133 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 134 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4306,14 +4306,14 @@ Checking test 134 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 277.092332
-  0: The maximum resident set size (KB)                   = 607976
+  0: The total amount of wall time                        = 273.813634
+  0: The maximum resident set size (KB)                   = 614824
 
 Test 134 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4324,28 +4324,28 @@ Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 624.240205
-  0: The maximum resident set size (KB)                   = 599484
+  0: The total amount of wall time                        = 624.561203
+  0: The maximum resident set size (KB)                   = 598468
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_global_storm_following_1nest_atm
 Checking test 136 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 79.436345
-  0: The maximum resident set size (KB)                   = 394008
+  0: The total amount of wall time                        = 78.726592
+  0: The maximum resident set size (KB)                   = 402388
 
 Test 136 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_docn
 Checking test 137 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4353,14 +4353,14 @@ Checking test 137 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 380.920351
-  0: The maximum resident set size (KB)                   = 1205824
+  0: The total amount of wall time                        = 382.331329
+  0: The maximum resident set size (KB)                   = 1207656
 
 Test 137 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_docn_oisst
 Checking test 138 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4368,131 +4368,131 @@ Checking test 138 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 384.080161
-  0: The maximum resident set size (KB)                   = 1198908
+  0: The total amount of wall time                        = 381.844260
+  0: The maximum resident set size (KB)                   = 1193884
 
 Test 138 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/hafs_regional_datm_cdeps
 Checking test 139 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 952.186902
-  0: The maximum resident set size (KB)                   = 1041352
+  0: The total amount of wall time                        = 939.622855
+  0: The maximum resident set size (KB)                   = 1040456
 
 Test 139 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_control_cfsr
 Checking test 140 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.185911
- 0: The maximum resident set size (KB)                   = 1056156
+ 0: The total amount of wall time                        = 155.491490
+ 0: The maximum resident set size (KB)                   = 1060964
 
 Test 140 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_restart_cfsr
 Checking test 141 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 93.699475
- 0: The maximum resident set size (KB)                   = 1043064
+ 0: The total amount of wall time                        = 92.924148
+ 0: The maximum resident set size (KB)                   = 1014204
 
 Test 141 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_control_gefs
 Checking test 142 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.398437
- 0: The maximum resident set size (KB)                   = 966688
+ 0: The total amount of wall time                        = 151.207513
+ 0: The maximum resident set size (KB)                   = 954968
 
 Test 142 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_iau_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_iau_gefs
 Checking test 143 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.016416
- 0: The maximum resident set size (KB)                   = 962132
+ 0: The total amount of wall time                        = 155.129986
+ 0: The maximum resident set size (KB)                   = 957552
 
 Test 143 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_stochy_gefs
 Checking test 144 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.373479
- 0: The maximum resident set size (KB)                   = 964220
+ 0: The total amount of wall time                        = 149.759660
+ 0: The maximum resident set size (KB)                   = 963588
 
 Test 144 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_ciceC_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_ciceC_cfsr
 Checking test 145 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.174372
- 0: The maximum resident set size (KB)                   = 1054500
+ 0: The total amount of wall time                        = 156.030448
+ 0: The maximum resident set size (KB)                   = 1073420
 
 Test 145 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_bulk_cfsr
 Checking test 146 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.155116
- 0: The maximum resident set size (KB)                   = 1065384
+ 0: The total amount of wall time                        = 157.724282
+ 0: The maximum resident set size (KB)                   = 1071732
 
 Test 146 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_bulk_gefs
 Checking test 147 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.498938
- 0: The maximum resident set size (KB)                   = 970656
+ 0: The total amount of wall time                        = 149.837474
+ 0: The maximum resident set size (KB)                   = 960636
 
 Test 147 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_mx025_cfsr
 Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4501,14 +4501,14 @@ Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 426.479650
-  0: The maximum resident set size (KB)                   = 879348
+  0: The total amount of wall time                        = 426.933914
+  0: The maximum resident set size (KB)                   = 877608
 
 Test 148 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_mx025_gefs
 Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4517,64 +4517,64 @@ Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 423.577288
-  0: The maximum resident set size (KB)                   = 931728
+  0: The total amount of wall time                        = 423.256750
+  0: The maximum resident set size (KB)                   = 935216
 
 Test 149 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_multiple_files_cfsr
 Checking test 150 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.651671
- 0: The maximum resident set size (KB)                   = 1077480
+ 0: The total amount of wall time                        = 153.630682
+ 0: The maximum resident set size (KB)                   = 1060916
 
 Test 150 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_3072x1536_cfsr
 Checking test 151 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 205.289255
- 0: The maximum resident set size (KB)                   = 2361068
+ 0: The total amount of wall time                        = 206.581385
+ 0: The maximum resident set size (KB)                   = 2353132
 
 Test 151 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_gfs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_gfs
 Checking test 152 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 208.128398
- 0: The maximum resident set size (KB)                   = 2358512
+ 0: The total amount of wall time                        = 207.991751
+ 0: The maximum resident set size (KB)                   = 2358724
 
 Test 152 datm_cdeps_gfs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_debug_cfsr
 Checking test 153 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 455.963675
- 0: The maximum resident set size (KB)                   = 993216
+ 0: The total amount of wall time                        = 454.999451
+ 0: The maximum resident set size (KB)                   = 992284
 
 Test 153 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_lnd_gswp3
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_lnd_gswp3
 Checking test 154 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4583,14 +4583,14 @@ Checking test 154 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 6.542921
-  0: The maximum resident set size (KB)                   = 255600
+  0: The total amount of wall time                        = 6.658266
+  0: The maximum resident set size (KB)                   = 264956
 
 Test 154 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/datm_cdeps_lnd_gswp3_rst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/datm_cdeps_lnd_gswp3_rst
 Checking test 155 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4599,14 +4599,14 @@ Checking test 155 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 11.582781
-  0: The maximum resident set size (KB)                   = 266544
+  0: The total amount of wall time                        = 11.818996
+  0: The maximum resident set size (KB)                   = 260800
 
 Test 155 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_p8_atmlnd_sbs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_p8_atmlnd_sbs
 Checking test 156 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4691,14 +4691,14 @@ Checking test 156 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.966178
-  0: The maximum resident set size (KB)                   = 1611976
+  0: The total amount of wall time                        = 200.029060
+  0: The maximum resident set size (KB)                   = 1614984
 
 Test 156 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/control_atmwav
 Checking test 157 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4742,14 +4742,14 @@ Checking test 157 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 85.375854
-  0: The maximum resident set size (KB)                   = 654508
+  0: The total amount of wall time                        = 84.360607
+  0: The maximum resident set size (KB)                   = 652044
 
 Test 157 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/atmaero_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/atmaero_control_p8
 Checking test 158 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4793,14 +4793,14 @@ Checking test 158 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.759810
-  0: The maximum resident set size (KB)                   = 2974356
+  0: The total amount of wall time                        = 223.540808
+  0: The maximum resident set size (KB)                   = 2975188
 
 Test 158 atmaero_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/atmaero_control_p8_rad
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/atmaero_control_p8_rad
 Checking test 159 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4844,14 +4844,14 @@ Checking test 159 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 285.780322
-  0: The maximum resident set size (KB)                   = 3049232
+  0: The total amount of wall time                        = 277.307185
+  0: The maximum resident set size (KB)                   = 3046384
 
 Test 159 atmaero_control_p8_rad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad_micro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/atmaero_control_p8_rad_micro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad_micro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/atmaero_control_p8_rad_micro
 Checking test 160 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4895,14 +4895,14 @@ Checking test 160 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 290.783016
-  0: The maximum resident set size (KB)                   = 3049048
+  0: The total amount of wall time                        = 282.853852
+  0: The maximum resident set size (KB)                   = 3048656
 
 Test 160 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31852/regional_atmaq
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_23410/regional_atmaq
 Checking test 161 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4918,12 +4918,12 @@ Checking test 161 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 670.673868
-  0: The maximum resident set size (KB)                   = 1083920
+  0: The total amount of wall time                        = 656.048359
+  0: The maximum resident set size (KB)                   = 1087268
 
 Test 161 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 15:36:16 UTC 2022
-Elapsed time: 01h:17m:42s. Have a nice day!
+Mon Nov  7 22:06:19 UTC 2022
+Elapsed time: 01h:01m:52s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,34 +1,34 @@
-Wed Nov  2 16:32:09 GMT 2022
+Mon Nov  7 23:51:54 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1922 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 1647 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 301 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 268 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 1401 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 006 elapsed time 1492 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 007 elapsed time 1502 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 1424 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 009 elapsed time 1353 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 010 elapsed time 1232 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 890 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 237 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 1264 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 1289 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 015 elapsed time 240 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 239 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 1708 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 018 elapsed time 1635 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 019 elapsed time 292 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 001 elapsed time 1743 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 1629 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 294 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 261 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 1377 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 006 elapsed time 1366 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1357 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 008 elapsed time 1375 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 009 elapsed time 1324 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 010 elapsed time 1220 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 815 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 229 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 1240 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 1281 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 015 elapsed time 234 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 1604 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 018 elapsed time 1676 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 019 elapsed time 290 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
 Compile 020 elapsed time 161 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 113 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 022 elapsed time 1410 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 023 elapsed time 1619 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 024 elapsed time 1266 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 025 elapsed time 1317 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 021 elapsed time 108 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 022 elapsed time 1419 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 023 elapsed time 1600 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 024 elapsed time 1247 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 025 elapsed time 1352 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 473.822783
-  0: The maximum resident set size (KB)                   = 1776344
+  0: The total amount of wall time                        = 469.840406
+  0: The maximum resident set size (KB)                   = 1772620
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -153,14 +153,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 277.132173
-  0: The maximum resident set size (KB)                   = 1490104
+  0: The total amount of wall time                        = 263.758818
+  0: The maximum resident set size (KB)                   = 1489232
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -213,14 +213,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 930.112521
-  0: The maximum resident set size (KB)                   = 1946520
+  0: The total amount of wall time                        = 932.187670
+  0: The maximum resident set size (KB)                   = 1953188
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_esmfthreads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 504.116600
-  0: The maximum resident set size (KB)                   = 1970412
+  0: The total amount of wall time                        = 510.517492
+  0: The maximum resident set size (KB)                   = 1966016
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 473.542899
-  0: The maximum resident set size (KB)                   = 1772852
+  0: The total amount of wall time                        = 487.124495
+  0: The maximum resident set size (KB)                   = 1763028
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_mpi_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 434.296944
-  0: The maximum resident set size (KB)                   = 1730760
+  0: The total amount of wall time                        = 410.664908
+  0: The maximum resident set size (KB)                   = 1727756
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_control_ciceC_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 467.412073
-  0: The maximum resident set size (KB)                   = 1777248
+  0: The total amount of wall time                        = 467.234499
+  0: The maximum resident set size (KB)                   = 1776112
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_control_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_control_noaero_p8
 Checking test 008 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -536,14 +536,14 @@ Checking test 008 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 315.731279
-  0: The maximum resident set size (KB)                   = 1623960
+  0: The total amount of wall time                        = 321.793495
+  0: The maximum resident set size (KB)                   = 1625892
 
 Test 008 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_control_nowave_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_control_nowave_noaero_p8
 Checking test 009 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -605,14 +605,14 @@ Checking test 009 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 343.719292
-  0: The maximum resident set size (KB)                   = 1667452
+  0: The total amount of wall time                        = 359.800780
+  0: The maximum resident set size (KB)                   = 1667984
 
 Test 009 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_debug_p8
 Checking test 010 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -665,14 +665,14 @@ Checking test 010 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 978.929236
-  0: The maximum resident set size (KB)                   = 1809244
+  0: The total amount of wall time                        = 889.118499
+  0: The maximum resident set size (KB)                   = 1828876
 
 Test 010 cpld_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_debug_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_debug_noaero_p8
 Checking test 011 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -724,14 +724,14 @@ Checking test 011 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 585.401701
-  0: The maximum resident set size (KB)                   = 1644724
+  0: The total amount of wall time                        = 555.302540
+  0: The maximum resident set size (KB)                   = 1645824
 
 Test 011 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_control_noaero_p8_agrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_control_noaero_p8_agrid
 Checking test 012 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -793,14 +793,14 @@ Checking test 012 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 370.017836
-  0: The maximum resident set size (KB)                   = 1670380
+  0: The total amount of wall time                        = 366.708641
+  0: The maximum resident set size (KB)                   = 1684008
 
 Test 012 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_control_c48
 Checking test 013 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -850,14 +850,14 @@ Checking test 013 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 786.484407
- 0: The maximum resident set size (KB)                   = 2771964
+ 0: The total amount of wall time                        = 787.135994
+ 0: The maximum resident set size (KB)                   = 2775144
 
 Test 013 cpld_control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_warmstart_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_warmstart_c48
 Checking test 014 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -907,14 +907,14 @@ Checking test 014 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 218.476538
- 0: The maximum resident set size (KB)                   = 2769468
+ 0: The total amount of wall time                        = 213.956336
+ 0: The maximum resident set size (KB)                   = 2774488
 
 Test 014 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/cpld_restart_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/cpld_restart_c48
 Checking test 015 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -964,14 +964,14 @@ Checking test 015 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 117.297465
- 0: The maximum resident set size (KB)                   = 2204992
+ 0: The total amount of wall time                        = 110.634630
+ 0: The maximum resident set size (KB)                   = 2199012
 
 Test 015 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1018,14 +1018,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.012732
-  0: The maximum resident set size (KB)                   = 574968
+  0: The total amount of wall time                        = 190.412603
+  0: The maximum resident set size (KB)                   = 568724
 
 Test 016 control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1068,14 +1068,14 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.458000
-  0: The maximum resident set size (KB)                   = 564552
+  0: The total amount of wall time                        = 189.762617
+  0: The maximum resident set size (KB)                   = 560104
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1086,14 +1086,14 @@ Checking test 018 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 183.034376
-  0: The maximum resident set size (KB)                   = 572064
+  0: The total amount of wall time                        = 182.738032
+  0: The maximum resident set size (KB)                   = 572368
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1136,14 +1136,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 419.991438
- 0: The maximum resident set size (KB)                   = 628992
+ 0: The total amount of wall time                        = 422.660447
+ 0: The maximum resident set size (KB)                   = 619404
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1182,14 +1182,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 93.869059
-  0: The maximum resident set size (KB)                   = 370688
+  0: The total amount of wall time                        = 94.810552
+  0: The maximum resident set size (KB)                   = 371924
 
 Test 020 control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_fhzero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1232,14 +1232,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.507969
-  0: The maximum resident set size (KB)                   = 573396
+  0: The total amount of wall time                        = 179.549505
+  0: The maximum resident set size (KB)                   = 569336
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1266,28 +1266,28 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 179.318875
-  0: The maximum resident set size (KB)                   = 569952
+  0: The total amount of wall time                        = 179.945554
+  0: The maximum resident set size (KB)                   = 572068
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_CubedSphereGrid_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_CubedSphereGrid_parallel
 Checking test 023 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 178.825092
-  0: The maximum resident set size (KB)                   = 566648
+  0: The total amount of wall time                        = 181.813643
+  0: The maximum resident set size (KB)                   = 571956
 
 Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_latlon
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_latlon
 Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1298,32 +1298,32 @@ Checking test 024 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 178.997739
-  0: The maximum resident set size (KB)                   = 567884
+  0: The total amount of wall time                        = 182.338481
+  0: The maximum resident set size (KB)                   = 572260
 
 Test 024 control_latlon PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_wrtGauss_netcdf_parallel
 Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.629856
-  0: The maximum resident set size (KB)                   = 570480
+  0: The total amount of wall time                        = 189.156124
+  0: The maximum resident set size (KB)                   = 570476
 
 Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_c48
 Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1362,14 +1362,14 @@ Checking test 026 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 591.387433
-0: The maximum resident set size (KB)                   = 784636
+0: The total amount of wall time                        = 588.940613
+0: The maximum resident set size (KB)                   = 788012
 
 Test 026 control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_c192
 Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1380,14 +1380,14 @@ Checking test 027 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 732.436315
-  0: The maximum resident set size (KB)                   = 681540
+  0: The total amount of wall time                        = 734.322749
+  0: The maximum resident set size (KB)                   = 690988
 
 Test 027 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_c384
 Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1398,14 +1398,14 @@ Checking test 028 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 969.801746
-  0: The maximum resident set size (KB)                   = 1072028
+  0: The total amount of wall time                        = 949.209753
+  0: The maximum resident set size (KB)                   = 1076360
 
 Test 028 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_c384gdas
 Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1448,14 +1448,14 @@ Checking test 029 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 823.132105
-  0: The maximum resident set size (KB)                   = 1155900
+  0: The total amount of wall time                        = 799.475506
+  0: The maximum resident set size (KB)                   = 1150560
 
 Test 029 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_c384_progsigma
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_c384_progsigma
 Checking test 030 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1466,14 +1466,14 @@ Checking test 030 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 972.659243
-  0: The maximum resident set size (KB)                   = 1000208
+  0: The total amount of wall time                        = 980.737314
+  0: The maximum resident set size (KB)                   = 986852
 
 Test 030 control_c384_progsigma PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_stochy
 Checking test 031 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1484,28 +1484,28 @@ Checking test 031 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 120.962648
-  0: The maximum resident set size (KB)                   = 575256
+  0: The total amount of wall time                        = 122.291086
+  0: The maximum resident set size (KB)                   = 570196
 
 Test 031 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_stochy_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_stochy_restart
 Checking test 032 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 62.198352
-  0: The maximum resident set size (KB)                   = 388432
+  0: The total amount of wall time                        = 63.336958
+  0: The maximum resident set size (KB)                   = 395416
 
 Test 032 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_lndp
 Checking test 033 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1516,14 +1516,14 @@ Checking test 033 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 107.439773
-  0: The maximum resident set size (KB)                   = 576800
+  0: The total amount of wall time                        = 107.128608
+  0: The maximum resident set size (KB)                   = 572932
 
 Test 033 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_iovr4
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_iovr4
 Checking test 034 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1538,14 +1538,14 @@ Checking test 034 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 184.240946
-  0: The maximum resident set size (KB)                   = 570796
+  0: The total amount of wall time                        = 187.852311
+  0: The maximum resident set size (KB)                   = 568828
 
 Test 034 control_iovr4 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_iovr5
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_iovr5
 Checking test 035 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1560,14 +1560,14 @@ Checking test 035 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 188.512206
-  0: The maximum resident set size (KB)                   = 568092
+  0: The total amount of wall time                        = 189.522789
+  0: The maximum resident set size (KB)                   = 571928
 
 Test 035 control_iovr5 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_p8
 Checking test 036 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1614,14 +1614,14 @@ Checking test 036 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.066788
-  0: The maximum resident set size (KB)                   = 1534924
+  0: The total amount of wall time                        = 231.386872
+  0: The maximum resident set size (KB)                   = 1534204
 
 Test 036 control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_p8_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_p8_lndp
 Checking test 037 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1640,14 +1640,14 @@ Checking test 037 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 443.727962
-  0: The maximum resident set size (KB)                   = 1544228
+  0: The total amount of wall time                        = 433.259858
+  0: The maximum resident set size (KB)                   = 1537596
 
 Test 037 control_p8_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_restart_p8
 Checking test 038 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1686,14 +1686,14 @@ Checking test 038 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 118.955339
-  0: The maximum resident set size (KB)                   = 762492
+  0: The total amount of wall time                        = 126.762541
+  0: The maximum resident set size (KB)                   = 773164
 
 Test 038 control_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_decomp_p8
 Checking test 039 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1736,14 +1736,14 @@ Checking test 039 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 237.814478
-  0: The maximum resident set size (KB)                   = 1520316
+  0: The total amount of wall time                        = 232.403284
+  0: The maximum resident set size (KB)                   = 1521972
 
 Test 039 control_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_2threads_p8
 Checking test 040 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1786,14 +1786,14 @@ Checking test 040 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 532.642707
- 0: The maximum resident set size (KB)                   = 1627040
+ 0: The total amount of wall time                        = 529.669851
+ 0: The maximum resident set size (KB)                   = 1607400
 
 Test 040 control_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_p8_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_p8_rrtmgp
 Checking test 041 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1840,14 +1840,14 @@ Checking test 041 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 286.227203
-  0: The maximum resident set size (KB)                   = 1658600
+  0: The total amount of wall time                        = 285.365269
+  0: The maximum resident set size (KB)                   = 1653124
 
 Test 041 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/merra2_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/merra2_thompson
 Checking test 042 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1894,14 +1894,14 @@ Checking test 042 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.377225
-  0: The maximum resident set size (KB)                   = 1544172
+  0: The total amount of wall time                        = 230.150891
+  0: The maximum resident set size (KB)                   = 1541704
 
 Test 042 merra2_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_control
 Checking test 043 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1912,28 +1912,28 @@ Checking test 043 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 476.666096
- 0: The maximum resident set size (KB)                   = 746104
+ 0: The total amount of wall time                        = 479.179680
+ 0: The maximum resident set size (KB)                   = 741112
 
 Test 043 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_restart
 Checking test 044 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 265.239291
- 0: The maximum resident set size (KB)                   = 731340
+ 0: The total amount of wall time                        = 264.789343
+ 0: The maximum resident set size (KB)                   = 736896
 
 Test 044 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_control_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_control_2dwrtdecomp
 Checking test 045 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1944,14 +1944,14 @@ Checking test 045 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 479.126199
- 0: The maximum resident set size (KB)                   = 744752
+ 0: The total amount of wall time                        = 469.394823
+ 0: The maximum resident set size (KB)                   = 742272
 
 Test 045 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_noquilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_noquilt
 Checking test 046 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1959,14 +1959,14 @@ Checking test 046 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 514.886729
- 0: The maximum resident set size (KB)                   = 726924
+ 0: The total amount of wall time                        = 501.769008
+ 0: The maximum resident set size (KB)                   = 727840
 
 Test 046 regional_noquilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_2threads
 Checking test 047 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1977,28 +1977,28 @@ Checking test 047 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 1087.198463
- 0: The maximum resident set size (KB)                   = 729488
+ 0: The total amount of wall time                        = 1089.080786
+ 0: The maximum resident set size (KB)                   = 709820
 
 Test 047 regional_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_netcdf_parallel
 Checking test 048 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 472.471628
- 0: The maximum resident set size (KB)                   = 739796
+ 0: The total amount of wall time                        = 471.269419
+ 0: The maximum resident set size (KB)                   = 733668
 
 Test 048 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_3km
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_3km
 Checking test 049 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2009,14 +2009,14 @@ Checking test 049 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 364.098824
-  0: The maximum resident set size (KB)                   = 772836
+  0: The total amount of wall time                        = 397.629892
+  0: The maximum resident set size (KB)                   = 771144
 
 Test 049 regional_3km PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_3km_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_3km_decomp
 Checking test 050 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2027,14 +2027,14 @@ Checking test 050 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 503.077572
-  0: The maximum resident set size (KB)                   = 778444
+  0: The total amount of wall time                        = 383.835132
+  0: The maximum resident set size (KB)                   = 772776
 
 Test 050 regional_3km_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_3km_wofs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_3km_wofs
 Checking test 051 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2045,14 +2045,14 @@ Checking test 051 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 479.943400
-  0: The maximum resident set size (KB)                   = 513284
+  0: The total amount of wall time                        = 483.877544
+  0: The maximum resident set size (KB)                   = 513148
 
 Test 051 regional_3km_wofs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_control
 Checking test 052 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 052 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 584.651014
-  0: The maximum resident set size (KB)                   = 955880
+  0: The total amount of wall time                        = 587.961537
+  0: The maximum resident set size (KB)                   = 946640
 
 Test 052 rap_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_rrtmgp
 Checking test 053 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2153,14 +2153,14 @@ Checking test 053 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 635.784193
-  0: The maximum resident set size (KB)                   = 1072488
+  0: The total amount of wall time                        = 633.238983
+  0: The maximum resident set size (KB)                   = 1068684
 
 Test 053 rap_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_spp_sppt_shum_skeb
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_spp_sppt_shum_skeb
 Checking test 054 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2171,14 +2171,14 @@ Checking test 054 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 839.874676
-  0: The maximum resident set size (KB)                   = 1068212
+  0: The total amount of wall time                        = 836.810407
+  0: The maximum resident set size (KB)                   = 1071088
 
 Test 054 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_decomp
 Checking test 055 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2225,14 +2225,14 @@ Checking test 055 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 617.195025
-  0: The maximum resident set size (KB)                   = 942956
+  0: The total amount of wall time                        = 614.522320
+  0: The maximum resident set size (KB)                   = 935960
 
 Test 055 rap_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_2threads
 Checking test 056 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2279,14 +2279,14 @@ Checking test 056 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1260.977468
- 0: The maximum resident set size (KB)                   = 1012472
+ 0: The total amount of wall time                        = 1259.050749
+ 0: The maximum resident set size (KB)                   = 1015512
 
 Test 056 rap_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_restart
 Checking test 057 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2325,14 +2325,14 @@ Checking test 057 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 301.627681
-  0: The maximum resident set size (KB)                   = 822848
+  0: The total amount of wall time                        = 293.393554
+  0: The maximum resident set size (KB)                   = 817224
 
 Test 057 rap_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_sfcdiff
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_sfcdiff
 Checking test 058 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2379,14 +2379,14 @@ Checking test 058 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 587.780025
-  0: The maximum resident set size (KB)                   = 943744
+  0: The total amount of wall time                        = 584.704622
+  0: The maximum resident set size (KB)                   = 942544
 
 Test 058 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_sfcdiff_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_sfcdiff_decomp
 Checking test 059 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2433,14 +2433,14 @@ Checking test 059 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 619.029549
-  0: The maximum resident set size (KB)                   = 944400
+  0: The total amount of wall time                        = 628.471248
+  0: The maximum resident set size (KB)                   = 934364
 
 Test 059 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_sfcdiff_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_sfcdiff_restart
 Checking test 060 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2479,14 +2479,14 @@ Checking test 060 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 435.042777
-  0: The maximum resident set size (KB)                   = 831284
+  0: The total amount of wall time                        = 436.090269
+  0: The maximum resident set size (KB)                   = 828540
 
 Test 060 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control
 Checking test 061 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2533,14 +2533,14 @@ Checking test 061 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 566.718844
-  0: The maximum resident set size (KB)                   = 944344
+  0: The total amount of wall time                        = 577.102104
+  0: The maximum resident set size (KB)                   = 943628
 
 Test 061 hrrr_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_decomp
 Checking test 062 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2587,14 +2587,14 @@ Checking test 062 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 583.259035
-  0: The maximum resident set size (KB)                   = 944500
+  0: The total amount of wall time                        = 590.566899
+  0: The maximum resident set size (KB)                   = 935216
 
 Test 062 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_2threads
 Checking test 063 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2641,14 +2641,14 @@ Checking test 063 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1197.678742
- 0: The maximum resident set size (KB)                   = 1012032
+ 0: The total amount of wall time                        = 1205.413785
+ 0: The maximum resident set size (KB)                   = 1009808
 
 Test 063 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_restart
 Checking test 064 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2687,14 +2687,14 @@ Checking test 064 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 418.806695
-  0: The maximum resident set size (KB)                   = 833660
+  0: The total amount of wall time                        = 426.579647
+  0: The maximum resident set size (KB)                   = 823924
 
 Test 064 hrrr_control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_v1beta
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_v1beta
 Checking test 065 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2741,14 +2741,14 @@ Checking test 065 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 583.295823
-  0: The maximum resident set size (KB)                   = 939164
+  0: The total amount of wall time                        = 587.129078
+  0: The maximum resident set size (KB)                   = 941440
 
 Test 065 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_v1nssl
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_v1nssl
 Checking test 066 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2763,14 +2763,14 @@ Checking test 066 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 706.312988
-  0: The maximum resident set size (KB)                   = 628952
+  0: The total amount of wall time                        = 720.004553
+  0: The maximum resident set size (KB)                   = 635940
 
 Test 066 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_v1nssl_nohailnoccn
 Checking test 067 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2785,14 +2785,14 @@ Checking test 067 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 704.427384
-  0: The maximum resident set size (KB)                   = 631196
+  0: The total amount of wall time                        = 697.300068
+  0: The maximum resident set size (KB)                   = 629948
 
 Test 067 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_conus13km_hrrr_warm
 Checking test 068 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2801,14 +2801,14 @@ Checking test 068 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 167.527837
-  0: The maximum resident set size (KB)                   = 842940
+  0: The total amount of wall time                        = 173.917879
+  0: The maximum resident set size (KB)                   = 843080
 
 Test 068 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_smoke_conus13km_hrrr_warm
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2817,14 +2817,14 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 188.957864
-  0: The maximum resident set size (KB)                   = 868748
+  0: The total amount of wall time                        = 190.860531
+  0: The maximum resident set size (KB)                   = 864872
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_conus13km_radar_tten_warm
 Checking test 070 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2833,14 +2833,14 @@ Checking test 070 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 168.705425
-  0: The maximum resident set size (KB)                   = 852388
+  0: The total amount of wall time                        = 174.215960
+  0: The maximum resident set size (KB)                   = 851308
 
 Test 070 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_conus13km_hrrr_warm_2threads
 Checking test 071 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2849,14 +2849,14 @@ Checking test 071 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 328.446432
-  0: The maximum resident set size (KB)                   = 808620
+  0: The total amount of wall time                        = 325.465483
+  0: The maximum resident set size (KB)                   = 804384
 
 Test 071 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 072 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2865,14 +2865,14 @@ Checking test 072 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 326.955645
-  0: The maximum resident set size (KB)                   = 816612
+  0: The total amount of wall time                        = 328.062045
+  0: The maximum resident set size (KB)                   = 821600
 
 Test 072 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_csawmg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_csawmg
 Checking test 073 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2883,14 +2883,14 @@ Checking test 073 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 470.881166
-  0: The maximum resident set size (KB)                   = 663796
+  0: The total amount of wall time                        = 461.280580
+  0: The maximum resident set size (KB)                   = 668460
 
 Test 073 control_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_csawmgt
 Checking test 074 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2901,14 +2901,14 @@ Checking test 074 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 459.476926
-  0: The maximum resident set size (KB)                   = 668624
+  0: The total amount of wall time                        = 458.656453
+  0: The maximum resident set size (KB)                   = 670552
 
 Test 074 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_ras
 Checking test 075 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2919,82 +2919,82 @@ Checking test 075 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 248.450853
-  0: The maximum resident set size (KB)                   = 625592
+  0: The total amount of wall time                        = 252.327784
+  0: The maximum resident set size (KB)                   = 642120
 
 Test 075 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_wam
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_wam
 Checking test 076 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 149.231807
-  0: The maximum resident set size (KB)                   = 477028
+  0: The total amount of wall time                        = 146.186367
+  0: The maximum resident set size (KB)                   = 473984
 
 Test 076 control_wam PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_conus13km_hrrr_warm_debug
 Checking test 077 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 955.051192
-  0: The maximum resident set size (KB)                   = 872340
+  0: The total amount of wall time                        = 948.008998
+  0: The maximum resident set size (KB)                   = 872676
 
 Test 077 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_conus13km_radar_tten_warm_debug
 Checking test 078 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 960.137532
-  0: The maximum resident set size (KB)                   = 871996
+  0: The total amount of wall time                        = 949.423313
+  0: The maximum resident set size (KB)                   = 876024
 
 Test 078 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_debug
 Checking test 079 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 218.376540
-  0: The maximum resident set size (KB)                   = 731564
+  0: The total amount of wall time                        = 193.159729
+  0: The maximum resident set size (KB)                   = 731220
 
 Test 079 control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_2threads_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_2threads_debug
 Checking test 080 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 349.271657
- 0: The maximum resident set size (KB)                   = 787508
+ 0: The total amount of wall time                        = 344.425002
+ 0: The maximum resident set size (KB)                   = 782932
 
 Test 080 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_CubedSphereGrid_debug
 Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3021,348 +3021,348 @@ Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 221.387985
-  0: The maximum resident set size (KB)                   = 731968
+  0: The total amount of wall time                        = 212.072782
+  0: The maximum resident set size (KB)                   = 732180
 
 Test 081 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_wrtGauss_netcdf_parallel_debug
 Checking test 082 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 209.887345
-  0: The maximum resident set size (KB)                   = 734868
+  0: The total amount of wall time                        = 200.450284
+  0: The maximum resident set size (KB)                   = 737800
 
 Test 082 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_stochy_debug
 Checking test 083 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.875520
-  0: The maximum resident set size (KB)                   = 741388
+  0: The total amount of wall time                        = 229.471998
+  0: The maximum resident set size (KB)                   = 741220
 
 Test 083 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_lndp_debug
 Checking test 084 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 206.299582
-  0: The maximum resident set size (KB)                   = 735988
+  0: The total amount of wall time                        = 204.200437
+  0: The maximum resident set size (KB)                   = 738052
 
 Test 084 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_csawmg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_csawmg_debug
 Checking test 085 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 321.247296
-  0: The maximum resident set size (KB)                   = 777532
+  0: The total amount of wall time                        = 310.563158
+  0: The maximum resident set size (KB)                   = 781728
 
 Test 085 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_csawmgt_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_csawmgt_debug
 Checking test 086 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 305.251205
-  0: The maximum resident set size (KB)                   = 785192
+  0: The total amount of wall time                        = 307.267707
+  0: The maximum resident set size (KB)                   = 778876
 
 Test 086 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_ras_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_ras_debug
 Checking test 087 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 208.532002
-  0: The maximum resident set size (KB)                   = 747284
+  0: The total amount of wall time                        = 202.660336
+  0: The maximum resident set size (KB)                   = 744964
 
 Test 087 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_diag_debug
 Checking test 088 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.491095
-  0: The maximum resident set size (KB)                   = 793752
+  0: The total amount of wall time                        = 210.081262
+  0: The maximum resident set size (KB)                   = 790640
 
 Test 088 control_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_debug_p8
 Checking test 089 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.540605
-  0: The maximum resident set size (KB)                   = 1555480
+  0: The total amount of wall time                        = 229.111027
+  0: The maximum resident set size (KB)                   = 1558840
 
 Test 089 control_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 330.071059
- 0: The maximum resident set size (KB)                   = 775148
+ 0: The total amount of wall time                        = 328.006315
+ 0: The maximum resident set size (KB)                   = 753540
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 364.470108
-  0: The maximum resident set size (KB)                   = 1106420
+  0: The total amount of wall time                        = 361.554981
+  0: The maximum resident set size (KB)                   = 1106192
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_debug
 Checking test 092 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 354.602866
-  0: The maximum resident set size (KB)                   = 1099672
+  0: The total amount of wall time                        = 352.284949
+  0: The maximum resident set size (KB)                   = 1107064
 
 Test 092 hrrr_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_unified_drag_suite_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_unified_drag_suite_debug
 Checking test 093 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 367.791364
-  0: The maximum resident set size (KB)                   = 1105176
+  0: The total amount of wall time                        = 359.275787
+  0: The maximum resident set size (KB)                   = 1104856
 
 Test 093 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_diag_debug
 Checking test 094 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 388.919285
-  0: The maximum resident set size (KB)                   = 1184608
+  0: The total amount of wall time                        = 377.813816
+  0: The maximum resident set size (KB)                   = 1188032
 
 Test 094 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_cires_ugwp_debug
 Checking test 095 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 374.805579
-  0: The maximum resident set size (KB)                   = 1102156
+  0: The total amount of wall time                        = 369.792895
+  0: The maximum resident set size (KB)                   = 1106364
 
 Test 095 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_unified_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_unified_ugwp_debug
 Checking test 096 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 373.279274
-  0: The maximum resident set size (KB)                   = 1111932
+  0: The total amount of wall time                        = 369.288106
+  0: The maximum resident set size (KB)                   = 1114804
 
 Test 096 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_lndp_debug
 Checking test 097 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 365.192005
-  0: The maximum resident set size (KB)                   = 1116116
+  0: The total amount of wall time                        = 370.126900
+  0: The maximum resident set size (KB)                   = 1110016
 
 Test 097 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_flake_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_flake_debug
 Checking test 098 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 363.911848
-  0: The maximum resident set size (KB)                   = 1106332
+  0: The total amount of wall time                        = 358.292373
+  0: The maximum resident set size (KB)                   = 1107348
 
 Test 098 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_progcld_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_progcld_thompson_debug
 Checking test 099 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 362.374107
-  0: The maximum resident set size (KB)                   = 1105040
+  0: The total amount of wall time                        = 360.746525
+  0: The maximum resident set size (KB)                   = 1103888
 
 Test 099 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_noah_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_noah_debug
 Checking test 100 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 359.819520
-  0: The maximum resident set size (KB)                   = 1107580
+  0: The total amount of wall time                        = 357.251266
+  0: The maximum resident set size (KB)                   = 1107596
 
 Test 100 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_rrtmgp_debug
 Checking test 101 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 607.398835
-  0: The maximum resident set size (KB)                   = 1232008
+  0: The total amount of wall time                        = 604.800172
+  0: The maximum resident set size (KB)                   = 1233756
 
 Test 101 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_sfcdiff_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_sfcdiff_debug
 Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 373.844143
-  0: The maximum resident set size (KB)                   = 1107660
+  0: The total amount of wall time                        = 367.387375
+  0: The maximum resident set size (KB)                   = 1106416
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 590.643921
-  0: The maximum resident set size (KB)                   = 1109988
+  0: The total amount of wall time                        = 586.568661
+  0: The maximum resident set size (KB)                   = 1103952
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rrfs_v1beta_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rrfs_v1beta_debug
 Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 363.185805
-  0: The maximum resident set size (KB)                   = 1108400
+  0: The total amount of wall time                        = 355.412029
+  0: The maximum resident set size (KB)                   = 1104076
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_wam_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 370.663020
-  0: The maximum resident set size (KB)                   = 433260
+  0: The total amount of wall time                        = 373.871919
+  0: The maximum resident set size (KB)                   = 435560
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3373,14 +3373,14 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 782.146863
-  0: The maximum resident set size (KB)                   = 967360
+  0: The total amount of wall time                        = 778.438423
+  0: The maximum resident set size (KB)                   = 960920
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_control_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_control_dyn32_phy32
 Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3427,14 +3427,14 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 494.956180
-  0: The maximum resident set size (KB)                   = 837292
+  0: The total amount of wall time                        = 481.902778
+  0: The maximum resident set size (KB)                   = 840088
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_dyn32_phy32
 Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3481,14 +3481,14 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 245.404154
-  0: The maximum resident set size (KB)                   = 825656
+  0: The total amount of wall time                        = 243.655528
+  0: The maximum resident set size (KB)                   = 825780
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_2threads_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_2threads_dyn32_phy32
 Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3535,14 +3535,14 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1078.087800
- 0: The maximum resident set size (KB)                   = 880000
+ 0: The total amount of wall time                        = 1043.307694
+ 0: The maximum resident set size (KB)                   = 874648
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_2threads_dyn32_phy32
 Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3589,14 +3589,14 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 545.881695
- 0: The maximum resident set size (KB)                   = 873256
+ 0: The total amount of wall time                        = 537.137993
+ 0: The maximum resident set size (KB)                   = 876848
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_decomp_dyn32_phy32
 Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3643,14 +3643,14 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 261.718843
-  0: The maximum resident set size (KB)                   = 817580
+  0: The total amount of wall time                        = 257.404199
+  0: The maximum resident set size (KB)                   = 818136
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_restart_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_restart_dyn32_phy32
 Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3689,14 +3689,14 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 354.492684
-  0: The maximum resident set size (KB)                   = 800788
+  0: The total amount of wall time                        = 349.500162
+  0: The maximum resident set size (KB)                   = 801692
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_restart_dyn32_phy32
 Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3735,14 +3735,14 @@ Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 151.261810
-  0: The maximum resident set size (KB)                   = 757356
+  0: The total amount of wall time                        = 125.415022
+  0: The maximum resident set size (KB)                   = 757296
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_control_dyn64_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_control_dyn64_phy32
 Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3789,81 +3789,81 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 313.469738
-  0: The maximum resident set size (KB)                   = 875784
+  0: The total amount of wall time                        = 305.300412
+  0: The maximum resident set size (KB)                   = 864168
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_control_debug_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_control_debug_dyn32_phy32
 Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 372.554657
-  0: The maximum resident set size (KB)                   = 994796
+  0: The total amount of wall time                        = 352.071502
+  0: The maximum resident set size (KB)                   = 1000332
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hrrr_control_debug_dyn32_phy32
 Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 374.493775
-  0: The maximum resident set size (KB)                   = 989576
+  0: The total amount of wall time                        = 350.237623
+  0: The maximum resident set size (KB)                   = 989608
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/rap_control_dyn64_phy32_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/rap_control_dyn64_phy32_debug
 Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 382.874918
-  0: The maximum resident set size (KB)                   = 1029832
+  0: The total amount of wall time                        = 366.273247
+  0: The maximum resident set size (KB)                   = 1035968
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_atm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_atm
 Checking test 118 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 762.881076
-  0: The maximum resident set size (KB)                   = 1157812
+  0: The total amount of wall time                        = 740.330233
+  0: The maximum resident set size (KB)                   = 1159812
 
 Test 118 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_atm_thompson_gfdlsf
 Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 847.438161
-  0: The maximum resident set size (KB)                   = 1506784
+  0: The total amount of wall time                        = 859.085108
+  0: The maximum resident set size (KB)                   = 1532460
 
 Test 119 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_atm_ocn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_atm_ocn
 Checking test 120 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3872,14 +3872,14 @@ Checking test 120 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 605.773693
-  0: The maximum resident set size (KB)                   = 1213916
+  0: The total amount of wall time                        = 543.000045
+  0: The maximum resident set size (KB)                   = 1270048
 
 Test 120 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_atm_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_atm_wav
 Checking test 121 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3888,14 +3888,14 @@ Checking test 121 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 914.101027
-  0: The maximum resident set size (KB)                   = 1302072
+  0: The total amount of wall time                        = 899.065215
+  0: The maximum resident set size (KB)                   = 1301356
 
 Test 121 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_atm_ocn_wav
 Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3906,14 +3906,14 @@ Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1040.779074
-  0: The maximum resident set size (KB)                   = 1273024
+  0: The total amount of wall time                        = 1016.270004
+  0: The maximum resident set size (KB)                   = 1314320
 
 Test 122 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_docn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_docn
 Checking test 123 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3921,14 +3921,14 @@ Checking test 123 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 614.484408
-  0: The maximum resident set size (KB)                   = 1282456
+  0: The total amount of wall time                        = 539.821061
+  0: The maximum resident set size (KB)                   = 1281616
 
 Test 123 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_docn_oisst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_docn_oisst
 Checking test 124 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3936,131 +3936,131 @@ Checking test 124 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 565.848915
-  0: The maximum resident set size (KB)                   = 1261184
+  0: The total amount of wall time                        = 547.235203
+  0: The maximum resident set size (KB)                   = 1264452
 
 Test 124 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/hafs_regional_datm_cdeps
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/hafs_regional_datm_cdeps
 Checking test 125 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1245.073017
-  0: The maximum resident set size (KB)                   = 974600
+  0: The total amount of wall time                        = 1235.847011
+  0: The maximum resident set size (KB)                   = 975516
 
 Test 125 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_control_cfsr
 Checking test 126 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 207.348145
- 0: The maximum resident set size (KB)                   = 969240
+ 0: The total amount of wall time                        = 210.309464
+ 0: The maximum resident set size (KB)                   = 960280
 
 Test 126 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_restart_cfsr
 Checking test 127 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.135795
- 0: The maximum resident set size (KB)                   = 926040
+ 0: The total amount of wall time                        = 128.959614
+ 0: The maximum resident set size (KB)                   = 932096
 
 Test 127 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_control_gefs
 Checking test 128 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 203.432106
- 0: The maximum resident set size (KB)                   = 858440
+ 0: The total amount of wall time                        = 201.513039
+ 0: The maximum resident set size (KB)                   = 864000
 
 Test 128 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_iau_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_iau_gefs
 Checking test 129 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 203.847091
- 0: The maximum resident set size (KB)                   = 868800
+ 0: The total amount of wall time                        = 209.074554
+ 0: The maximum resident set size (KB)                   = 868332
 
 Test 129 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_stochy_gefs
 Checking test 130 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 204.758005
- 0: The maximum resident set size (KB)                   = 863020
+ 0: The total amount of wall time                        = 206.735865
+ 0: The maximum resident set size (KB)                   = 867580
 
 Test 130 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_ciceC_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_ciceC_cfsr
 Checking test 131 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 229.878496
- 0: The maximum resident set size (KB)                   = 954320
+ 0: The total amount of wall time                        = 206.572780
+ 0: The maximum resident set size (KB)                   = 962788
 
 Test 131 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_bulk_cfsr
 Checking test 132 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 209.876942
- 0: The maximum resident set size (KB)                   = 961824
+ 0: The total amount of wall time                        = 212.698345
+ 0: The maximum resident set size (KB)                   = 957860
 
 Test 132 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_bulk_gefs
 Checking test 133 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 219.657684
- 0: The maximum resident set size (KB)                   = 863184
+ 0: The total amount of wall time                        = 204.878344
+ 0: The maximum resident set size (KB)                   = 862020
 
 Test 133 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_mx025_cfsr
 Checking test 134 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4069,14 +4069,14 @@ Checking test 134 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 588.045646
-  0: The maximum resident set size (KB)                   = 761928
+  0: The total amount of wall time                        = 591.144659
+  0: The maximum resident set size (KB)                   = 764852
 
 Test 134 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_mx025_gefs
 Checking test 135 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4085,64 +4085,64 @@ Checking test 135 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 584.621083
-  0: The maximum resident set size (KB)                   = 734568
+  0: The total amount of wall time                        = 588.533295
+  0: The maximum resident set size (KB)                   = 736100
 
 Test 135 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_multiple_files_cfsr
 Checking test 136 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 223.994106
- 0: The maximum resident set size (KB)                   = 974460
+ 0: The total amount of wall time                        = 214.152872
+ 0: The maximum resident set size (KB)                   = 970712
 
 Test 136 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_3072x1536_cfsr
 Checking test 137 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 308.019967
- 0: The maximum resident set size (KB)                   = 2258808
+ 0: The total amount of wall time                        = 297.715077
+ 0: The maximum resident set size (KB)                   = 2251596
 
 Test 137 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_gfs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_gfs
 Checking test 138 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 329.633268
- 0: The maximum resident set size (KB)                   = 2264512
+ 0: The total amount of wall time                        = 297.482386
+ 0: The maximum resident set size (KB)                   = 2257016
 
 Test 138 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_debug_cfsr
 Checking test 139 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 587.519187
- 0: The maximum resident set size (KB)                   = 914804
+ 0: The total amount of wall time                        = 581.978131
+ 0: The maximum resident set size (KB)                   = 920676
 
 Test 139 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_lnd_gswp3
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_lnd_gswp3
 Checking test 140 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4151,14 +4151,14 @@ Checking test 140 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 27.822803
-  0: The maximum resident set size (KB)                   = 252232
+  0: The total amount of wall time                        = 13.482601
+  0: The maximum resident set size (KB)                   = 248772
 
 Test 140 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/datm_cdeps_lnd_gswp3_rst
 Checking test 141 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4167,14 +4167,14 @@ Checking test 141 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 22.526804
-  0: The maximum resident set size (KB)                   = 254500
+  0: The total amount of wall time                        = 26.830153
+  0: The maximum resident set size (KB)                   = 247896
 
 Test 141 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_p8_atmlnd_sbs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_p8_atmlnd_sbs
 Checking test 142 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4259,14 +4259,14 @@ Checking test 142 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 309.997396
-  0: The maximum resident set size (KB)                   = 1588432
+  0: The total amount of wall time                        = 303.511248
+  0: The maximum resident set size (KB)                   = 1582744
 
 Test 142 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/control_atmwav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/control_atmwav
 Checking test 143 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4310,14 +4310,14 @@ Checking test 143 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 123.279236
-  0: The maximum resident set size (KB)                   = 593000
+  0: The total amount of wall time                        = 120.690966
+  0: The maximum resident set size (KB)                   = 600124
 
 Test 143 control_atmwav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/atmaero_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/atmaero_control_p8
 Checking test 144 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4361,14 +4361,14 @@ Checking test 144 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 318.381252
-  0: The maximum resident set size (KB)                   = 1631248
+  0: The total amount of wall time                        = 304.870055
+  0: The maximum resident set size (KB)                   = 1636260
 
 Test 144 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/atmaero_control_p8_rad
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/atmaero_control_p8_rad
 Checking test 145 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4412,14 +4412,14 @@ Checking test 145 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 385.343674
-  0: The maximum resident set size (KB)                   = 1663964
+  0: The total amount of wall time                        = 380.090514
+  0: The maximum resident set size (KB)                   = 1668392
 
 Test 145 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/atmaero_control_p8_rad_micro
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/atmaero_control_p8_rad_micro
 Checking test 146 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4463,49 +4463,15 @@ Checking test 146 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 392.790678
-  0: The maximum resident set size (KB)                   = 1651936
+  0: The total amount of wall time                        = 387.831269
+  0: The maximum resident set size (KB)                   = 1671764
 
 Test 146 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_127768/regional_atmaq
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_196011/regional_atmaq
 Checking test 147 regional_atmaq results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf003.nc ............ALT CHECK......NOT OK
- Comparing sfcf006.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf003.nc ............ALT CHECK......NOT OK
- Comparing atmf006.nc ............ALT CHECK......NOT OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/phy_data.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 1215.881428
-  0: The maximum resident set size (KB)                   = 1032940
-
-Test 147 regional_atmaq FAIL Tries: 2
-
-FAILED TESTS: 
-Test regional_atmaq 147 failed in check_result failed 
-Test regional_atmaq 147 failed in run_test failed 
-
-REGRESSION TEST FAILED
-Wed Nov  2 19:32:27 GMT 2022
-Elapsed time: 03h:00m:18s. Have a nice day!
-Wed Nov  2 21:12:36 GMT 2022
-Start Regression test
-
-Compile 001 elapsed time 1363 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_221570/regional_atmaq
-Checking test 001 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4520,12 +4486,12 @@ Checking test 001 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1038.738427
-  0: The maximum resident set size (KB)                   = 1024360
+  0: The total amount of wall time                        = 1015.909999
+  0: The maximum resident set size (KB)                   = 1046944
 
-Test 001 regional_atmaq PASS
+Test 147 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 22:09:06 GMT 2022
-Elapsed time: 00h:56m:31s. Have a nice day!
+Tue Nov  8 02:00:55 GMT 2022
+Elapsed time: 02h:09m:02s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,34 +1,34 @@
-Wed Nov  2 20:05:19 CDT 2022
+Mon Nov  7 17:07:31 CST 2022
 Start Regression test
 
-Compile 001 elapsed time 800 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 716 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 339 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 337 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 557 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 557 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 520 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 520 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 520 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 449 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 748 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 173 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 402 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 216 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 216 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 575 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 603 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 200 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 129 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 021 elapsed time 58 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 386 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 587 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 352 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 359 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 633 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 614 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 258 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 214 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 455 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 475 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 424 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 426 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 436 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 391 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 780 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 168 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 346 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 388 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 205 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 204 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 594 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 602 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 208 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 127 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 021 elapsed time 63 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 433 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 649 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 436 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 399 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 349.589492
-  0: The maximum resident set size (KB)                   = 3174584
+  0: The total amount of wall time                        = 375.742971
+  0: The maximum resident set size (KB)                   = 3172856
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_restart_p8
 Checking test 002 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -153,14 +153,14 @@ Checking test 002 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 199.788492
-  0: The maximum resident set size (KB)                   = 3049192
+  0: The total amount of wall time                        = 204.802609
+  0: The maximum resident set size (KB)                   = 3052920
 
 Test 002 cpld_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_2threads_p8
 Checking test 003 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -213,14 +213,14 @@ Checking test 003 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 421.206208
-  0: The maximum resident set size (KB)                   = 3457388
+  0: The total amount of wall time                        = 428.179199
+  0: The maximum resident set size (KB)                   = 3452008
 
 Test 003 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_esmfthreads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_esmfthreads_p8
 Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 004 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 407.987570
-  0: The maximum resident set size (KB)                   = 3517876
+  0: The total amount of wall time                        = 409.305717
+  0: The maximum resident set size (KB)                   = 3459944
 
 Test 004 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_decomp_p8
 Checking test 005 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 005 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 344.014501
-  0: The maximum resident set size (KB)                   = 3169540
+  0: The total amount of wall time                        = 351.285438
+  0: The maximum resident set size (KB)                   = 3168088
 
 Test 005 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_mpi_p8
 Checking test 006 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 006 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 284.796534
-  0: The maximum resident set size (KB)                   = 3026504
+  0: The total amount of wall time                        = 285.346946
+  0: The maximum resident set size (KB)                   = 3025204
 
 Test 006 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_ciceC_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_ciceC_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_ciceC_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_ciceC_p8
 Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 007 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 341.380247
-  0: The maximum resident set size (KB)                   = 3179564
+  0: The total amount of wall time                        = 347.278341
+  0: The maximum resident set size (KB)                   = 3184540
 
 Test 007 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -525,14 +525,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 738.055285
-  0: The maximum resident set size (KB)                   = 3227200
+  0: The total amount of wall time                        = 672.931541
+  0: The maximum resident set size (KB)                   = 3231384
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -585,14 +585,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 429.540682
-  0: The maximum resident set size (KB)                   = 3146584
+  0: The total amount of wall time                        = 444.247798
+  0: The maximum resident set size (KB)                   = 3140916
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -640,14 +640,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 839.143180
-  0: The maximum resident set size (KB)                   = 3996684
+  0: The total amount of wall time                        = 963.012028
+  0: The maximum resident set size (KB)                   = 3996568
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_restart_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -695,14 +695,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 579.937236
-  0: The maximum resident set size (KB)                   = 3953064
+  0: The total amount of wall time                        = 532.388433
+  0: The maximum resident set size (KB)                   = 3950352
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_bmark_esmfthreads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_bmark_esmfthreads_p8
 Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -750,14 +750,14 @@ Checking test 012 cpld_bmark_esmfthreads_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 981.345501
-   0: The maximum resident set size (KB)                   = 4041612
+   0: The total amount of wall time                        = 892.678847
+   0: The maximum resident set size (KB)                   = 4036108
 
 Test 012 cpld_bmark_esmfthreads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -821,14 +821,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 235.619407
-  0: The maximum resident set size (KB)                   = 1716180
+  0: The total amount of wall time                        = 233.179496
+  0: The maximum resident set size (KB)                   = 1726644
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_nowave_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -890,14 +890,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 259.579078
-  0: The maximum resident set size (KB)                   = 1756584
+  0: The total amount of wall time                        = 267.883436
+  0: The maximum resident set size (KB)                   = 1686284
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -950,14 +950,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 669.440178
-  0: The maximum resident set size (KB)                   = 3251456
+  0: The total amount of wall time                        = 700.504398
+  0: The maximum resident set size (KB)                   = 3253112
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_debug_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_debug_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_debug_noaero_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 408.372315
-  0: The maximum resident set size (KB)                   = 1751292
+  0: The total amount of wall time                        = 452.206091
+  0: The maximum resident set size (KB)                   = 1763916
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_noaero_p8_agrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1078,14 +1078,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 266.513335
-  0: The maximum resident set size (KB)                   = 1753892
+  0: The total amount of wall time                        = 265.219250
+  0: The maximum resident set size (KB)                   = 1763452
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1135,14 +1135,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 500.722314
- 0: The maximum resident set size (KB)                   = 2810132
+ 0: The total amount of wall time                        = 519.579359
+ 0: The maximum resident set size (KB)                   = 2742556
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_warmstart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1192,14 +1192,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 139.264900
- 0: The maximum resident set size (KB)                   = 2803352
+ 0: The total amount of wall time                        = 137.917636
+ 0: The maximum resident set size (KB)                   = 2812588
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/cpld_restart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1249,14 +1249,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 73.478248
- 0: The maximum resident set size (KB)                   = 2248692
+ 0: The total amount of wall time                        = 76.023918
+ 0: The maximum resident set size (KB)                   = 2222060
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control
 Checking test 021 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1303,14 +1303,14 @@ Checking test 021 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.266147
-  0: The maximum resident set size (KB)                   = 639032
+  0: The total amount of wall time                        = 146.130439
+  0: The maximum resident set size (KB)                   = 630816
 
 Test 021 control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_decomp
 Checking test 022 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 022 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 140.040017
-  0: The maximum resident set size (KB)                   = 622320
+  0: The total amount of wall time                        = 153.236166
+  0: The maximum resident set size (KB)                   = 612404
 
 Test 022 control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_2dwrtdecomp
 Checking test 023 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1371,14 +1371,14 @@ Checking test 023 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 132.500650
-  0: The maximum resident set size (KB)                   = 634332
+  0: The total amount of wall time                        = 145.696094
+  0: The maximum resident set size (KB)                   = 636304
 
 Test 023 control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_2threads
 Checking test 024 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1421,14 +1421,14 @@ Checking test 024 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 161.064473
- 0: The maximum resident set size (KB)                   = 670036
+ 0: The total amount of wall time                        = 168.600694
+ 0: The maximum resident set size (KB)                   = 674772
 
 Test 024 control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_restart
 Checking test 025 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1467,14 +1467,14 @@ Checking test 025 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 69.349082
-  0: The maximum resident set size (KB)                   = 475328
+  0: The total amount of wall time                        = 69.563239
+  0: The maximum resident set size (KB)                   = 467092
 
 Test 025 control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_fhzero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_fhzero
 Checking test 026 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1517,14 +1517,14 @@ Checking test 026 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.195548
-  0: The maximum resident set size (KB)                   = 631080
+  0: The total amount of wall time                        = 137.035753
+  0: The maximum resident set size (KB)                   = 633324
 
 Test 026 control_fhzero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_CubedSphereGrid
 Checking test 027 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1551,28 +1551,28 @@ Checking test 027 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.106454
-  0: The maximum resident set size (KB)                   = 633916
+  0: The total amount of wall time                        = 146.127363
+  0: The maximum resident set size (KB)                   = 636612
 
 Test 027 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_CubedSphereGrid_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_CubedSphereGrid_parallel
 Checking test 028 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 126.748065
-  0: The maximum resident set size (KB)                   = 631448
+  0: The total amount of wall time                        = 141.726667
+  0: The maximum resident set size (KB)                   = 577136
 
 Test 028 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_latlon
 Checking test 029 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1583,14 +1583,14 @@ Checking test 029 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.387195
-  0: The maximum resident set size (KB)                   = 633692
+  0: The total amount of wall time                        = 144.645859
+  0: The maximum resident set size (KB)                   = 636328
 
 Test 029 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_wrtGauss_netcdf_parallel
 Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1601,14 +1601,14 @@ Checking test 030 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.070254
-  0: The maximum resident set size (KB)                   = 633500
+  0: The total amount of wall time                        = 150.782945
+  0: The maximum resident set size (KB)                   = 634552
 
 Test 030 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_c48
 Checking test 031 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1647,14 +1647,14 @@ Checking test 031 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 342.382301
-0: The maximum resident set size (KB)                   = 821704
+0: The total amount of wall time                        = 345.039866
+0: The maximum resident set size (KB)                   = 822928
 
 Test 031 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_c192
 Checking test 032 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1665,14 +1665,14 @@ Checking test 032 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 527.426592
-  0: The maximum resident set size (KB)                   = 762156
+  0: The total amount of wall time                        = 532.905629
+  0: The maximum resident set size (KB)                   = 769672
 
 Test 032 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_c384
 Checking test 033 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1683,14 +1683,14 @@ Checking test 033 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 725.136306
-  0: The maximum resident set size (KB)                   = 1092412
+  0: The total amount of wall time                        = 742.791610
+  0: The maximum resident set size (KB)                   = 1087120
 
 Test 033 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_c384gdas
 Checking test 034 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1733,14 +1733,14 @@ Checking test 034 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 569.089836
-  0: The maximum resident set size (KB)                   = 1247756
+  0: The total amount of wall time                        = 599.162802
+  0: The maximum resident set size (KB)                   = 1246592
 
 Test 034 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_c384_progsigma
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_c384_progsigma
 Checking test 035 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 035 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 690.677894
-  0: The maximum resident set size (KB)                   = 1087920
+  0: The total amount of wall time                        = 700.280669
+  0: The maximum resident set size (KB)                   = 1087088
 
 Test 035 control_c384_progsigma PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_stochy
 Checking test 036 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1769,28 +1769,28 @@ Checking test 036 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 86.221791
-  0: The maximum resident set size (KB)                   = 644388
+  0: The total amount of wall time                        = 96.714405
+  0: The maximum resident set size (KB)                   = 641268
 
 Test 036 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_stochy_restart
 Checking test 037 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.404548
-  0: The maximum resident set size (KB)                   = 488660
+  0: The total amount of wall time                        = 47.105155
+  0: The maximum resident set size (KB)                   = 485812
 
 Test 037 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_lndp
 Checking test 038 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1801,14 +1801,14 @@ Checking test 038 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 82.369098
-  0: The maximum resident set size (KB)                   = 636252
+  0: The total amount of wall time                        = 91.515998
+  0: The maximum resident set size (KB)                   = 640524
 
 Test 038 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_iovr4
 Checking test 039 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1823,14 +1823,14 @@ Checking test 039 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.159436
-  0: The maximum resident set size (KB)                   = 634048
+  0: The total amount of wall time                        = 146.690794
+  0: The maximum resident set size (KB)                   = 634272
 
 Test 039 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_iovr5
 Checking test 040 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1845,14 +1845,14 @@ Checking test 040 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.366470
-  0: The maximum resident set size (KB)                   = 639192
+  0: The total amount of wall time                        = 149.353655
+  0: The maximum resident set size (KB)                   = 633144
 
 Test 040 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_p8
 Checking test 041 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1899,14 +1899,14 @@ Checking test 041 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.900465
-  0: The maximum resident set size (KB)                   = 1604616
+  0: The total amount of wall time                        = 185.516496
+  0: The maximum resident set size (KB)                   = 1605256
 
 Test 041 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_p8_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_p8_lndp
 Checking test 042 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 042 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 312.512569
-  0: The maximum resident set size (KB)                   = 1605980
+  0: The total amount of wall time                        = 328.887506
+  0: The maximum resident set size (KB)                   = 1612680
 
 Test 042 control_p8_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_restart_p8
 Checking test 043 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 043 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 86.192611
-  0: The maximum resident set size (KB)                   = 876416
+  0: The total amount of wall time                        = 87.779768
+  0: The maximum resident set size (KB)                   = 864044
 
 Test 043 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_decomp_p8
 Checking test 044 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2021,14 +2021,14 @@ Checking test 044 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.690462
-  0: The maximum resident set size (KB)                   = 1598168
+  0: The total amount of wall time                        = 189.142292
+  0: The maximum resident set size (KB)                   = 1587536
 
 Test 044 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_2threads_p8
 Checking test 045 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 045 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 195.526324
- 0: The maximum resident set size (KB)                   = 1678392
+ 0: The total amount of wall time                        = 205.710149
+ 0: The maximum resident set size (KB)                   = 1675608
 
 Test 045 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_p8_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_p8_rrtmgp
 Checking test 046 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 046 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 197.939439
-  0: The maximum resident set size (KB)                   = 1730616
+  0: The total amount of wall time                        = 215.506222
+  0: The maximum resident set size (KB)                   = 1738700
 
 Test 046 control_p8_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/merra2_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.914533
-  0: The maximum resident set size (KB)                   = 1626636
+  0: The total amount of wall time                        = 184.547944
+  0: The maximum resident set size (KB)                   = 1624016
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2197,28 +2197,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 347.130505
- 0: The maximum resident set size (KB)                   = 847400
+ 0: The total amount of wall time                        = 357.044266
+ 0: The maximum resident set size (KB)                   = 821308
 
 Test 048 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 191.039426
- 0: The maximum resident set size (KB)                   = 815692
+ 0: The total amount of wall time                        = 191.416408
+ 0: The maximum resident set size (KB)                   = 836988
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_control_2dwrtdecomp
 Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 050 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 348.246578
- 0: The maximum resident set size (KB)                   = 792424
+ 0: The total amount of wall time                        = 354.077108
+ 0: The maximum resident set size (KB)                   = 845240
 
 Test 050 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2244,14 +2244,14 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 370.277477
- 0: The maximum resident set size (KB)                   = 835616
+ 0: The total amount of wall time                        = 379.557077
+ 0: The maximum resident set size (KB)                   = 840420
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2262,28 +2262,28 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 240.825554
- 0: The maximum resident set size (KB)                   = 770812
+ 0: The total amount of wall time                        = 254.892665
+ 0: The maximum resident set size (KB)                   = 774152
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_netcdf_parallel
 Checking test 053 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 344.343622
- 0: The maximum resident set size (KB)                   = 840508
+ 0: The total amount of wall time                        = 346.295229
+ 0: The maximum resident set size (KB)                   = 841148
 
 Test 053 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_3km
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_3km
 Checking test 054 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2294,14 +2294,14 @@ Checking test 054 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 264.182203
-  0: The maximum resident set size (KB)                   = 865536
+  0: The total amount of wall time                        = 261.131221
+  0: The maximum resident set size (KB)                   = 858924
 
 Test 054 regional_3km PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_3km_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_3km_decomp
 Checking test 055 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2312,14 +2312,14 @@ Checking test 055 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 277.405337
-  0: The maximum resident set size (KB)                   = 868136
+  0: The total amount of wall time                        = 276.040264
+  0: The maximum resident set size (KB)                   = 863904
 
 Test 055 regional_3km_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_3km_wofs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_3km_wofs
 Checking test 056 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2330,14 +2330,14 @@ Checking test 056 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 341.415315
-  0: The maximum resident set size (KB)                   = 630204
+  0: The total amount of wall time                        = 340.480549
+  0: The maximum resident set size (KB)                   = 625732
 
 Test 056 regional_3km_wofs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_control
 Checking test 057 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2384,14 +2384,14 @@ Checking test 057 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.424769
-  0: The maximum resident set size (KB)                   = 1051132
+  0: The total amount of wall time                        = 445.700511
+  0: The maximum resident set size (KB)                   = 994848
 
 Test 057 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_rrtmgp
 Checking test 058 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2438,14 +2438,14 @@ Checking test 058 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 469.920395
-  0: The maximum resident set size (KB)                   = 1211548
+  0: The total amount of wall time                        = 469.470190
+  0: The maximum resident set size (KB)                   = 1212708
 
 Test 058 rap_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_spp_sppt_shum_skeb
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_spp_sppt_shum_skeb
 Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2456,14 +2456,14 @@ Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 287.573954
-  0: The maximum resident set size (KB)                   = 1177452
+  0: The total amount of wall time                        = 293.614327
+  0: The maximum resident set size (KB)                   = 1178856
 
 Test 059 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_decomp
 Checking test 060 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2510,14 +2510,14 @@ Checking test 060 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.033510
-  0: The maximum resident set size (KB)                   = 1004072
+  0: The total amount of wall time                        = 466.170991
+  0: The maximum resident set size (KB)                   = 1000848
 
 Test 060 rap_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_2threads
 Checking test 061 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2564,14 +2564,14 @@ Checking test 061 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 505.235679
- 0: The maximum resident set size (KB)                   = 1065912
+ 0: The total amount of wall time                        = 507.620093
+ 0: The maximum resident set size (KB)                   = 1067120
 
 Test 061 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_restart
 Checking test 062 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2610,14 +2610,14 @@ Checking test 062 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 224.033445
-  0: The maximum resident set size (KB)                   = 956628
+  0: The total amount of wall time                        = 223.921859
+  0: The maximum resident set size (KB)                   = 960420
 
 Test 062 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_sfcdiff
 Checking test 063 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2664,14 +2664,14 @@ Checking test 063 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 434.341642
-  0: The maximum resident set size (KB)                   = 1054368
+  0: The total amount of wall time                        = 435.471800
+  0: The maximum resident set size (KB)                   = 1058980
 
 Test 063 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_sfcdiff_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_sfcdiff_decomp
 Checking test 064 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2718,14 +2718,14 @@ Checking test 064 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.458966
-  0: The maximum resident set size (KB)                   = 1006844
+  0: The total amount of wall time                        = 461.361960
+  0: The maximum resident set size (KB)                   = 1001512
 
 Test 064 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_sfcdiff_restart
 Checking test 065 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2764,14 +2764,14 @@ Checking test 065 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 328.407703
-  0: The maximum resident set size (KB)                   = 988392
+  0: The total amount of wall time                        = 328.946282
+  0: The maximum resident set size (KB)                   = 975552
 
 Test 065 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control
 Checking test 066 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2818,14 +2818,14 @@ Checking test 066 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 416.794552
-  0: The maximum resident set size (KB)                   = 1049536
+  0: The total amount of wall time                        = 421.895378
+  0: The maximum resident set size (KB)                   = 1045288
 
 Test 066 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_decomp
 Checking test 067 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2872,14 +2872,14 @@ Checking test 067 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.993866
-  0: The maximum resident set size (KB)                   = 995800
+  0: The total amount of wall time                        = 444.134054
+  0: The maximum resident set size (KB)                   = 996156
 
 Test 067 hrrr_control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_2threads
 Checking test 068 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2926,14 +2926,14 @@ Checking test 068 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 469.824761
- 0: The maximum resident set size (KB)                   = 1057736
+ 0: The total amount of wall time                        = 481.786062
+ 0: The maximum resident set size (KB)                   = 1058452
 
 Test 068 hrrr_control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_restart
 Checking test 069 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2972,14 +2972,14 @@ Checking test 069 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 315.711321
-  0: The maximum resident set size (KB)                   = 978584
+  0: The total amount of wall time                        = 319.378562
+  0: The maximum resident set size (KB)                   = 982688
 
 Test 069 hrrr_control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_v1beta
 Checking test 070 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3026,14 +3026,14 @@ Checking test 070 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 431.269346
-  0: The maximum resident set size (KB)                   = 1045076
+  0: The total amount of wall time                        = 432.234088
+  0: The maximum resident set size (KB)                   = 1044576
 
 Test 070 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_v1nssl
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_v1nssl
 Checking test 071 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3048,14 +3048,14 @@ Checking test 071 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 510.617301
-  0: The maximum resident set size (KB)                   = 689828
+  0: The total amount of wall time                        = 512.444851
+  0: The maximum resident set size (KB)                   = 685344
 
 Test 071 rrfs_v1nssl PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_v1nssl_nohailnoccn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_v1nssl_nohailnoccn
 Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3070,14 +3070,14 @@ Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 501.736568
-  0: The maximum resident set size (KB)                   = 753328
+  0: The total amount of wall time                        = 501.195100
+  0: The maximum resident set size (KB)                   = 746468
 
 Test 072 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_conus13km_hrrr_warm
 Checking test 073 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3086,14 +3086,14 @@ Checking test 073 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 122.937309
-  0: The maximum resident set size (KB)                   = 929600
+  0: The total amount of wall time                        = 122.232130
+  0: The maximum resident set size (KB)                   = 927456
 
 Test 073 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_smoke_conus13km_hrrr_warm
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3102,14 +3102,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 138.108119
-  0: The maximum resident set size (KB)                   = 955604
+  0: The total amount of wall time                        = 138.817689
+  0: The maximum resident set size (KB)                   = 958668
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_conus13km_radar_tten_warm
 Checking test 075 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3118,14 +3118,14 @@ Checking test 075 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 122.459019
-  0: The maximum resident set size (KB)                   = 932052
+  0: The total amount of wall time                        = 124.415617
+  0: The maximum resident set size (KB)                   = 935604
 
 Test 075 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_conus13km_hrrr_warm_2threads
 Checking test 076 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3134,14 +3134,14 @@ Checking test 076 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 92.634668
-  0: The maximum resident set size (KB)                   = 903928
+  0: The total amount of wall time                        = 90.708514
+  0: The maximum resident set size (KB)                   = 899452
 
 Test 076 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 077 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3150,14 +3150,14 @@ Checking test 077 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 94.900696
-  0: The maximum resident set size (KB)                   = 904580
+  0: The total amount of wall time                        = 92.465502
+  0: The maximum resident set size (KB)                   = 901368
 
 Test 077 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_csawmg
 Checking test 078 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3168,14 +3168,14 @@ Checking test 078 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 340.010704
-  0: The maximum resident set size (KB)                   = 728404
+  0: The total amount of wall time                        = 342.115173
+  0: The maximum resident set size (KB)                   = 731888
 
 Test 078 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_csawmgt
 Checking test 079 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3186,14 +3186,14 @@ Checking test 079 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 335.386162
-  0: The maximum resident set size (KB)                   = 731912
+  0: The total amount of wall time                        = 335.224743
+  0: The maximum resident set size (KB)                   = 723960
 
 Test 079 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_ras
 Checking test 080 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3204,82 +3204,82 @@ Checking test 080 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 192.225260
-  0: The maximum resident set size (KB)                   = 718960
+  0: The total amount of wall time                        = 180.737368
+  0: The maximum resident set size (KB)                   = 721148
 
 Test 080 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_wam
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_wam
 Checking test 081 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 108.339743
-  0: The maximum resident set size (KB)                   = 636496
+  0: The total amount of wall time                        = 108.550339
+  0: The maximum resident set size (KB)                   = 639536
 
 Test 081 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_conus13km_hrrr_warm_debug
 Checking test 082 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 739.122821
-  0: The maximum resident set size (KB)                   = 954076
+  0: The total amount of wall time                        = 733.023707
+  0: The maximum resident set size (KB)                   = 956264
 
 Test 082 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_conus13km_radar_tten_warm_debug
 Checking test 083 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 749.076953
-  0: The maximum resident set size (KB)                   = 966748
+  0: The total amount of wall time                        = 741.174556
+  0: The maximum resident set size (KB)                   = 961116
 
 Test 083 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_debug
 Checking test 084 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.925146
-  0: The maximum resident set size (KB)                   = 793000
+  0: The total amount of wall time                        = 161.357813
+  0: The maximum resident set size (KB)                   = 781348
 
 Test 084 control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_2threads_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_2threads_debug
 Checking test 085 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 229.658011
- 0: The maximum resident set size (KB)                   = 839000
+ 0: The total amount of wall time                        = 234.614506
+ 0: The maximum resident set size (KB)                   = 834824
 
 Test 085 control_2threads_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_CubedSphereGrid_debug
 Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3306,348 +3306,348 @@ Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.247583
-  0: The maximum resident set size (KB)                   = 792616
+  0: The total amount of wall time                        = 172.522235
+  0: The maximum resident set size (KB)                   = 792556
 
 Test 086 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_wrtGauss_netcdf_parallel_debug
 Checking test 087 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.035783
-  0: The maximum resident set size (KB)                   = 797688
+  0: The total amount of wall time                        = 161.552114
+  0: The maximum resident set size (KB)                   = 794252
 
 Test 087 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_stochy_debug
 Checking test 088 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.654897
-  0: The maximum resident set size (KB)                   = 802224
+  0: The total amount of wall time                        = 183.787736
+  0: The maximum resident set size (KB)                   = 802260
 
 Test 088 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_lndp_debug
 Checking test 089 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.384628
-  0: The maximum resident set size (KB)                   = 810620
+  0: The total amount of wall time                        = 163.995943
+  0: The maximum resident set size (KB)                   = 806948
 
 Test 089 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_csawmg_debug
 Checking test 090 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 249.379784
-  0: The maximum resident set size (KB)                   = 852324
+  0: The total amount of wall time                        = 247.533727
+  0: The maximum resident set size (KB)                   = 847924
 
 Test 090 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_csawmgt_debug
 Checking test 091 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 244.769289
-  0: The maximum resident set size (KB)                   = 851364
+  0: The total amount of wall time                        = 241.814464
+  0: The maximum resident set size (KB)                   = 843400
 
 Test 091 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_ras_debug
 Checking test 092 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.400605
-  0: The maximum resident set size (KB)                   = 810056
+  0: The total amount of wall time                        = 178.503719
+  0: The maximum resident set size (KB)                   = 803924
 
 Test 092 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_diag_debug
 Checking test 093 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.354897
-  0: The maximum resident set size (KB)                   = 823452
+  0: The total amount of wall time                        = 168.927716
+  0: The maximum resident set size (KB)                   = 855320
 
 Test 093 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_debug_p8
 Checking test 094 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.664903
-  0: The maximum resident set size (KB)                   = 1617576
+  0: The total amount of wall time                        = 184.656759
+  0: The maximum resident set size (KB)                   = 1608252
 
 Test 094 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_debug
 Checking test 095 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 261.828276
- 0: The maximum resident set size (KB)                   = 856604
+ 0: The total amount of wall time                        = 258.335799
+ 0: The maximum resident set size (KB)                   = 850996
 
 Test 095 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_control_debug
 Checking test 096 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.344873
-  0: The maximum resident set size (KB)                   = 1180124
+  0: The total amount of wall time                        = 285.879204
+  0: The maximum resident set size (KB)                   = 1176900
 
 Test 096 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_debug
 Checking test 097 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.459691
-  0: The maximum resident set size (KB)                   = 1170208
+  0: The total amount of wall time                        = 281.440985
+  0: The maximum resident set size (KB)                   = 1170060
 
 Test 097 hrrr_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_unified_drag_suite_debug
 Checking test 098 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.480008
-  0: The maximum resident set size (KB)                   = 1173040
+  0: The total amount of wall time                        = 292.809190
+  0: The maximum resident set size (KB)                   = 1172784
 
 Test 098 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_diag_debug
 Checking test 099 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 300.558022
-  0: The maximum resident set size (KB)                   = 1259664
+  0: The total amount of wall time                        = 307.264042
+  0: The maximum resident set size (KB)                   = 1255608
 
 Test 099 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_cires_ugwp_debug
 Checking test 100 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.474585
-  0: The maximum resident set size (KB)                   = 1173076
+  0: The total amount of wall time                        = 295.907827
+  0: The maximum resident set size (KB)                   = 1171320
 
 Test 100 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_unified_ugwp_debug
 Checking test 101 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.111956
-  0: The maximum resident set size (KB)                   = 1176172
+  0: The total amount of wall time                        = 300.935545
+  0: The maximum resident set size (KB)                   = 1175636
 
 Test 101 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_lndp_debug
 Checking test 102 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.101165
-  0: The maximum resident set size (KB)                   = 1179092
+  0: The total amount of wall time                        = 287.815746
+  0: The maximum resident set size (KB)                   = 1172624
 
 Test 102 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_flake_debug
 Checking test 103 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.464056
-  0: The maximum resident set size (KB)                   = 1175368
+  0: The total amount of wall time                        = 283.077941
+  0: The maximum resident set size (KB)                   = 1177848
 
 Test 103 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_progcld_thompson_debug
 Checking test 104 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.074630
-  0: The maximum resident set size (KB)                   = 1172780
+  0: The total amount of wall time                        = 288.750069
+  0: The maximum resident set size (KB)                   = 1174612
 
 Test 104 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_noah_debug
 Checking test 105 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.846907
-  0: The maximum resident set size (KB)                   = 1178276
+  0: The total amount of wall time                        = 281.381608
+  0: The maximum resident set size (KB)                   = 1168564
 
 Test 105 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_rrtmgp_debug
 Checking test 106 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 477.587872
-  0: The maximum resident set size (KB)                   = 1301712
+  0: The total amount of wall time                        = 477.426754
+  0: The maximum resident set size (KB)                   = 1301140
 
 Test 106 rap_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_sfcdiff_debug
 Checking test 107 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.171177
-  0: The maximum resident set size (KB)                   = 1132576
+  0: The total amount of wall time                        = 281.495519
+  0: The maximum resident set size (KB)                   = 1171016
 
 Test 107 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 108 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 468.034589
-  0: The maximum resident set size (KB)                   = 1119224
+  0: The total amount of wall time                        = 472.391103
+  0: The maximum resident set size (KB)                   = 1171916
 
 Test 108 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rrfs_v1beta_debug
 Checking test 109 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.765254
-  0: The maximum resident set size (KB)                   = 1174188
+  0: The total amount of wall time                        = 280.878674
+  0: The maximum resident set size (KB)                   = 1167860
 
 Test 109 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_wam_debug
 Checking test 110 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 296.151701
-  0: The maximum resident set size (KB)                   = 535396
+  0: The total amount of wall time                        = 293.374455
+  0: The maximum resident set size (KB)                   = 525228
 
 Test 110 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3658,14 +3658,14 @@ Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 266.519357
-  0: The maximum resident set size (KB)                   = 1078360
+  0: The total amount of wall time                        = 266.101936
+  0: The maximum resident set size (KB)                   = 1078700
 
 Test 111 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_control_dyn32_phy32
 Checking test 112 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3712,14 +3712,14 @@ Checking test 112 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 355.179181
-  0: The maximum resident set size (KB)                   = 965692
+  0: The total amount of wall time                        = 353.275026
+  0: The maximum resident set size (KB)                   = 991900
 
 Test 112 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_dyn32_phy32
 Checking test 113 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3766,14 +3766,14 @@ Checking test 113 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 183.036719
-  0: The maximum resident set size (KB)                   = 953672
+  0: The total amount of wall time                        = 185.829050
+  0: The maximum resident set size (KB)                   = 941764
 
 Test 113 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_2threads_dyn32_phy32
 Checking test 114 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3820,14 +3820,14 @@ Checking test 114 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 416.294773
- 0: The maximum resident set size (KB)                   = 926900
+ 0: The total amount of wall time                        = 433.994202
+ 0: The maximum resident set size (KB)                   = 923408
 
 Test 114 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_2threads_dyn32_phy32
 Checking test 115 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3874,14 +3874,14 @@ Checking test 115 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 257.156298
- 0: The maximum resident set size (KB)                   = 925540
+ 0: The total amount of wall time                        = 213.383682
+ 0: The maximum resident set size (KB)                   = 927296
 
 Test 115 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_decomp_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_decomp_dyn32_phy32
 Checking test 116 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3928,14 +3928,14 @@ Checking test 116 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.564296
-  0: The maximum resident set size (KB)                   = 897388
+  0: The total amount of wall time                        = 195.928538
+  0: The maximum resident set size (KB)                   = 902928
 
 Test 116 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_restart_dyn32_phy32
 Checking test 117 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3974,14 +3974,14 @@ Checking test 117 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 273.613660
-  0: The maximum resident set size (KB)                   = 957496
+  0: The total amount of wall time                        = 266.700727
+  0: The maximum resident set size (KB)                   = 949684
 
 Test 117 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_restart_dyn32_phy32
 Checking test 118 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4020,14 +4020,14 @@ Checking test 118 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 95.204266
-  0: The maximum resident set size (KB)                   = 796824
+  0: The total amount of wall time                        = 95.933769
+  0: The maximum resident set size (KB)                   = 861808
 
 Test 118 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_control_dyn64_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_control_dyn64_phy32
 Checking test 119 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4074,81 +4074,81 @@ Checking test 119 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 230.232379
-  0: The maximum resident set size (KB)                   = 964808
+  0: The total amount of wall time                        = 230.595662
+  0: The maximum resident set size (KB)                   = 962172
 
 Test 119 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_control_debug_dyn32_phy32
 Checking test 120 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.958116
-  0: The maximum resident set size (KB)                   = 1065380
+  0: The total amount of wall time                        = 282.042931
+  0: The maximum resident set size (KB)                   = 1058212
 
 Test 120 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hrrr_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hrrr_control_debug_dyn32_phy32
 Checking test 121 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.584180
-  0: The maximum resident set size (KB)                   = 1056920
+  0: The total amount of wall time                        = 272.834793
+  0: The maximum resident set size (KB)                   = 1061492
 
 Test 121 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/rap_control_dyn64_phy32_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/rap_control_dyn64_phy32_debug
 Checking test 122 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.837995
-  0: The maximum resident set size (KB)                   = 1100032
+  0: The total amount of wall time                        = 286.775826
+  0: The maximum resident set size (KB)                   = 1102812
 
 Test 122 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_atm
 Checking test 123 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 308.342120
-  0: The maximum resident set size (KB)                   = 979340
+  0: The total amount of wall time                        = 314.394741
+  0: The maximum resident set size (KB)                   = 975164
 
 Test 123 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_atm_thompson_gfdlsf
 Checking test 124 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 410.084551
-  0: The maximum resident set size (KB)                   = 1361832
+  0: The total amount of wall time                        = 406.622149
+  0: The maximum resident set size (KB)                   = 1352524
 
 Test 124 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_atm_ocn
 Checking test 125 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4157,14 +4157,14 @@ Checking test 125 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 388.146507
-  0: The maximum resident set size (KB)                   = 1200040
+  0: The total amount of wall time                        = 392.672059
+  0: The maximum resident set size (KB)                   = 1200992
 
 Test 125 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_atm_wav
 Checking test 126 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4173,14 +4173,14 @@ Checking test 126 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 717.674327
-  0: The maximum resident set size (KB)                   = 1192904
+  0: The total amount of wall time                        = 720.262435
+  0: The maximum resident set size (KB)                   = 1234576
 
 Test 126 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_atm_ocn_wav
 Checking test 127 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4191,28 +4191,28 @@ Checking test 127 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 826.967571
-  0: The maximum resident set size (KB)                   = 1241428
+  0: The total amount of wall time                        = 813.727922
+  0: The maximum resident set size (KB)                   = 1265052
 
 Test 127 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_1nest_atm
 Checking test 128 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 458.552340
-  0: The maximum resident set size (KB)                   = 533400
+  0: The total amount of wall time                        = 456.248573
+  0: The maximum resident set size (KB)                   = 520732
 
 Test 128 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_telescopic_2nests_atm
 Checking test 129 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4221,28 +4221,28 @@ Checking test 129 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 508.910266
-  0: The maximum resident set size (KB)                   = 530588
+  0: The total amount of wall time                        = 508.467081
+  0: The maximum resident set size (KB)                   = 538556
 
 Test 129 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_global_1nest_atm
 Checking test 130 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 211.072026
-  0: The maximum resident set size (KB)                   = 382540
+  0: The total amount of wall time                        = 211.194911
+  0: The maximum resident set size (KB)                   = 380392
 
 Test 130 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_global_multiple_4nests_atm
 Checking test 131 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4260,14 +4260,14 @@ Checking test 131 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 588.597699
-  0: The maximum resident set size (KB)                   = 390672
+  0: The total amount of wall time                        = 606.147001
+  0: The maximum resident set size (KB)                   = 393624
 
 Test 131 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_specified_moving_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_specified_moving_1nest_atm
 Checking test 132 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4276,28 +4276,28 @@ Checking test 132 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 275.198044
-  0: The maximum resident set size (KB)                   = 526576
+  0: The total amount of wall time                        = 273.351912
+  0: The maximum resident set size (KB)                   = 528944
 
 Test 132 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_storm_following_1nest_atm
 Checking test 133 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 262.540810
-  0: The maximum resident set size (KB)                   = 524684
+  0: The total amount of wall time                        = 264.167625
+  0: The maximum resident set size (KB)                   = 530268
 
 Test 133 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 134 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4306,14 +4306,14 @@ Checking test 134 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 275.783808
-  0: The maximum resident set size (KB)                   = 575396
+  0: The total amount of wall time                        = 272.885501
+  0: The maximum resident set size (KB)                   = 535552
 
 Test 134 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4324,28 +4324,28 @@ Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 623.865171
-  0: The maximum resident set size (KB)                   = 563236
+  0: The total amount of wall time                        = 611.051745
+  0: The maximum resident set size (KB)                   = 559888
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_global_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_global_storm_following_1nest_atm
 Checking test 136 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 80.128783
-  0: The maximum resident set size (KB)                   = 357464
+  0: The total amount of wall time                        = 81.168296
+  0: The maximum resident set size (KB)                   = 398944
 
 Test 136 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_docn
 Checking test 137 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4353,14 +4353,14 @@ Checking test 137 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 402.243794
-  0: The maximum resident set size (KB)                   = 1216512
+  0: The total amount of wall time                        = 395.594692
+  0: The maximum resident set size (KB)                   = 1214476
 
 Test 137 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_docn_oisst
 Checking test 138 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4368,131 +4368,131 @@ Checking test 138 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 396.013770
-  0: The maximum resident set size (KB)                   = 1205948
+  0: The total amount of wall time                        = 399.475628
+  0: The maximum resident set size (KB)                   = 1173480
 
 Test 138 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/hafs_regional_datm_cdeps
 Checking test 139 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 927.803763
-  0: The maximum resident set size (KB)                   = 1044704
+  0: The total amount of wall time                        = 930.594530
+  0: The maximum resident set size (KB)                   = 1044256
 
 Test 139 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_control_cfsr
 Checking test 140 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 162.244454
- 0: The maximum resident set size (KB)                   = 1080076
+ 0: The total amount of wall time                        = 148.596897
+ 0: The maximum resident set size (KB)                   = 1030240
 
 Test 140 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_restart_cfsr
 Checking test 141 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 89.653203
- 0: The maximum resident set size (KB)                   = 1044908
+ 0: The total amount of wall time                        = 90.732403
+ 0: The maximum resident set size (KB)                   = 1016048
 
 Test 141 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_control_gefs
 Checking test 142 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.949392
- 0: The maximum resident set size (KB)                   = 968876
+ 0: The total amount of wall time                        = 145.472017
+ 0: The maximum resident set size (KB)                   = 962756
 
 Test 142 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_iau_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_iau_gefs
 Checking test 143 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 158.969486
- 0: The maximum resident set size (KB)                   = 955696
+ 0: The total amount of wall time                        = 146.704372
+ 0: The maximum resident set size (KB)                   = 975572
 
 Test 143 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_stochy_gefs
 Checking test 144 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.245721
- 0: The maximum resident set size (KB)                   = 962272
+ 0: The total amount of wall time                        = 144.062418
+ 0: The maximum resident set size (KB)                   = 965480
 
 Test 144 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_ciceC_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_ciceC_cfsr
 Checking test 145 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.238155
- 0: The maximum resident set size (KB)                   = 1056360
+ 0: The total amount of wall time                        = 145.232016
+ 0: The maximum resident set size (KB)                   = 1073644
 
 Test 145 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_bulk_cfsr
 Checking test 146 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.872278
- 0: The maximum resident set size (KB)                   = 1062748
+ 0: The total amount of wall time                        = 154.939689
+ 0: The maximum resident set size (KB)                   = 1069616
 
 Test 146 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_bulk_gefs
 Checking test 147 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.118343
- 0: The maximum resident set size (KB)                   = 968468
+ 0: The total amount of wall time                        = 143.621170
+ 0: The maximum resident set size (KB)                   = 964320
 
 Test 147 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_mx025_cfsr
 Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4501,14 +4501,14 @@ Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 474.263003
-  0: The maximum resident set size (KB)                   = 880088
+  0: The total amount of wall time                        = 445.733293
+  0: The maximum resident set size (KB)                   = 881868
 
 Test 148 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_mx025_gefs
 Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4517,64 +4517,64 @@ Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 449.550118
-  0: The maximum resident set size (KB)                   = 924628
+  0: The total amount of wall time                        = 449.238256
+  0: The maximum resident set size (KB)                   = 927012
 
 Test 149 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_multiple_files_cfsr
 Checking test 150 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.362853
- 0: The maximum resident set size (KB)                   = 1062412
+ 0: The total amount of wall time                        = 147.207548
+ 0: The maximum resident set size (KB)                   = 1049908
 
 Test 150 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_3072x1536_cfsr
 Checking test 151 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 210.516628
- 0: The maximum resident set size (KB)                   = 2346024
+ 0: The total amount of wall time                        = 201.456325
+ 0: The maximum resident set size (KB)                   = 2270832
 
 Test 151 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_gfs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_gfs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_gfs
 Checking test 152 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 207.946530
- 0: The maximum resident set size (KB)                   = 2299808
+ 0: The total amount of wall time                        = 204.599768
+ 0: The maximum resident set size (KB)                   = 2267048
 
 Test 152 datm_cdeps_gfs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_debug_cfsr
 Checking test 153 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 453.854256
- 0: The maximum resident set size (KB)                   = 998120
+ 0: The total amount of wall time                        = 445.704083
+ 0: The maximum resident set size (KB)                   = 1001168
 
 Test 153 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_lnd_gswp3
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_lnd_gswp3
 Checking test 154 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4583,14 +4583,14 @@ Checking test 154 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 20.072757
-  0: The maximum resident set size (KB)                   = 257700
+  0: The total amount of wall time                        = 7.567069
+  0: The maximum resident set size (KB)                   = 262084
 
 Test 154 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/datm_cdeps_lnd_gswp3_rst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/datm_cdeps_lnd_gswp3_rst
 Checking test 155 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4599,14 +4599,14 @@ Checking test 155 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 36.133354
-  0: The maximum resident set size (KB)                   = 256552
+  0: The total amount of wall time                        = 12.065600
+  0: The maximum resident set size (KB)                   = 269624
 
 Test 155 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_p8_atmlnd_sbs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_p8_atmlnd_sbs
 Checking test 156 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4691,14 +4691,14 @@ Checking test 156 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.380855
-  0: The maximum resident set size (KB)                   = 1619312
+  0: The total amount of wall time                        = 204.648620
+  0: The maximum resident set size (KB)                   = 1595072
 
 Test 156 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/control_atmwav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/control_atmwav
 Checking test 157 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4742,14 +4742,14 @@ Checking test 157 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 102.398535
-  0: The maximum resident set size (KB)                   = 655876
+  0: The total amount of wall time                        = 86.827864
+  0: The maximum resident set size (KB)                   = 655284
 
 Test 157 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/atmaero_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/atmaero_control_p8
 Checking test 158 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4793,14 +4793,14 @@ Checking test 158 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.981947
-  0: The maximum resident set size (KB)                   = 2980544
+  0: The total amount of wall time                        = 224.951299
+  0: The maximum resident set size (KB)                   = 2974088
 
 Test 158 atmaero_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/atmaero_control_p8_rad
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/atmaero_control_p8_rad
 Checking test 159 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4844,14 +4844,14 @@ Checking test 159 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 318.039389
-  0: The maximum resident set size (KB)                   = 3045024
+  0: The total amount of wall time                        = 280.868404
+  0: The maximum resident set size (KB)                   = 3005624
 
 Test 159 atmaero_control_p8_rad PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/atmaero_control_p8_rad_micro
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/atmaero_control_p8_rad_micro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/atmaero_control_p8_rad_micro
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/atmaero_control_p8_rad_micro
 Checking test 160 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4895,14 +4895,14 @@ Checking test 160 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 333.699550
-  0: The maximum resident set size (KB)                   = 3051484
+  0: The total amount of wall time                        = 281.763326
+  0: The maximum resident set size (KB)                   = 3064796
 
 Test 160 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /work/noaa/epic-ps/jongkim/rt-1456/stmp/jongkim/FV3_RT/rt_149540/regional_atmaq
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_330199/regional_atmaq
 Checking test 161 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4918,12 +4918,12 @@ Checking test 161 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 658.556817
-  0: The maximum resident set size (KB)                   = 1088468
+  0: The total amount of wall time                        = 641.419284
+  0: The maximum resident set size (KB)                   = 1083916
 
 Test 161 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 21:29:02 CDT 2022
-Elapsed time: 01h:23m:45s. Have a nice day!
+Mon Nov  7 20:06:23 CST 2022
+Elapsed time: 02h:58m:53s. Have a nice day!

--- a/tests/RegressionTests_wcoss2.intel.log
+++ b/tests/RegressionTests_wcoss2.intel.log
@@ -1,25 +1,25 @@
-Wed Nov  2 16:35:40 UTC 2022
+Mon Nov  7 22:09:37 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 921 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 353 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 435 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 548 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 529 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 706 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 672 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 982 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 474 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 971 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 525 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 382 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 323 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 442 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 476 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 451 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 477 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 394 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 671 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 452 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 575 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 315 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1299 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 655 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 689 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 391 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 213 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 587 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 496 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 314 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/cpld_control_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/cpld_control_noaero_p8
 Checking test 001 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -83,14 +83,14 @@ Checking test 001 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 260.098259
-The maximum resident set size (KB)                   = 1573116
+The total amount of wall time                        = 271.316971
+The maximum resident set size (KB)                   = 1577924
 
 Test 001 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/cpld_control_nowave_noaero_p8
 Checking test 002 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -152,14 +152,14 @@ Checking test 002 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 295.342849
-The maximum resident set size (KB)                   = 1631644
+The total amount of wall time                        = 307.345309
+The maximum resident set size (KB)                   = 1626688
 
 Test 002 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/cpld_control_noaero_p8_agrid
 Checking test 003 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -221,14 +221,14 @@ Checking test 003 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 306.609580
-The maximum resident set size (KB)                   = 1632344
+The total amount of wall time                        = 319.007167
+The maximum resident set size (KB)                   = 1622392
 
 Test 003 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control
 Checking test 004 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -275,14 +275,14 @@ Checking test 004 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 132.311830
-The maximum resident set size (KB)                   = 516528
+The total amount of wall time                        = 138.186029
+The maximum resident set size (KB)                   = 512216
 
 Test 004 control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_decomp
 Checking test 005 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -325,14 +325,14 @@ Checking test 005 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 134.913088
-The maximum resident set size (KB)                   = 514840
+The total amount of wall time                        = 141.641382
+The maximum resident set size (KB)                   = 515644
 
 Test 005 control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_2dwrtdecomp
 Checking test 006 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -343,14 +343,14 @@ Checking test 006 control_2dwrtdecomp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 130.835033
-The maximum resident set size (KB)                   = 515900
+The total amount of wall time                        = 133.716075
+The maximum resident set size (KB)                   = 516500
 
 Test 006 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_2threads
 Checking test 007 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -393,14 +393,14 @@ Checking test 007 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 398.413297
-The maximum resident set size (KB)                   = 563240
+The total amount of wall time                        = 402.464259
+The maximum resident set size (KB)                   = 565412
 
 Test 007 control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_restart
 Checking test 008 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -439,14 +439,14 @@ Checking test 008 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 67.260319
-The maximum resident set size (KB)                   = 258860
+The total amount of wall time                        = 69.143805
+The maximum resident set size (KB)                   = 270744
 
 Test 008 control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_fhzero
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_fhzero
 Checking test 009 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -489,14 +489,14 @@ Checking test 009 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 125.285799
-The maximum resident set size (KB)                   = 512492
+The total amount of wall time                        = 132.023407
+The maximum resident set size (KB)                   = 517120
 
 Test 009 control_fhzero PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_CubedSphereGrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_CubedSphereGrid
 Checking test 010 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -523,14 +523,14 @@ Checking test 010 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 127.140208
-The maximum resident set size (KB)                   = 511616
+The total amount of wall time                        = 134.129910
+The maximum resident set size (KB)                   = 511184
 
 Test 010 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_latlon
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_latlon
 Checking test 011 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -541,14 +541,14 @@ Checking test 011 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 129.658534
-The maximum resident set size (KB)                   = 516852
+The total amount of wall time                        = 134.529816
+The maximum resident set size (KB)                   = 512556
 
 Test 011 control_latlon PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_wrtGauss_netcdf_parallel
 Checking test 012 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -559,14 +559,14 @@ Checking test 012 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.148270
-The maximum resident set size (KB)                   = 514508
+The total amount of wall time                        = 138.471383
+The maximum resident set size (KB)                   = 515188
 
 Test 012 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_c48
 Checking test 013 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -605,14 +605,14 @@ Checking test 013 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 326.313574
-The maximum resident set size (KB)                   = 666252
+The total amount of wall time                        = 327.364511
+The maximum resident set size (KB)                   = 666288
 
 Test 013 control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_c192
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_c192
 Checking test 014 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -623,32 +623,16 @@ Checking test 014 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 529.788543
-The maximum resident set size (KB)                   = 614488
+The total amount of wall time                        = 548.443287
+The maximum resident set size (KB)                   = 614164
 
 Test 014 control_c192 PASS
 
-
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_c384
-Checking test 015 control_c384 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-The total amount of wall time                        = 1639.701784
-The maximum resident set size (KB)                   = 879744
-
-Test 015 control_c384 PASS
+Test 015 control_c384 FAIL
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_c384gdas
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_c384gdas
 Checking test 016 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -691,14 +675,14 @@ Checking test 016 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1415.323658
-The maximum resident set size (KB)                   = 1015432
+The total amount of wall time                        = 1436.580639
+The maximum resident set size (KB)                   = 1013948
 
 Test 016 control_c384gdas PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_c384_progsigma
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_c384_progsigma
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384_progsigma
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_c384_progsigma
 Checking test 017 control_c384_progsigma results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -709,14 +693,14 @@ Checking test 017 control_c384_progsigma results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 1683.803006
-The maximum resident set size (KB)                   = 902136
+The total amount of wall time                        = 1687.029223
+The maximum resident set size (KB)                   = 902828
 
 Test 017 control_c384_progsigma PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_stochy
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_stochy
 Checking test 018 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -727,28 +711,28 @@ Checking test 018 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 88.728115
-The maximum resident set size (KB)                   = 517908
+The total amount of wall time                        = 96.543772
+The maximum resident set size (KB)                   = 519780
 
 Test 018 control_stochy PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_stochy_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_stochy_restart
 Checking test 019 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 45.868096
-The maximum resident set size (KB)                   = 290924
+The total amount of wall time                        = 49.059453
+The maximum resident set size (KB)                   = 335864
 
 Test 019 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_lndp
 Checking test 020 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -759,14 +743,14 @@ Checking test 020 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 80.500852
-The maximum resident set size (KB)                   = 519328
+The total amount of wall time                        = 89.116678
+The maximum resident set size (KB)                   = 518600
 
 Test 020 control_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_iovr4
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_iovr4
 Checking test 021 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -781,14 +765,14 @@ Checking test 021 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.625824
-The maximum resident set size (KB)                   = 518260
+The total amount of wall time                        = 137.345580
+The maximum resident set size (KB)                   = 512636
 
 Test 021 control_iovr4 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_iovr5
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_iovr5
 Checking test 022 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -803,14 +787,14 @@ Checking test 022 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.465278
-The maximum resident set size (KB)                   = 518300
+The total amount of wall time                        = 141.541970
+The maximum resident set size (KB)                   = 515472
 
 Test 022 control_iovr5 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_p8
 Checking test 023 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -857,14 +841,14 @@ Checking test 023 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.927718
-The maximum resident set size (KB)                   = 1492688
+The total amount of wall time                        = 194.328287
+The maximum resident set size (KB)                   = 1480856
 
 Test 023 control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_p8_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_p8_lndp
 Checking test 024 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -883,14 +867,14 @@ Checking test 024 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 320.111859
-The maximum resident set size (KB)                   = 1482336
+The total amount of wall time                        = 330.128003
+The maximum resident set size (KB)                   = 1483888
 
 Test 024 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_restart_p8
 Checking test 025 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -929,14 +913,14 @@ Checking test 025 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 98.035058
-The maximum resident set size (KB)                   = 652320
+The total amount of wall time                        = 104.791566
+The maximum resident set size (KB)                   = 648636
 
 Test 025 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_decomp_p8
 Checking test 026 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,14 +963,14 @@ Checking test 026 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.670283
-The maximum resident set size (KB)                   = 1485132
+The total amount of wall time                        = 186.578764
+The maximum resident set size (KB)                   = 1478208
 
 Test 026 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_2threads_p8
 Checking test 027 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1029,14 +1013,14 @@ Checking test 027 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 495.063716
-The maximum resident set size (KB)                   = 1570660
+The total amount of wall time                        = 492.497066
+The maximum resident set size (KB)                   = 1569080
 
 Test 027 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_p8_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_p8_rrtmgp
 Checking test 028 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1083,14 +1067,14 @@ Checking test 028 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 258.015513
-The maximum resident set size (KB)                   = 1606136
+The total amount of wall time                        = 262.489732
+The maximum resident set size (KB)                   = 1600984
 
 Test 028 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/merra2_thompson
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/merra2_thompson
 Checking test 029 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1137,14 +1121,14 @@ Checking test 029 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 182.749095
-The maximum resident set size (KB)                   = 1496884
+The total amount of wall time                        = 193.947255
+The maximum resident set size (KB)                   = 1493668
 
 Test 029 merra2_thompson PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_control
 Checking test 030 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1155,28 +1139,28 @@ Checking test 030 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 307.473608
-The maximum resident set size (KB)                   = 598364
+The total amount of wall time                        = 318.281526
+The maximum resident set size (KB)                   = 598564
 
 Test 030 regional_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_restart
 Checking test 031 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 168.480686
-The maximum resident set size (KB)                   = 591148
+The total amount of wall time                        = 174.088859
+The maximum resident set size (KB)                   = 592140
 
 Test 031 regional_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_control_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_control_2dwrtdecomp
 Checking test 032 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1187,14 +1171,14 @@ Checking test 032 regional_control_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 306.712417
-The maximum resident set size (KB)                   = 597324
+The total amount of wall time                        = 311.954895
+The maximum resident set size (KB)                   = 594932
 
 Test 032 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_noquilt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_noquilt
 Checking test 033 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1202,14 +1186,14 @@ Checking test 033 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 323.763038
-The maximum resident set size (KB)                   = 586648
+The total amount of wall time                        = 336.259869
+The maximum resident set size (KB)                   = 588440
 
 Test 033 regional_noquilt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_2threads
 Checking test 034 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1220,28 +1204,28 @@ Checking test 034 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 615.892056
-The maximum resident set size (KB)                   = 649284
+The total amount of wall time                        = 626.072996
+The maximum resident set size (KB)                   = 648416
 
 Test 034 regional_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_netcdf_parallel
 Checking test 035 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 304.598996
-The maximum resident set size (KB)                   = 597348
+The total amount of wall time                        = 317.865649
+The maximum resident set size (KB)                   = 594456
 
 Test 035 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_3km
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_3km
 Checking test 036 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1252,14 +1236,14 @@ Checking test 036 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 253.013989
-The maximum resident set size (KB)                   = 646024
+The total amount of wall time                        = 267.276652
+The maximum resident set size (KB)                   = 646920
 
 Test 036 regional_3km PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_3km_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_3km_decomp
 Checking test 037 regional_3km_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1270,14 +1254,14 @@ Checking test 037 regional_3km_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 266.638117
-The maximum resident set size (KB)                   = 656012
+The total amount of wall time                        = 286.920691
+The maximum resident set size (KB)                   = 660108
 
 Test 037 regional_3km_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_3km_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_3km_wofs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_3km_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_3km_wofs
 Checking test 038 regional_3km_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1288,14 +1272,14 @@ Checking test 038 regional_3km_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 334.362236
-The maximum resident set size (KB)                   = 334704
+The total amount of wall time                        = 347.561478
+The maximum resident set size (KB)                   = 335076
 
 Test 038 regional_3km_wofs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_control
 Checking test 039 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1342,14 +1326,14 @@ Checking test 039 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 399.215109
-The maximum resident set size (KB)                   = 892528
+The total amount of wall time                        = 407.908851
+The maximum resident set size (KB)                   = 897308
 
 Test 039 rap_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_rrtmgp
 Checking test 040 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1396,14 +1380,14 @@ Checking test 040 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 478.071915
-The maximum resident set size (KB)                   = 1005888
+The total amount of wall time                        = 491.625410
+The maximum resident set size (KB)                   = 1009468
 
 Test 040 rap_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_spp_sppt_shum_skeb
 Checking test 041 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1414,14 +1398,14 @@ Checking test 041 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 714.690251
-The maximum resident set size (KB)                   = 974760
+The total amount of wall time                        = 722.423440
+The maximum resident set size (KB)                   = 976076
 
 Test 041 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_decomp
 Checking test 042 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1468,14 +1452,14 @@ Checking test 042 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 415.568593
-The maximum resident set size (KB)                   = 893360
+The total amount of wall time                        = 444.661464
+The maximum resident set size (KB)                   = 892500
 
 Test 042 rap_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1522,14 +1506,14 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1247.833473
-The maximum resident set size (KB)                   = 949628
+The total amount of wall time                        = 1255.661784
+The maximum resident set size (KB)                   = 954264
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_restart
 Checking test 044 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1568,14 +1552,14 @@ Checking test 044 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.646623
-The maximum resident set size (KB)                   = 640616
+The total amount of wall time                        = 211.836292
+The maximum resident set size (KB)                   = 637900
 
 Test 044 rap_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_sfcdiff
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_sfcdiff
 Checking test 045 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1622,14 +1606,14 @@ Checking test 045 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 396.328418
-The maximum resident set size (KB)                   = 894056
+The total amount of wall time                        = 407.221305
+The maximum resident set size (KB)                   = 893052
 
 Test 045 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_sfcdiff_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_sfcdiff_decomp
 Checking test 046 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1676,14 +1660,14 @@ Checking test 046 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 413.504661
-The maximum resident set size (KB)                   = 893392
+The total amount of wall time                        = 432.088775
+The maximum resident set size (KB)                   = 893436
 
 Test 046 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_sfcdiff_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_sfcdiff_restart
 Checking test 047 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1722,14 +1706,14 @@ Checking test 047 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 293.816600
-The maximum resident set size (KB)                   = 638044
+The total amount of wall time                        = 308.718476
+The maximum resident set size (KB)                   = 637276
 
 Test 047 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control
 Checking test 048 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1776,14 +1760,14 @@ Checking test 048 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 383.962826
-The maximum resident set size (KB)                   = 889004
+The total amount of wall time                        = 403.977863
+The maximum resident set size (KB)                   = 885512
 
 Test 048 hrrr_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_decomp
 Checking test 049 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1830,14 +1814,14 @@ Checking test 049 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 397.507304
-The maximum resident set size (KB)                   = 890828
+The total amount of wall time                        = 417.751292
+The maximum resident set size (KB)                   = 890152
 
 Test 049 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_2threads
 Checking test 050 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1884,14 +1868,14 @@ Checking test 050 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1233.068599
-The maximum resident set size (KB)                   = 948600
+The total amount of wall time                        = 1227.396136
+The maximum resident set size (KB)                   = 947064
 
 Test 050 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_restart
 Checking test 051 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1930,14 +1914,14 @@ Checking test 051 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 282.741650
-The maximum resident set size (KB)                   = 631328
+The total amount of wall time                        = 316.499510
+The maximum resident set size (KB)                   = 631756
 
 Test 051 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_v1beta
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1984,14 +1968,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 396.966308
-The maximum resident set size (KB)                   = 888896
+The total amount of wall time                        = 425.557622
+The maximum resident set size (KB)                   = 887072
 
 Test 052 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_v1nssl
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2006,14 +1990,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 457.702688
-The maximum resident set size (KB)                   = 575752
+The total amount of wall time                        = 478.895911
+The maximum resident set size (KB)                   = 577724
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2028,14 +2012,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 448.230846
-The maximum resident set size (KB)                   = 568876
+The total amount of wall time                        = 462.549311
+The maximum resident set size (KB)                   = 567908
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2044,14 +2028,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 114.986062
-The maximum resident set size (KB)                   = 767520
+The total amount of wall time                        = 120.675436
+The maximum resident set size (KB)                   = 766112
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_smoke_conus13km_hrrr_warm
 Checking test 056 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2060,14 +2044,14 @@ Checking test 056 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 126.695651
-The maximum resident set size (KB)                   = 786208
+The total amount of wall time                        = 136.965074
+The maximum resident set size (KB)                   = 779688
 
 Test 056 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_conus13km_radar_tten_warm
 Checking test 057 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2076,14 +2060,14 @@ Checking test 057 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 117.012507
-The maximum resident set size (KB)                   = 766784
+The total amount of wall time                        = 124.485808
+The maximum resident set size (KB)                   = 770832
 
 Test 057 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_conus13km_hrrr_warm_2threads
 Checking test 058 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2092,14 +2076,14 @@ Checking test 058 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 214.324757
-The maximum resident set size (KB)                   = 758276
+The total amount of wall time                        = 225.530015
+The maximum resident set size (KB)                   = 751192
 
 Test 058 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 059 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2108,14 +2092,14 @@ Checking test 059 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 216.057801
-The maximum resident set size (KB)                   = 766676
+The total amount of wall time                        = 235.855774
+The maximum resident set size (KB)                   = 759216
 
 Test 059 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_csawmg
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_csawmg
 Checking test 060 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2126,14 +2110,14 @@ Checking test 060 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 345.070294
-The maximum resident set size (KB)                   = 586920
+The total amount of wall time                        = 353.295425
+The maximum resident set size (KB)                   = 587172
 
 Test 060 control_csawmg PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_csawmgt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_csawmgt
 Checking test 061 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2144,14 +2128,14 @@ Checking test 061 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 342.504206
-The maximum resident set size (KB)                   = 588832
+The total amount of wall time                        = 354.843668
+The maximum resident set size (KB)                   = 588132
 
 Test 061 control_csawmgt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_ras
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_ras
 Checking test 062 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2162,82 +2146,82 @@ Checking test 062 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 179.151591
-The maximum resident set size (KB)                   = 553384
+The total amount of wall time                        = 194.704475
+The maximum resident set size (KB)                   = 556312
 
 Test 062 control_ras PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_wam
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_wam
 Checking test 063 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 113.202999
-The maximum resident set size (KB)                   = 264932
+The total amount of wall time                        = 117.227568
+The maximum resident set size (KB)                   = 266536
 
 Test 063 control_wam PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_conus13km_hrrr_warm_debug
 Checking test 064 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 769.923539
-The maximum resident set size (KB)                   = 795272
+The total amount of wall time                        = 780.093786
+The maximum resident set size (KB)                   = 790904
 
 Test 064 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_conus13km_radar_tten_warm_debug
 Checking test 065 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 770.336906
-The maximum resident set size (KB)                   = 794124
+The total amount of wall time                        = 786.354304
+The maximum resident set size (KB)                   = 791780
 
 Test 065 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_debug
 Checking test 066 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 153.158679
-The maximum resident set size (KB)                   = 676520
+The total amount of wall time                        = 160.985525
+The maximum resident set size (KB)                   = 678272
 
 Test 066 control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_2threads_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_2threads_debug
 Checking test 067 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 448.763406
-The maximum resident set size (KB)                   = 731136
+The total amount of wall time                        = 456.106987
+The maximum resident set size (KB)                   = 728072
 
 Test 067 control_2threads_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_CubedSphereGrid_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_CubedSphereGrid_debug
 Checking test 068 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2264,348 +2248,348 @@ Checking test 068 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 156.744791
-The maximum resident set size (KB)                   = 678552
+The total amount of wall time                        = 158.059128
+The maximum resident set size (KB)                   = 674408
 
 Test 068 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_wrtGauss_netcdf_parallel_debug
 Checking test 069 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 155.853026
-The maximum resident set size (KB)                   = 677720
+The total amount of wall time                        = 160.452151
+The maximum resident set size (KB)                   = 677020
 
 Test 069 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_stochy_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_stochy_debug
 Checking test 070 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.654855
-The maximum resident set size (KB)                   = 681392
+The total amount of wall time                        = 185.974300
+The maximum resident set size (KB)                   = 681068
 
 Test 070 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_lndp_debug
 Checking test 071 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 157.765634
-The maximum resident set size (KB)                   = 682620
+The total amount of wall time                        = 161.434000
+The maximum resident set size (KB)                   = 684172
 
 Test 071 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_csawmg_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 251.739603
-The maximum resident set size (KB)                   = 721168
+The total amount of wall time                        = 258.833911
+The maximum resident set size (KB)                   = 722012
 
 Test 072 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_csawmgt_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 249.023663
-The maximum resident set size (KB)                   = 718184
+The total amount of wall time                        = 253.783291
+The maximum resident set size (KB)                   = 720344
 
 Test 073 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_ras_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.491994
-The maximum resident set size (KB)                   = 694872
+The total amount of wall time                        = 173.178800
+The maximum resident set size (KB)                   = 694568
 
 Test 074 control_ras_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.111707
-The maximum resident set size (KB)                   = 734680
+The total amount of wall time                        = 169.331192
+The maximum resident set size (KB)                   = 735412
 
 Test 075 control_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_debug_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 187.564937
-The maximum resident set size (KB)                   = 1511164
+The total amount of wall time                        = 196.715423
+The maximum resident set size (KB)                   = 1510964
 
 Test 076 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/fv3_regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/fv3_regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_debug
 Checking test 077 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 255.709265
-The maximum resident set size (KB)                   = 626340
+The total amount of wall time                        = 260.958827
+The maximum resident set size (KB)                   = 629860
 
 Test 077 regional_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_control_debug
 Checking test 078 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.874574
-The maximum resident set size (KB)                   = 1053692
+The total amount of wall time                        = 306.290307
+The maximum resident set size (KB)                   = 1050668
 
 Test 078 rap_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_debug
 Checking test 079 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 287.308852
-The maximum resident set size (KB)                   = 1050520
+The total amount of wall time                        = 304.528697
+The maximum resident set size (KB)                   = 1050828
 
 Test 079 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_unified_drag_suite_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_unified_drag_suite_debug
 Checking test 080 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.953212
-The maximum resident set size (KB)                   = 1053256
+The total amount of wall time                        = 305.181676
+The maximum resident set size (KB)                   = 1057264
 
 Test 080 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_diag_debug
 Checking test 081 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.984966
-The maximum resident set size (KB)                   = 1135972
+The total amount of wall time                        = 315.607551
+The maximum resident set size (KB)                   = 1140228
 
 Test 081 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_cires_ugwp_debug
 Checking test 082 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.778651
-The maximum resident set size (KB)                   = 1053868
+The total amount of wall time                        = 312.080673
+The maximum resident set size (KB)                   = 1053220
 
 Test 082 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_unified_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_unified_ugwp_debug
 Checking test 083 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.680101
-The maximum resident set size (KB)                   = 1051336
+The total amount of wall time                        = 319.037132
+The maximum resident set size (KB)                   = 1056792
 
 Test 083 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_lndp_debug
 Checking test 084 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.522872
-The maximum resident set size (KB)                   = 1055516
+The total amount of wall time                        = 304.246096
+The maximum resident set size (KB)                   = 1056376
 
 Test 084 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_flake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_flake_debug
 Checking test 085 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.173349
-The maximum resident set size (KB)                   = 1050876
+The total amount of wall time                        = 304.170992
+The maximum resident set size (KB)                   = 1053120
 
 Test 085 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_progcld_thompson_debug
 Checking test 086 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.385400
-The maximum resident set size (KB)                   = 1055888
+The total amount of wall time                        = 306.822311
+The maximum resident set size (KB)                   = 1056732
 
 Test 086 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_noah_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.986340
-The maximum resident set size (KB)                   = 1053676
+The total amount of wall time                        = 319.651209
+The maximum resident set size (KB)                   = 1053564
 
 Test 087 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_rrtmgp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_rrtmgp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_rrtmgp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 501.103153
-The maximum resident set size (KB)                   = 1169112
+The total amount of wall time                        = 533.603643
+The maximum resident set size (KB)                   = 1171116
 
 Test 088 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_sfcdiff_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_sfcdiff_debug
 Checking test 089 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.869056
-The maximum resident set size (KB)                   = 1051260
+The total amount of wall time                        = 306.094898
+The maximum resident set size (KB)                   = 1054144
 
 Test 089 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 090 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 481.677521
-The maximum resident set size (KB)                   = 1052880
+The total amount of wall time                        = 493.063559
+The maximum resident set size (KB)                   = 1051788
 
 Test 090 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rrfs_v1beta_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rrfs_v1beta_debug
 Checking test 091 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 286.828782
-The maximum resident set size (KB)                   = 1046348
+The total amount of wall time                        = 290.267441
+The maximum resident set size (KB)                   = 1049984
 
 Test 091 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_wam_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_wam_debug
 Checking test 092 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 297.537509
-The maximum resident set size (KB)                   = 295588
+The total amount of wall time                        = 299.367308
+The maximum resident set size (KB)                   = 295396
 
 Test 092 control_wam_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 093 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2616,14 +2600,14 @@ Checking test 093 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 657.962955
-The maximum resident set size (KB)                   = 875748
+The total amount of wall time                        = 697.598965
+The maximum resident set size (KB)                   = 875768
 
 Test 093 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_control_dyn32_phy32
 Checking test 094 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2670,14 +2654,14 @@ Checking test 094 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 325.438600
-The maximum resident set size (KB)                   = 770832
+The total amount of wall time                        = 343.985540
+The maximum resident set size (KB)                   = 774004
 
 Test 094 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_dyn32_phy32
 Checking test 095 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2724,14 +2708,14 @@ Checking test 095 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 171.646327
-The maximum resident set size (KB)                   = 772448
+The total amount of wall time                        = 189.058622
+The maximum resident set size (KB)                   = 774460
 
 Test 095 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_2threads_dyn32_phy32
 Checking test 096 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2778,14 +2762,14 @@ Checking test 096 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 1027.861104
-The maximum resident set size (KB)                   = 815272
+The total amount of wall time                        = 1095.832169
+The maximum resident set size (KB)                   = 821360
 
 Test 096 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_2threads_dyn32_phy32
 Checking test 097 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2832,14 +2816,14 @@ Checking test 097 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 522.542289
-The maximum resident set size (KB)                   = 817124
+The total amount of wall time                        = 561.923678
+The maximum resident set size (KB)                   = 817608
 
 Test 097 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_decomp_dyn32_phy32
 Checking test 098 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2886,14 +2870,14 @@ Checking test 098 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.742103
-The maximum resident set size (KB)                   = 771548
+The total amount of wall time                        = 188.680735
+The maximum resident set size (KB)                   = 772904
 
 Test 098 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_restart_dyn32_phy32
 Checking test 099 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2932,14 +2916,14 @@ Checking test 099 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 239.275727
-The maximum resident set size (KB)                   = 603544
+The total amount of wall time                        = 244.834315
+The maximum resident set size (KB)                   = 605608
 
 Test 099 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_restart_dyn32_phy32
 Checking test 100 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2978,14 +2962,14 @@ Checking test 100 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 87.977407
-The maximum resident set size (KB)                   = 600372
+The total amount of wall time                        = 93.012114
+The maximum resident set size (KB)                   = 603928
 
 Test 100 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_control_dyn64_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_control_dyn64_phy32
 Checking test 101 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3032,81 +3016,81 @@ Checking test 101 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 222.562890
-The maximum resident set size (KB)                   = 794700
+The total amount of wall time                        = 224.827110
+The maximum resident set size (KB)                   = 796928
 
 Test 101 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_control_debug_dyn32_phy32
 Checking test 102 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 285.238761
-The maximum resident set size (KB)                   = 939548
+The total amount of wall time                        = 287.276458
+The maximum resident set size (KB)                   = 938064
 
 Test 102 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hrrr_control_debug_dyn32_phy32
 Checking test 103 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 281.930188
-The maximum resident set size (KB)                   = 938272
+The total amount of wall time                        = 282.057810
+The maximum resident set size (KB)                   = 935372
 
 Test 103 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/rap_control_dyn64_phy32_debug
 Checking test 104 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.799130
-The maximum resident set size (KB)                   = 954456
+The total amount of wall time                        = 292.785058
+The maximum resident set size (KB)                   = 955804
 
 Test 104 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_atm
 Checking test 105 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 708.293562
-The maximum resident set size (KB)                   = 779832
+The total amount of wall time                        = 716.373477
+The maximum resident set size (KB)                   = 777436
 
 Test 105 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_atm_thompson_gfdlsf
 Checking test 106 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 808.822250
-The maximum resident set size (KB)                   = 1158664
+The total amount of wall time                        = 819.402799
+The maximum resident set size (KB)                   = 1147196
 
 Test 106 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_atm_ocn
 Checking test 107 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3115,14 +3099,14 @@ Checking test 107 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 432.119592
-The maximum resident set size (KB)                   = 837032
+The total amount of wall time                        = 447.884527
+The maximum resident set size (KB)                   = 836796
 
 Test 107 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_atm_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_atm_wav
 Checking test 108 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3131,14 +3115,14 @@ Checking test 108 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 698.206503
-The maximum resident set size (KB)                   = 868640
+The total amount of wall time                        = 716.454439
+The maximum resident set size (KB)                   = 863836
 
 Test 108 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_atm_ocn_wav
 Checking test 109 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3149,28 +3133,28 @@ Checking test 109 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 896.311188
-The maximum resident set size (KB)                   = 891848
+The total amount of wall time                        = 907.595427
+The maximum resident set size (KB)                   = 891176
 
 Test 109 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_1nest_atm
 Checking test 110 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 1111.146636
-The maximum resident set size (KB)                   = 375596
+The total amount of wall time                        = 1112.290968
+The maximum resident set size (KB)                   = 377636
 
 Test 110 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_telescopic_2nests_atm
 Checking test 111 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3179,28 +3163,28 @@ Checking test 111 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 1258.199335
-The maximum resident set size (KB)                   = 389400
+The total amount of wall time                        = 1265.686836
+The maximum resident set size (KB)                   = 385500
 
 Test 111 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_global_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_global_1nest_atm
 Checking test 112 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 542.372530
-The maximum resident set size (KB)                   = 275360
+The total amount of wall time                        = 537.553254
+The maximum resident set size (KB)                   = 271116
 
 Test 112 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_global_multiple_4nests_atm
 Checking test 113 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3218,14 +3202,14 @@ Checking test 113 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 1414.181230
-The maximum resident set size (KB)                   = 331800
+The total amount of wall time                        = 1438.805161
+The maximum resident set size (KB)                   = 325300
 
 Test 113 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_specified_moving_1nest_atm
 Checking test 114 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3234,28 +3218,28 @@ Checking test 114 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 661.863601
-The maximum resident set size (KB)                   = 382044
+The total amount of wall time                        = 680.153874
+The maximum resident set size (KB)                   = 382124
 
 Test 114 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_storm_following_1nest_atm
 Checking test 115 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 633.161240
-The maximum resident set size (KB)                   = 381968
+The total amount of wall time                        = 635.272172
+The maximum resident set size (KB)                   = 381244
 
 Test 115 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 116 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3264,14 +3248,14 @@ Checking test 116 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 658.827207
-The maximum resident set size (KB)                   = 409716
+The total amount of wall time                        = 665.004773
+The maximum resident set size (KB)                   = 412504
 
 Test 116 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 117 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3282,28 +3266,28 @@ Checking test 117 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 1325.225761
-The maximum resident set size (KB)                   = 479316
+The total amount of wall time                        = 1332.315532
+The maximum resident set size (KB)                   = 476960
 
 Test 117 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/hafs_global_storm_following_1nest_atm
 Checking test 118 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 216.746620
-The maximum resident set size (KB)                   = 340732
+The total amount of wall time                        = 212.944507
+The maximum resident set size (KB)                   = 271728
 
 Test 118 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/control_p8_atmlnd_sbs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/control_p8_atmlnd_sbs
 Checking test 119 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3388,14 +3372,14 @@ Checking test 119 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 236.048783
-The maximum resident set size (KB)                   = 1548072
+The total amount of wall time                        = 244.168220
+The maximum resident set size (KB)                   = 1539256
 
 Test 119 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221101/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_54823/regional_atmaq
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_157747/regional_atmaq
 Checking test 120 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3411,12 +3395,40 @@ Checking test 120 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 705.768289
-The maximum resident set size (KB)                   = 1036332
+The total amount of wall time                        = 724.866285
+The maximum resident set size (KB)                   = 1041584
 
 Test 120 regional_atmaq PASS
 
+FAILED TESTS: 
+Test control_c384 015 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Mon Nov  7 23:17:39 UTC 2022
+Elapsed time: 01h:08m:03s. Have a nice day!
+Mon Nov  7 23:19:28 UTC 2022
+Start Regression test
+
+Compile 001 elapsed time 341 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20221107/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_65155/control_c384
+Checking test 001 control_c384 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+The total amount of wall time                        = 1661.538420
+The maximum resident set size (KB)                   = 883368
+
+Test 001 control_c384 PASS
+
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov  2 17:33:38 UTC 2022
-Elapsed time: 00h:57m:59s. Have a nice day!
+Mon Nov  7 23:59:28 UTC 2022
+Elapsed time: 00h:40m:01s. Have a nice day!

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -13,7 +13,7 @@ RUN     | cpld_mpi_p8                                                           
 RUN     | cpld_control_ciceC_p8                                                                                                   | - wcoss2.intel                          | fv3 |
 
 RUN     | cpld_control_c192_p8                                                                                                    | - wcoss2.intel jet.intel acorn.intel    | fv3 |
-RUN     | cpld_restart_c192_p8                                                                                                    | - wcoss2.intel jet.intel                |     | cpld_control_c192_p8
+RUN     | cpld_restart_c192_p8                                                                                                    | - wcoss2.intel jet.intel acorn.intel    |     | cpld_control_c192_p8
 
 RUN     | cpld_bmark_p8                                                                                                           | - wcoss2.intel jet.intel cheyenne.intel acorn.intel | fv3 |
 RUN     | cpld_restart_bmark_p8                                                                                                   | - wcoss2.intel jet.intel cheyenne.intel acorn.intel |     | cpld_bmark_p8

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -443,7 +443,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20221101
+BL_DATE=20221107
 
 RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR
are specified below.

- [x] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Description
This PR is associated with ccpp-physics PR#19 to improve radiative fluxes and cloud cover calculation in GFSv17 by modifying the Thompson microphysics scheme and its connection to the radiation scheme. This implementation is for HR1.

### Issue(s) addressed
- fixes  ufs-community/ccpp-physics issue#<[21](https://github.com/ufs-community/ccpp-physics/issues/21)>

## Testing
The regression tests are conducted on hera.intel and all the tests used the Thompson microphysics scheme failed due to baseline changes. The control_p8, which uses the Thompson scheme, was selected for the ORT test, and the ORT test was successful.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel
- [x] cheyenne.gnu
- [x] gaea.intel
- [x] jet.intel
- [x] wcoss2.intel
- [ ] acorn.intel
- [ ] opnReqTest for newly added/changed feature
- [x] CI

## Dependencies
- waiting on ufs-community/ccpp-physics/pull/<[19](https://github.com/ufs-community/ccpp-physics/pull/19)>
- waiting on noaa-emc/fv3atm/pull/<[599](https://github.com/NOAA-EMC/fv3atm/pull/599)>
