### PR TITLE
Remove loading anaconda module on hera

### DIFF
--- a/modulefiles/hera.intel/fv3.lua
+++ b/modulefiles/hera.intel/fv3.lua
@@ -5,11 +5,6 @@ Load environment to compile ufs-weather-model on Hera using Intel
 cmake_ver=os.getenv("cmake_ver") or "3.20.1"
 load(pathJoin("cmake", cmake_ver))
 
-prepend_path("MODULEPATH", "/contrib/anaconda/modulefiles")
-
-anaconda_ver=os.getenv("anaconda_ver") or "anaconda3-5.3.1"
-load(pathJoin("anaconda", anaconda_ver))
-
 prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 hpc_ver=os.getenv("hpc_ver") or "1.2.0"


### PR DESCRIPTION
This PR removes loading anaconda module on hera. It is not needed during build or model execution. This avoids conflict with different version of anaconda module loaded by GSI in global-workflow.