### PR TITLE
Bug fix for cloud effective radius for convective clouds (HR1)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+#  url = https://github.com/NOAA-EMC/fv3atm
+#  branch = develop
+  url = https://github.com/ChunxiZhang-NOAA/fv3atm
+  branch = bugfix/cloud_rad
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-#  url = https://github.com/NOAA-EMC/fv3atm
-#  branch = develop
-  url = https://github.com/ChunxiZhang-NOAA/fv3atm
-  branch = bugfix/cloud_rad
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_acorn.intel.log
+++ b/tests/RegressionTests_acorn.intel.log
@@ -1,34 +1,34 @@
-Fri Jan 20 23:49:32 UTC 2023
+Sat Jan 28 17:54:25 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 1496 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 968 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1118 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 483 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 1533 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 1799 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 1571 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 875 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 1455 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 950 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 1770 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 997 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1251 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 1137 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 750 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 486 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 1073 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 836 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 1097 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 020 elapsed time 292 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 1480 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 487 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 928 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 918 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 502 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 557 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 566 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1630 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 485 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 1079 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 1095 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 585 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1145 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 641 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 595 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 972 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 1518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 763 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 387 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 1218 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 699 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 471 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 227 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 020 elapsed time 145 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 613 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 581 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 819 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 633 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 153 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_p8_mixedmode
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 331.062983
-The maximum resident set size (KB)                   = 2949140
+The total amount of wall time                        = 331.550842
+The maximum resident set size (KB)                   = 2949216
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_gfsv17
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_gfsv17
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_gfsv17
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -164,14 +164,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 254.235103
-The maximum resident set size (KB)                   = 1578488
+The total amount of wall time                        = 257.021678
+The maximum resident set size (KB)                   = 1576492
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -236,14 +236,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 383.731351
-The maximum resident set size (KB)                   = 2978352
+The total amount of wall time                        = 384.488380
+The maximum resident set size (KB)                   = 2990636
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -296,14 +296,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 223.973340
-The maximum resident set size (KB)                   = 2864428
+The total amount of wall time                        = 229.043586
+The maximum resident set size (KB)                   = 2863872
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_2threads_p8
 Checking test 005 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -356,14 +356,14 @@ Checking test 005 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 373.936235
-The maximum resident set size (KB)                   = 3280636
+The total amount of wall time                        = 368.905849
+The maximum resident set size (KB)                   = 3282240
 
 Test 005 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_esmfthreads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_esmfthreads_p8
 Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -416,14 +416,14 @@ Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 371.513971
-The maximum resident set size (KB)                   = 3280800
+The total amount of wall time                        = 368.401308
+The maximum resident set size (KB)                   = 3278620
 
 Test 006 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -476,14 +476,14 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 377.013712
-The maximum resident set size (KB)                   = 2973964
+The total amount of wall time                        = 377.335213
+The maximum resident set size (KB)                   = 2981092
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_mpi_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -536,14 +536,14 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 310.685361
-The maximum resident set size (KB)                   = 2910624
+The total amount of wall time                        = 316.574470
+The maximum resident set size (KB)                   = 2903684
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_ciceC_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -608,14 +608,14 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 381.260620
-The maximum resident set size (KB)                   = 2976040
+The total amount of wall time                        = 383.631791
+The maximum resident set size (KB)                   = 2977192
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_noaero_p8
 Checking test 010 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -679,14 +679,14 @@ Checking test 010 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 279.221235
-The maximum resident set size (KB)                   = 1573756
+The total amount of wall time                        = 280.453764
+The maximum resident set size (KB)                   = 1568560
 
 Test 010 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_nowave_noaero_p8
 Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -748,14 +748,14 @@ Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 292.868761
-The maximum resident set size (KB)                   = 1620728
+The total amount of wall time                        = 295.634376
+The maximum resident set size (KB)                   = 1626672
 
 Test 011 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_noaero_p8_agrid
 Checking test 012 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -817,14 +817,14 @@ Checking test 012 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 303.966542
-The maximum resident set size (KB)                   = 1624316
+The total amount of wall time                        = 301.070354
+The maximum resident set size (KB)                   = 1616708
 
 Test 012 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_control_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_control_c48
 Checking test 013 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -874,14 +874,14 @@ Checking test 013 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 432.351583
-The maximum resident set size (KB)                   = 2626708
+The total amount of wall time                        = 432.677183
+The maximum resident set size (KB)                   = 2629884
 
 Test 013 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_warmstart_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_warmstart_c48
 Checking test 014 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -931,14 +931,14 @@ Checking test 014 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 121.649355
-The maximum resident set size (KB)                   = 2644204
+The total amount of wall time                        = 120.423648
+The maximum resident set size (KB)                   = 2643044
 
 Test 014 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/cpld_restart_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/cpld_restart_c48
 Checking test 015 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -988,14 +988,14 @@ Checking test 015 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 66.133301
-The maximum resident set size (KB)                   = 2057652
+The total amount of wall time                        = 66.565714
+The maximum resident set size (KB)                   = 2060140
 
 Test 015 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_CubedSphereGrid
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_CubedSphereGrid
 Checking test 016 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1022,14 +1022,14 @@ Checking test 016 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 126.305361
-The maximum resident set size (KB)                   = 513780
+The total amount of wall time                        = 126.958261
+The maximum resident set size (KB)                   = 522184
 
 Test 016 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_latlon
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_latlon
 Checking test 017 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1040,14 +1040,14 @@ Checking test 017 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 129.285198
-The maximum resident set size (KB)                   = 516108
+The total amount of wall time                        = 129.177553
+The maximum resident set size (KB)                   = 515232
 
 Test 017 control_latlon PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_wrtGauss_netcdf_parallel
 Checking test 018 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1058,14 +1058,14 @@ Checking test 018 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 130.989217
-The maximum resident set size (KB)                   = 520612
+The total amount of wall time                        = 131.235093
+The maximum resident set size (KB)                   = 515516
 
 Test 018 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_c48
 Checking test 019 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1104,14 +1104,14 @@ Checking test 019 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 326.060638
-The maximum resident set size (KB)                   = 667788
+The total amount of wall time                        = 327.444607
+The maximum resident set size (KB)                   = 672288
 
 Test 019 control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_c192
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_c192
 Checking test 020 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1122,14 +1122,14 @@ Checking test 020 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 526.831685
-The maximum resident set size (KB)                   = 615748
+The total amount of wall time                        = 528.490443
+The maximum resident set size (KB)                   = 617324
 
 Test 020 control_c192 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_c384
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_c384
 Checking test 021 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1140,14 +1140,14 @@ Checking test 021 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 566.535413
-The maximum resident set size (KB)                   = 891328
+The total amount of wall time                        = 565.626157
+The maximum resident set size (KB)                   = 891912
 
 Test 021 control_c384 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_c384gdas
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_c384gdas
 Checking test 022 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1190,14 +1190,14 @@ Checking test 022 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 512.644827
-The maximum resident set size (KB)                   = 1017792
+The total amount of wall time                        = 494.946140
+The maximum resident set size (KB)                   = 1017528
 
 Test 022 control_c384gdas PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_stochy
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_stochy
 Checking test 023 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1208,28 +1208,28 @@ Checking test 023 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 88.695530
-The maximum resident set size (KB)                   = 525852
+The total amount of wall time                        = 89.055579
+The maximum resident set size (KB)                   = 523256
 
 Test 023 control_stochy PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_stochy_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_stochy_restart
 Checking test 024 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 45.723145
-The maximum resident set size (KB)                   = 291956
+The total amount of wall time                        = 45.898097
+The maximum resident set size (KB)                   = 288096
 
 Test 024 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_lndp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_lndp
 Checking test 025 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 025 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 79.957637
-The maximum resident set size (KB)                   = 521024
+The total amount of wall time                        = 79.836763
+The maximum resident set size (KB)                   = 521112
 
 Test 025 control_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_iovr4
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_iovr4
 Checking test 026 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1262,14 +1262,14 @@ Checking test 026 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.088035
-The maximum resident set size (KB)                   = 518488
+The total amount of wall time                        = 132.713840
+The maximum resident set size (KB)                   = 517244
 
 Test 026 control_iovr4 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_iovr5
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_iovr5
 Checking test 027 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1284,14 +1284,14 @@ Checking test 027 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.231979
-The maximum resident set size (KB)                   = 517104
+The total amount of wall time                        = 132.189898
+The maximum resident set size (KB)                   = 517144
 
 Test 027 control_iovr5 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_p8
 Checking test 028 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1338,14 +1338,14 @@ Checking test 028 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 173.733138
-The maximum resident set size (KB)                   = 1486520
+The total amount of wall time                        = 177.119912
+The maximum resident set size (KB)                   = 1493172
 
 Test 028 control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_p8_lndp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_p8_lndp
 Checking test 029 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1364,14 +1364,14 @@ Checking test 029 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 314.425369
-The maximum resident set size (KB)                   = 1490872
+The total amount of wall time                        = 318.007693
+The maximum resident set size (KB)                   = 1485052
 
 Test 029 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_restart_p8
 Checking test 030 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 030 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 93.150852
-The maximum resident set size (KB)                   = 649936
+The total amount of wall time                        = 95.744861
+The maximum resident set size (KB)                   = 648864
 
 Test 030 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_decomp_p8
 Checking test 031 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1460,14 +1460,14 @@ Checking test 031 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 175.486015
-The maximum resident set size (KB)                   = 1478264
+The total amount of wall time                        = 179.933561
+The maximum resident set size (KB)                   = 1482676
 
 Test 031 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_2threads_p8
 Checking test 032 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1510,14 +1510,14 @@ Checking test 032 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 156.678326
-The maximum resident set size (KB)                   = 1570528
+The total amount of wall time                        = 158.152924
+The maximum resident set size (KB)                   = 1568888
 
 Test 032 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_p8_rrtmgp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_p8_rrtmgp
 Checking test 033 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1564,14 +1564,14 @@ Checking test 033 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 252.756851
-The maximum resident set size (KB)                   = 1599856
+The total amount of wall time                        = 255.355562
+The maximum resident set size (KB)                   = 1604768
 
 Test 033 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/merra2_thompson
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/merra2_thompson
 Checking test 034 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1618,14 +1618,14 @@ Checking test 034 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.814343
-The maximum resident set size (KB)                   = 1490720
+The total amount of wall time                        = 200.782729
+The maximum resident set size (KB)                   = 1500824
 
 Test 034 merra2_thompson PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_control
 Checking test 035 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1636,28 +1636,28 @@ Checking test 035 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 283.530027
-The maximum resident set size (KB)                   = 651488
+The total amount of wall time                        = 285.111426
+The maximum resident set size (KB)                   = 647812
 
 Test 035 regional_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_restart
 Checking test 036 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 149.694026
-The maximum resident set size (KB)                   = 650344
+The total amount of wall time                        = 151.186328
+The maximum resident set size (KB)                   = 649424
 
 Test 036 regional_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_decomp
 Checking test 037 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1668,14 +1668,14 @@ Checking test 037 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 297.984839
-The maximum resident set size (KB)                   = 649844
+The total amount of wall time                        = 301.494935
+The maximum resident set size (KB)                   = 648324
 
 Test 037 regional_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_2threads
 Checking test 038 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1686,14 +1686,14 @@ Checking test 038 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 175.380658
-The maximum resident set size (KB)                   = 683672
+The total amount of wall time                        = 176.393262
+The maximum resident set size (KB)                   = 687868
 
 Test 038 regional_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_noquilt
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_noquilt
 Checking test 039 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1701,14 +1701,14 @@ Checking test 039 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 311.528528
-The maximum resident set size (KB)                   = 642460
+The total amount of wall time                        = 310.671281
+The maximum resident set size (KB)                   = 647076
 
 Test 039 regional_noquilt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_2dwrtdecomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_2dwrtdecomp
 Checking test 040 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1719,14 +1719,14 @@ Checking test 040 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 282.941625
-The maximum resident set size (KB)                   = 653092
+The total amount of wall time                        = 286.299408
+The maximum resident set size (KB)                   = 654384
 
 Test 040 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/fv3_regional_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_wofs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_wofs
 Checking test 041 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1737,14 +1737,14 @@ Checking test 041 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 358.778125
-The maximum resident set size (KB)                   = 335984
+The total amount of wall time                        = 358.148415
+The maximum resident set size (KB)                   = 333184
 
 Test 041 regional_wofs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_control
 Checking test 042 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1791,14 +1791,14 @@ Checking test 042 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 416.575324
-The maximum resident set size (KB)                   = 894464
+The total amount of wall time                        = 415.250332
+The maximum resident set size (KB)                   = 891984
 
 Test 042 rap_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_rrtmgp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_rrtmgp
 Checking test 043 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1845,14 +1845,14 @@ Checking test 043 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 495.044786
-The maximum resident set size (KB)                   = 1008044
+The total amount of wall time                        = 494.887038
+The maximum resident set size (KB)                   = 1009052
 
 Test 043 rap_rrtmgp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_spp_sppt_shum_skeb
 Checking test 044 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1863,14 +1863,14 @@ Checking test 044 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 282.931363
-The maximum resident set size (KB)                   = 984700
+The total amount of wall time                        = 284.321818
+The maximum resident set size (KB)                   = 984324
 
 Test 044 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_decomp
 Checking test 045 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1917,14 +1917,14 @@ Checking test 045 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 432.118325
-The maximum resident set size (KB)                   = 894264
+The total amount of wall time                        = 431.443124
+The maximum resident set size (KB)                   = 889272
 
 Test 045 rap_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_2threads
 Checking test 046 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 046 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 389.756424
-The maximum resident set size (KB)                   = 958404
+The total amount of wall time                        = 388.753190
+The maximum resident set size (KB)                   = 961692
 
 Test 046 rap_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_restart
 Checking test 047 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2017,14 +2017,14 @@ Checking test 047 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 210.050090
-The maximum resident set size (KB)                   = 636344
+The total amount of wall time                        = 209.640942
+The maximum resident set size (KB)                   = 637596
 
 Test 047 rap_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_sfcdiff
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_sfcdiff
 Checking test 048 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 048 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 417.643389
-The maximum resident set size (KB)                   = 892340
+The total amount of wall time                        = 415.140009
+The maximum resident set size (KB)                   = 895276
 
 Test 048 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_sfcdiff_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_sfcdiff_decomp
 Checking test 049 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 049 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 433.049408
-The maximum resident set size (KB)                   = 892816
+The total amount of wall time                        = 432.365840
+The maximum resident set size (KB)                   = 889692
 
 Test 049 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_sfcdiff_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_sfcdiff_restart
 Checking test 050 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2171,14 +2171,14 @@ Checking test 050 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 307.757599
-The maximum resident set size (KB)                   = 634980
+The total amount of wall time                        = 307.395230
+The maximum resident set size (KB)                   = 637796
 
 Test 050 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control
 Checking test 051 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2225,14 +2225,14 @@ Checking test 051 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 398.810600
-The maximum resident set size (KB)                   = 889632
+The total amount of wall time                        = 398.609293
+The maximum resident set size (KB)                   = 892544
 
 Test 051 hrrr_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_decomp
 Checking test 052 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2279,14 +2279,14 @@ Checking test 052 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 414.558162
-The maximum resident set size (KB)                   = 889784
+The total amount of wall time                        = 414.518433
+The maximum resident set size (KB)                   = 889764
 
 Test 052 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_2threads
 Checking test 053 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2333,14 +2333,14 @@ Checking test 053 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 370.880570
-The maximum resident set size (KB)                   = 959928
+The total amount of wall time                        = 370.572219
+The maximum resident set size (KB)                   = 961000
 
 Test 053 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_restart
 Checking test 054 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2379,14 +2379,14 @@ Checking test 054 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 296.900933
-The maximum resident set size (KB)                   = 635768
+The total amount of wall time                        = 296.540625
+The maximum resident set size (KB)                   = 634592
 
 Test 054 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_v1beta
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_v1beta
 Checking test 055 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2433,14 +2433,14 @@ Checking test 055 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 410.107278
-The maximum resident set size (KB)                   = 889696
+The total amount of wall time                        = 410.204972
+The maximum resident set size (KB)                   = 889788
 
-Test 055 rrfs_v1beta PASS
+Test 055 rrfs_v1beta PASS Tries: 2
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_v1nssl
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_v1nssl
 Checking test 056 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2455,14 +2455,14 @@ Checking test 056 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 474.304193
-The maximum resident set size (KB)                   = 573196
+The total amount of wall time                        = 473.775815
+The maximum resident set size (KB)                   = 573912
 
 Test 056 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_v1nssl_nohailnoccn
 Checking test 057 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2477,14 +2477,14 @@ Checking test 057 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 463.294507
-The maximum resident set size (KB)                   = 568900
+The total amount of wall time                        = 464.771799
+The maximum resident set size (KB)                   = 568384
 
 Test 057 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_conus13km_hrrr_warm
 Checking test 058 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2493,14 +2493,14 @@ Checking test 058 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 114.010099
-The maximum resident set size (KB)                   = 766396
+The total amount of wall time                        = 114.942096
+The maximum resident set size (KB)                   = 763372
 
 Test 058 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_smoke_conus13km_hrrr_warm
 Checking test 059 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2509,14 +2509,14 @@ Checking test 059 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 125.949093
-The maximum resident set size (KB)                   = 773012
+The total amount of wall time                        = 125.418182
+The maximum resident set size (KB)                   = 771136
 
 Test 059 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_conus13km_radar_tten_warm
 Checking test 060 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2525,14 +2525,14 @@ Checking test 060 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 114.775181
-The maximum resident set size (KB)                   = 768508
+The total amount of wall time                        = 115.584011
+The maximum resident set size (KB)                   = 768552
 
 Test 060 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_conus13km_hrrr_warm_2threads
 Checking test 061 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2541,14 +2541,14 @@ Checking test 061 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 84.000676
-The maximum resident set size (KB)                   = 760872
+The total amount of wall time                        = 85.720081
+The maximum resident set size (KB)                   = 764868
 
 Test 061 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 062 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2557,14 +2557,14 @@ Checking test 062 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 84.567795
-The maximum resident set size (KB)                   = 761468
+The total amount of wall time                        = 84.301718
+The maximum resident set size (KB)                   = 765888
 
 Test 062 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_csawmg
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_csawmg
 Checking test 063 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2575,14 +2575,14 @@ Checking test 063 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 342.428904
-The maximum resident set size (KB)                   = 581536
+The total amount of wall time                        = 345.031276
+The maximum resident set size (KB)                   = 585816
 
 Test 063 control_csawmg PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_csawmgt
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_csawmgt
 Checking test 064 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2593,14 +2593,14 @@ Checking test 064 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 340.668039
-The maximum resident set size (KB)                   = 586116
+The total amount of wall time                        = 340.810728
+The maximum resident set size (KB)                   = 584232
 
 Test 064 control_csawmgt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_ras
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_ras
 Checking test 065 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2611,54 +2611,54 @@ Checking test 065 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 179.321238
-The maximum resident set size (KB)                   = 550224
+The total amount of wall time                        = 179.107275
+The maximum resident set size (KB)                   = 548636
 
 Test 065 control_ras PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_wam
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_wam
 Checking test 066 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 115.748901
-The maximum resident set size (KB)                   = 263608
+The total amount of wall time                        = 116.167834
+The maximum resident set size (KB)                   = 263320
 
 Test 066 control_wam PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_conus13km_hrrr_warm_debug
 Checking test 067 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 772.046666
-The maximum resident set size (KB)                   = 790532
+The total amount of wall time                        = 768.573303
+The maximum resident set size (KB)                   = 782660
 
 Test 067 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_conus13km_radar_tten_warm_debug
 Checking test 068 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 773.008761
-The maximum resident set size (KB)                   = 794816
+The total amount of wall time                        = 771.219146
+The maximum resident set size (KB)                   = 788804
 
 Test 068 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_CubedSphereGrid_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_CubedSphereGrid_debug
 Checking test 069 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2685,348 +2685,348 @@ Checking test 069 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 164.006544
-The maximum resident set size (KB)                   = 675328
+The total amount of wall time                        = 164.399604
+The maximum resident set size (KB)                   = 675608
 
 Test 069 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_wrtGauss_netcdf_parallel_debug
 Checking test 070 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 155.976968
-The maximum resident set size (KB)                   = 680084
+The total amount of wall time                        = 156.912106
+The maximum resident set size (KB)                   = 676908
 
 Test 070 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_stochy_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_stochy_debug
 Checking test 071 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 176.471138
-The maximum resident set size (KB)                   = 681996
+The total amount of wall time                        = 177.186684
+The maximum resident set size (KB)                   = 682676
 
 Test 071 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_lndp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_lndp_debug
 Checking test 072 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.159076
-The maximum resident set size (KB)                   = 680728
+The total amount of wall time                        = 158.986337
+The maximum resident set size (KB)                   = 682512
 
 Test 072 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_csawmg_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_csawmg_debug
 Checking test 073 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 253.371760
-The maximum resident set size (KB)                   = 717012
+The total amount of wall time                        = 251.849727
+The maximum resident set size (KB)                   = 715208
 
 Test 073 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_csawmgt_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_csawmgt_debug
 Checking test 074 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 248.604142
-The maximum resident set size (KB)                   = 717472
+The total amount of wall time                        = 249.001199
+The maximum resident set size (KB)                   = 717132
 
 Test 074 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_ras_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_ras_debug
 Checking test 075 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.050924
-The maximum resident set size (KB)                   = 689388
+The total amount of wall time                        = 160.517718
+The maximum resident set size (KB)                   = 692804
 
 Test 075 control_ras_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_diag_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_diag_debug
 Checking test 076 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.404644
-The maximum resident set size (KB)                   = 737068
+The total amount of wall time                        = 161.609027
+The maximum resident set size (KB)                   = 734716
 
 Test 076 control_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_debug_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_debug_p8
 Checking test 077 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 183.763958
-The maximum resident set size (KB)                   = 1497276
+The total amount of wall time                        = 183.207744
+The maximum resident set size (KB)                   = 1497460
 
 Test 077 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_debug
 Checking test 078 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1091.869980
-The maximum resident set size (KB)                   = 669732
+The total amount of wall time                        = 1038.994046
+The maximum resident set size (KB)                   = 672372
 
 Test 078 regional_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_control_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_control_debug
 Checking test 079 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.180130
-The maximum resident set size (KB)                   = 1050916
+The total amount of wall time                        = 295.523312
+The maximum resident set size (KB)                   = 1053200
 
 Test 079 rap_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_debug
 Checking test 080 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.082242
-The maximum resident set size (KB)                   = 1049108
+The total amount of wall time                        = 290.456018
+The maximum resident set size (KB)                   = 1046520
 
 Test 080 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_unified_drag_suite_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_unified_drag_suite_debug
 Checking test 081 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.966230
-The maximum resident set size (KB)                   = 1050772
+The total amount of wall time                        = 295.855442
+The maximum resident set size (KB)                   = 1055140
 
 Test 081 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_diag_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_diag_debug
 Checking test 082 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 311.095345
-The maximum resident set size (KB)                   = 1135548
+The total amount of wall time                        = 307.906334
+The maximum resident set size (KB)                   = 1136308
 
 Test 082 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_cires_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_cires_ugwp_debug
 Checking test 083 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.000135
-The maximum resident set size (KB)                   = 1050052
+The total amount of wall time                        = 302.307240
+The maximum resident set size (KB)                   = 1052148
 
 Test 083 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_unified_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_unified_ugwp_debug
 Checking test 084 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.296885
-The maximum resident set size (KB)                   = 1051600
+The total amount of wall time                        = 303.161940
+The maximum resident set size (KB)                   = 1051604
 
 Test 084 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_lndp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_lndp_debug
 Checking test 085 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.138139
-The maximum resident set size (KB)                   = 1053152
+The total amount of wall time                        = 299.087030
+The maximum resident set size (KB)                   = 1053276
 
 Test 085 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_flake_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_flake_debug
 Checking test 086 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.120232
-The maximum resident set size (KB)                   = 1051644
+The total amount of wall time                        = 297.390282
+The maximum resident set size (KB)                   = 1051624
 
 Test 086 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_progcld_thompson_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_progcld_thompson_debug
 Checking test 087 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.143867
-The maximum resident set size (KB)                   = 1051708
+The total amount of wall time                        = 295.822943
+The maximum resident set size (KB)                   = 1053648
 
 Test 087 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_noah_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_noah_debug
 Checking test 088 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.085269
-The maximum resident set size (KB)                   = 1054460
+The total amount of wall time                        = 289.374754
+The maximum resident set size (KB)                   = 1050332
 
 Test 088 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_rrtmgp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_rrtmgp_debug
 Checking test 089 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 496.886559
-The maximum resident set size (KB)                   = 1166644
+The total amount of wall time                        = 500.831081
+The maximum resident set size (KB)                   = 1167376
 
 Test 089 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_sfcdiff_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.172532
-The maximum resident set size (KB)                   = 1052936
+The total amount of wall time                        = 296.348992
+The maximum resident set size (KB)                   = 1049768
 
 Test 090 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 091 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 486.295254
-The maximum resident set size (KB)                   = 1046816
+The total amount of wall time                        = 486.474144
+The maximum resident set size (KB)                   = 1050180
 
 Test 091 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rrfs_v1beta_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rrfs_v1beta_debug
 Checking test 092 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.473356
-The maximum resident set size (KB)                   = 1048752
+The total amount of wall time                        = 292.201439
+The maximum resident set size (KB)                   = 1048064
 
 Test 092 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_wam_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_wam_debug
 Checking test 093 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 297.131398
-The maximum resident set size (KB)                   = 295996
+The total amount of wall time                        = 296.110267
+The maximum resident set size (KB)                   = 296096
 
 Test 093 control_wam_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 094 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3037,14 +3037,14 @@ Checking test 094 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 266.206997
-The maximum resident set size (KB)                   = 889376
+The total amount of wall time                        = 264.372505
+The maximum resident set size (KB)                   = 886384
 
-Test 094 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
+Test 094 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS Tries: 2
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_control_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_control_dyn32_phy32
 Checking test 095 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3091,14 +3091,14 @@ Checking test 095 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 341.092741
-The maximum resident set size (KB)                   = 774280
+The total amount of wall time                        = 342.344146
+The maximum resident set size (KB)                   = 774700
 
 Test 095 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_dyn32_phy32
 Checking test 096 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3145,14 +3145,14 @@ Checking test 096 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.935271
-The maximum resident set size (KB)                   = 772952
+The total amount of wall time                        = 180.158080
+The maximum resident set size (KB)                   = 772404
 
 Test 096 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_2threads_dyn32_phy32
 Checking test 097 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3199,14 +3199,14 @@ Checking test 097 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 320.623596
-The maximum resident set size (KB)                   = 830772
+The total amount of wall time                        = 320.642953
+The maximum resident set size (KB)                   = 831740
 
 Test 097 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_2threads_dyn32_phy32
 Checking test 098 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3253,14 +3253,14 @@ Checking test 098 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 170.895995
-The maximum resident set size (KB)                   = 832680
+The total amount of wall time                        = 170.959040
+The maximum resident set size (KB)                   = 826968
 
 Test 098 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_decomp_dyn32_phy32
 Checking test 099 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3307,14 +3307,14 @@ Checking test 099 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 189.236695
-The maximum resident set size (KB)                   = 773248
+The total amount of wall time                        = 188.213980
+The maximum resident set size (KB)                   = 771544
 
 Test 099 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_restart_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_restart_dyn32_phy32
 Checking test 100 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3353,14 +3353,14 @@ Checking test 100 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 254.297960
-The maximum resident set size (KB)                   = 612296
+The total amount of wall time                        = 253.050730
+The maximum resident set size (KB)                   = 612340
 
 Test 100 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_restart_dyn32_phy32
 Checking test 101 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3399,14 +3399,14 @@ Checking test 101 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 91.650566
-The maximum resident set size (KB)                   = 602360
+The total amount of wall time                        = 91.782082
+The maximum resident set size (KB)                   = 603284
 
 Test 101 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_control_dyn64_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_control_dyn64_phy32
 Checking test 102 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3453,81 +3453,81 @@ Checking test 102 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 229.838549
-The maximum resident set size (KB)                   = 795640
+The total amount of wall time                        = 230.623657
+The maximum resident set size (KB)                   = 797192
 
 Test 102 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_control_debug_dyn32_phy32
 Checking test 103 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.743473
-The maximum resident set size (KB)                   = 935452
+The total amount of wall time                        = 289.879851
+The maximum resident set size (KB)                   = 937108
 
 Test 103 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hrrr_control_debug_dyn32_phy32
 Checking test 104 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 283.779565
-The maximum resident set size (KB)                   = 937764
+The total amount of wall time                        = 285.497796
+The maximum resident set size (KB)                   = 935432
 
 Test 104 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/rap_control_dyn64_phy32_debug
 Checking test 105 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.878687
-The maximum resident set size (KB)                   = 960632
+The total amount of wall time                        = 291.161480
+The maximum resident set size (KB)                   = 957344
 
-Test 105 rap_control_dyn64_phy32_debug PASS Tries: 2
+Test 105 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_atm
 Checking test 106 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 255.136026
-The maximum resident set size (KB)                   = 794836
+The total amount of wall time                        = 252.962608
+The maximum resident set size (KB)                   = 796864
 
 Test 106 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_atm_thompson_gfdlsf
 Checking test 107 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 290.949853
-The maximum resident set size (KB)                   = 1158992
+The total amount of wall time                        = 293.147221
+The maximum resident set size (KB)                   = 1156376
 
 Test 107 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_atm_ocn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_atm_ocn
 Checking test 108 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3536,14 +3536,14 @@ Checking test 108 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 374.821084
-The maximum resident set size (KB)                   = 832168
+The total amount of wall time                        = 375.783947
+The maximum resident set size (KB)                   = 831984
 
 Test 108 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_atm_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_atm_wav
 Checking test 109 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3552,14 +3552,14 @@ Checking test 109 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 698.260985
-The maximum resident set size (KB)                   = 864648
+The total amount of wall time                        = 697.229057
+The maximum resident set size (KB)                   = 863700
 
 Test 109 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_atm_ocn_wav
 Checking test 110 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3570,28 +3570,28 @@ Checking test 110 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 899.925185
-The maximum resident set size (KB)                   = 893276
+The total amount of wall time                        = 889.953527
+The maximum resident set size (KB)                   = 894912
 
 Test 110 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_1nest_atm
 Checking test 111 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 323.396067
-The maximum resident set size (KB)                   = 384536
+The total amount of wall time                        = 326.541986
+The maximum resident set size (KB)                   = 383256
 
 Test 111 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_telescopic_2nests_atm
 Checking test 112 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3600,28 +3600,28 @@ Checking test 112 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 391.723962
-The maximum resident set size (KB)                   = 395728
+The total amount of wall time                        = 392.300560
+The maximum resident set size (KB)                   = 400680
 
 Test 112 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_global_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_global_1nest_atm
 Checking test 113 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 162.951663
-The maximum resident set size (KB)                   = 262220
+The total amount of wall time                        = 164.253731
+The maximum resident set size (KB)                   = 263816
 
 Test 113 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_global_multiple_4nests_atm
 Checking test 114 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3639,14 +3639,14 @@ Checking test 114 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 482.496490
-The maximum resident set size (KB)                   = 335472
+The total amount of wall time                        = 483.526810
+The maximum resident set size (KB)                   = 334596
 
 Test 114 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_specified_moving_1nest_atm
 Checking test 115 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3655,28 +3655,28 @@ Checking test 115 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 209.375925
-The maximum resident set size (KB)                   = 393196
+The total amount of wall time                        = 209.146021
+The maximum resident set size (KB)                   = 395376
 
 Test 115 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_storm_following_1nest_atm
 Checking test 116 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 196.468111
-The maximum resident set size (KB)                   = 394732
+The total amount of wall time                        = 198.771743
+The maximum resident set size (KB)                   = 395204
 
 Test 116 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 117 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3685,28 +3685,28 @@ Checking test 117 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 236.828584
-The maximum resident set size (KB)                   = 446704
+The total amount of wall time                        = 236.124058
+The maximum resident set size (KB)                   = 442204
 
 Test 117 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_global_storm_following_1nest_atm
 Checking test 118 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 77.647505
-The maximum resident set size (KB)                   = 282884
+The total amount of wall time                        = 78.131758
+The maximum resident set size (KB)                   = 278948
 
 Test 118 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 119 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3717,14 +3717,14 @@ Checking test 119 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 515.896408
-The maximum resident set size (KB)                   = 514160
+The total amount of wall time                        = 512.339867
+The maximum resident set size (KB)                   = 513456
 
 Test 119 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_docn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_docn
 Checking test 120 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3732,14 +3732,14 @@ Checking test 120 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 358.910929
-The maximum resident set size (KB)                   = 834804
+The total amount of wall time                        = 358.295259
+The maximum resident set size (KB)                   = 835052
 
 Test 120 hafs_regional_docn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_docn_oisst
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_docn_oisst
 Checking test 121 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3747,131 +3747,131 @@ Checking test 121 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 360.728642
-The maximum resident set size (KB)                   = 824112
+The total amount of wall time                        = 359.377478
+The maximum resident set size (KB)                   = 822040
 
 Test 121 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/hafs_regional_datm_cdeps
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/hafs_regional_datm_cdeps
 Checking test 122 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 942.620012
-The maximum resident set size (KB)                   = 834332
+The total amount of wall time                        = 945.338616
+The maximum resident set size (KB)                   = 837560
 
 Test 122 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_control_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_control_cfsr
 Checking test 123 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.738315
-The maximum resident set size (KB)                   = 736036
+The total amount of wall time                        = 141.154487
+The maximum resident set size (KB)                   = 732816
 
 Test 123 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_restart_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_restart_cfsr
 Checking test 124 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 86.225894
-The maximum resident set size (KB)                   = 727476
+The total amount of wall time                        = 86.277716
+The maximum resident set size (KB)                   = 728320
 
 Test 124 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_control_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_control_gefs
 Checking test 125 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 133.829719
-The maximum resident set size (KB)                   = 612632
+The total amount of wall time                        = 135.463203
+The maximum resident set size (KB)                   = 616100
 
 Test 125 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_iau_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_iau_gefs
 Checking test 126 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 136.715602
-The maximum resident set size (KB)                   = 611560
+The total amount of wall time                        = 137.240899
+The maximum resident set size (KB)                   = 610736
 
 Test 126 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_stochy_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_stochy_gefs
 Checking test 127 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 138.879682
-The maximum resident set size (KB)                   = 611024
+The total amount of wall time                        = 138.044506
+The maximum resident set size (KB)                   = 616736
 
 Test 127 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_ciceC_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_ciceC_cfsr
 Checking test 128 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.852821
-The maximum resident set size (KB)                   = 732324
+The total amount of wall time                        = 140.339562
+The maximum resident set size (KB)                   = 735932
 
 Test 128 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_bulk_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_bulk_cfsr
 Checking test 129 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.310555
-The maximum resident set size (KB)                   = 732736
+The total amount of wall time                        = 141.482542
+The maximum resident set size (KB)                   = 734356
 
 Test 129 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_bulk_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_bulk_gefs
 Checking test 130 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 134.194291
-The maximum resident set size (KB)                   = 615956
+The total amount of wall time                        = 134.493898
+The maximum resident set size (KB)                   = 611340
 
 Test 130 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_mx025_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_mx025_cfsr
 Checking test 131 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3880,14 +3880,14 @@ Checking test 131 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 428.779516
-The maximum resident set size (KB)                   = 574924
+The total amount of wall time                        = 431.448953
+The maximum resident set size (KB)                   = 571968
 
 Test 131 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_mx025_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_mx025_gefs
 Checking test 132 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3896,51 +3896,51 @@ Checking test 132 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 428.493510
-The maximum resident set size (KB)                   = 546448
+The total amount of wall time                        = 430.213919
+The maximum resident set size (KB)                   = 547420
 
 Test 132 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_multiple_files_cfsr
 Checking test 133 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.626805
-The maximum resident set size (KB)                   = 732024
+The total amount of wall time                        = 141.180231
+The maximum resident set size (KB)                   = 722104
 
 Test 133 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_3072x1536_cfsr
 Checking test 134 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 253.956894
-The maximum resident set size (KB)                   = 1982344
+The total amount of wall time                        = 256.245055
+The maximum resident set size (KB)                   = 1981644
 
 Test 134 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_gfs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_gfs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_gfs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_gfs
 Checking test 135 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 254.942563
-The maximum resident set size (KB)                   = 1978456
+The total amount of wall time                        = 256.554287
+The maximum resident set size (KB)                   = 1980132
 
 Test 135 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_lnd_gswp3
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_lnd_gswp3
 Checking test 136 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -3949,14 +3949,14 @@ Checking test 136 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 21.796178
-The maximum resident set size (KB)                   = 229572
+The total amount of wall time                        = 21.662447
+The maximum resident set size (KB)                   = 230564
 
 Test 136 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/datm_cdeps_lnd_gswp3_rst
 Checking test 137 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -3965,14 +3965,14 @@ Checking test 137 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 26.793213
-The maximum resident set size (KB)                   = 223772
+The total amount of wall time                        = 27.226760
+The maximum resident set size (KB)                   = 223420
 
 Test 137 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_p8_atmlnd_sbs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_p8_atmlnd_sbs
 Checking test 138 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4057,14 +4057,14 @@ Checking test 138 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 230.916007
-The maximum resident set size (KB)                   = 1533716
+The total amount of wall time                        = 232.633291
+The maximum resident set size (KB)                   = 1531792
 
 Test 138 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/control_atmwav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/control_atmwav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_atmwav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/control_atmwav
 Checking test 139 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4108,14 +4108,14 @@ Checking test 139 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 87.357644
-The maximum resident set size (KB)                   = 543608
+The total amount of wall time                        = 88.239697
+The maximum resident set size (KB)                   = 543940
 
 Test 139 control_atmwav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/atmaero_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/atmaero_control_p8
 Checking test 140 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4159,14 +4159,14 @@ Checking test 140 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 238.242702
-The maximum resident set size (KB)                   = 2813900
+The total amount of wall time                        = 244.281371
+The maximum resident set size (KB)                   = 2812544
 
 Test 140 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/atmaero_control_p8_rad
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/atmaero_control_p8_rad
 Checking test 141 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4210,14 +4210,14 @@ Checking test 141 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 278.367713
-The maximum resident set size (KB)                   = 2872856
+The total amount of wall time                        = 279.012916
+The maximum resident set size (KB)                   = 2874968
 
 Test 141 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/atmaero_control_p8_rad_micro
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/atmaero_control_p8_rad_micro
 Checking test 142 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4261,14 +4261,14 @@ Checking test 142 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 284.709844
-The maximum resident set size (KB)                   = 2881568
+The total amount of wall time                        = 285.028152
+The maximum resident set size (KB)                   = 2885016
 
 Test 142 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_atmaq
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_atmaq
 Checking test 143 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4284,14 +4284,14 @@ Checking test 143 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 656.599881
-The maximum resident set size (KB)                   = 1379552
+The total amount of wall time                        = 661.708637
+The maximum resident set size (KB)                   = 1381696
 
 Test 143 regional_atmaq PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_142945/regional_atmaq_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_195956/regional_atmaq_debug
 Checking test 144 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4305,12 +4305,12 @@ Checking test 144 regional_atmaq_debug results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 1429.528994
-The maximum resident set size (KB)                   = 1418388
+The total amount of wall time                        = 1433.141109
+The maximum resident set size (KB)                   = 1419348
 
 Test 144 regional_atmaq_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jan 21 01:25:15 UTC 2023
-Elapsed time: 01h:35m:44s. Have a nice day!
+Sat Jan 28 19:24:46 UTC 2023
+Elapsed time: 01h:30m:22s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,26 +1,26 @@
-Wed Jan 25 15:14:12 MST 2023
+Thu Jan 26 11:57:45 MST 2023
 Start Regression test
 
-Compile 001 elapsed time 387 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 401 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 851 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 367 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1086 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 856 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 861 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 662 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 566 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 353 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 304 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 386 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 406 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 876 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 200 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 371 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1081 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 870 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 890 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 636 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 568 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 360 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 301 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_c48
 Checking test 001 control_c48 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -54,57 +54,57 @@ Checking test 001 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 821.572639
-0:The maximum resident set size (KB)                   = 677252
+0:The total amount of wall time                        = 818.909176
+0:The maximum resident set size (KB)                   = 677220
 
 Test 001 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_stochy
 Checking test 002 control_stochy results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 177.349648
-0:The maximum resident set size (KB)                   = 429944
+0:The total amount of wall time                        = 177.754505
+0:The maximum resident set size (KB)                   = 430060
 
 Test 002 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_ras
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_ras
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_ras
 Checking test 003 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 286.831425
-0:The maximum resident set size (KB)                   = 447964
+0:The total amount of wall time                        = 292.658747
+0:The maximum resident set size (KB)                   = 448044
 
 Test 003 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_p8
 Checking test 004 control_p8 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -144,14 +144,14 @@ Checking test 004 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 310.220925
-0:The maximum resident set size (KB)                   = 1222768
+0:The total amount of wall time                        = 309.237035
+0:The maximum resident set size (KB)                   = 1222868
 
 Test 004 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_control
 Checking test 005 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 005 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 712.321044
-0:The maximum resident set size (KB)                   = 778804
+0:The total amount of wall time                        = 719.535979
+0:The maximum resident set size (KB)                   = 778840
 
 Test 005 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_decomp
 Checking test 006 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -252,14 +252,14 @@ Checking test 006 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 720.714677
-0:The maximum resident set size (KB)                   = 779044
+0:The total amount of wall time                        = 725.419765
+0:The maximum resident set size (KB)                   = 778972
 
 Test 006 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_2threads
 Checking test 007 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -306,14 +306,14 @@ Checking test 007 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 662.642668
-0:The maximum resident set size (KB)                   = 851152
+0:The total amount of wall time                        = 664.596787
+0:The maximum resident set size (KB)                   = 850916
 
 Test 007 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_restart
 Checking test 008 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 360.992545
-0:The maximum resident set size (KB)                   = 527400
+0:The total amount of wall time                        = 359.271085
+0:The maximum resident set size (KB)                   = 527160
 
 Test 008 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_sfcdiff
 Checking test 009 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 705.589083
-0:The maximum resident set size (KB)                   = 778760
+0:The total amount of wall time                        = 709.738708
+0:The maximum resident set size (KB)                   = 778756
 
 Test 009 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_sfcdiff_decomp
 Checking test 010 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -460,14 +460,14 @@ Checking test 010 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 723.215666
-0:The maximum resident set size (KB)                   = 778924
+0:The total amount of wall time                        = 724.071468
+0:The maximum resident set size (KB)                   = 778816
 
 Test 010 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_sfcdiff_restart
 Checking test 011 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 531.959324
-0:The maximum resident set size (KB)                   = 526564
+0:The total amount of wall time                        = 531.566637
+0:The maximum resident set size (KB)                   = 526524
 
 Test 011 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control
 Checking test 012 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 684.317242
-0:The maximum resident set size (KB)                   = 776268
+0:The total amount of wall time                        = 682.196703
+0:The maximum resident set size (KB)                   = 776300
 
 Test 012 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_2threads
 Checking test 013 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -614,14 +614,14 @@ Checking test 013 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 621.627386
-0:The maximum resident set size (KB)                   = 845852
+0:The total amount of wall time                        = 622.345978
+0:The maximum resident set size (KB)                   = 845892
 
 Test 013 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_decomp
 Checking test 014 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -668,14 +668,14 @@ Checking test 014 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 681.847883
-0:The maximum resident set size (KB)                   = 776484
+0:The total amount of wall time                        = 683.458246
+0:The maximum resident set size (KB)                   = 776472
 
 Test 014 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_restart
 Checking test 015 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 516.491439
-0:The maximum resident set size (KB)                   = 522412
+0:The total amount of wall time                        = 515.432531
+0:The maximum resident set size (KB)                   = 522496
 
 Test 015 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_v1beta
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_v1beta
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 699.785966
-0:The maximum resident set size (KB)                   = 775692
+0:The total amount of wall time                        = 692.623909
+0:The maximum resident set size (KB)                   = 775732
 
 Test 016 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_conus13km_hrrr_warm
 Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -784,14 +784,14 @@ Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 203.258587
-0:The maximum resident set size (KB)                   = 594152
+0:The total amount of wall time                        = 203.049549
+0:The maximum resident set size (KB)                   = 594160
 
 Test 017 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_smoke_conus13km_hrrr_warm
 Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -800,14 +800,14 @@ Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 220.676306
-0:The maximum resident set size (KB)                   = 608144
+0:The total amount of wall time                        = 221.304283
+0:The maximum resident set size (KB)                   = 608288
 
 Test 018 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -816,14 +816,14 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 202.950412
-0:The maximum resident set size (KB)                   = 596716
+0:The total amount of wall time                        = 203.943744
+0:The maximum resident set size (KB)                   = 596896
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 020 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -832,208 +832,208 @@ Checking test 020 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 130.805195
-0:The maximum resident set size (KB)                   = 603452
+0:The total amount of wall time                        = 130.148485
+0:The maximum resident set size (KB)                   = 603632
 
 Test 020 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 87.596203
-0:The maximum resident set size (KB)                   = 483728
+0:The total amount of wall time                        = 90.356592
+0:The maximum resident set size (KB)                   = 483780
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/regional_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/regional_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 473.072708
-0:The maximum resident set size (KB)                   = 559316
+0:The total amount of wall time                        = 473.324980
+0:The maximum resident set size (KB)                   = 559816
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 153.123009
-0:The maximum resident set size (KB)                   = 801364
+0:The total amount of wall time                        = 148.065405
+0:The maximum resident set size (KB)                   = 801272
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_debug
 Checking test 024 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.968150
-0:The maximum resident set size (KB)                   = 796216
+0:The total amount of wall time                        = 145.505263
+0:The maximum resident set size (KB)                   = 796188
 
 Test 024 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_diag_debug
 Checking test 025 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.514378
-0:The maximum resident set size (KB)                   = 884560
+0:The total amount of wall time                        = 156.938868
+0:The maximum resident set size (KB)                   = 884484
 
 Test 025 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 026 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 240.271189
-0:The maximum resident set size (KB)                   = 799780
+0:The total amount of wall time                        = 235.994103
+0:The maximum resident set size (KB)                   = 799764
 
 Test 026 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_progcld_thompson_debug
 Checking test 027 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 152.296530
-0:The maximum resident set size (KB)                   = 801528
+0:The total amount of wall time                        = 148.486376
+0:The maximum resident set size (KB)                   = 801392
 
 Test 027 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_v1beta_debug
 Checking test 028 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 150.635703
-0:The maximum resident set size (KB)                   = 795672
+0:The total amount of wall time                        = 147.576990
+0:The maximum resident set size (KB)                   = 795536
 
 Test 028 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_ras_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_ras_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_ras_debug
 Checking test 029 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.906057
-0:The maximum resident set size (KB)                   = 436452
+0:The total amount of wall time                        = 84.579668
+0:The maximum resident set size (KB)                   = 436424
 
 Test 029 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_stochy_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_stochy_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_stochy_debug
 Checking test 030 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 96.055227
-0:The maximum resident set size (KB)                   = 430372
+0:The total amount of wall time                        = 91.553061
+0:The maximum resident set size (KB)                   = 430184
 
 Test 030 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_debug_p8
 Checking test 031 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 97.139260
-0:The maximum resident set size (KB)                   = 1214212
+0:The total amount of wall time                        = 94.455916
+0:The maximum resident set size (KB)                   = 1214200
 
 Test 031 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_conus13km_hrrr_warm_debug
 Checking test 032 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 382.632533
-0:The maximum resident set size (KB)                   = 601940
+0:The total amount of wall time                        = 381.268395
+0:The maximum resident set size (KB)                   = 601852
 
 Test 032 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rrfs_conus13km_radar_tten_warm_debug
 Checking test 033 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 383.891682
-0:The maximum resident set size (KB)                   = 604444
+0:The total amount of wall time                        = 382.997985
+0:The maximum resident set size (KB)                   = 604240
 
 Test 033 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/control_wam_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/control_wam_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/control_wam_debug
 Checking test 034 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 148.660770
-0:The maximum resident set size (KB)                   = 173388
+0:The total amount of wall time                        = 146.344399
+0:The maximum resident set size (KB)                   = 173384
 
 Test 034 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_control_dyn32_phy32
 Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1080,14 +1080,14 @@ Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 682.657429
-0:The maximum resident set size (KB)                   = 664328
+0:The total amount of wall time                        = 683.490607
+0:The maximum resident set size (KB)                   = 664372
 
 Test 035 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_dyn32_phy32
 Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1134,14 +1134,14 @@ Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 345.146723
-0:The maximum resident set size (KB)                   = 662860
+0:The total amount of wall time                        = 347.799481
+0:The maximum resident set size (KB)                   = 662864
 
 Test 036 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_2threads_dyn32_phy32
 Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1188,14 +1188,14 @@ Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 626.440252
-0:The maximum resident set size (KB)                   = 710044
+0:The total amount of wall time                        = 623.523412
+0:The maximum resident set size (KB)                   = 710020
 
 Test 037 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_2threads_dyn32_phy32
 Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1242,14 +1242,14 @@ Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 317.294915
-0:The maximum resident set size (KB)                   = 702652
+0:The total amount of wall time                        = 319.803768
+0:The maximum resident set size (KB)                   = 703008
 
 Test 038 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_decomp_dyn32_phy32
 Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1296,14 +1296,14 @@ Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 347.552823
+0:The total amount of wall time                        = 346.690548
 0:The maximum resident set size (KB)                   = 662356
 
 Test 039 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_restart_dyn32_phy32
 Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 513.952264
-0:The maximum resident set size (KB)                   = 502284
+0:The total amount of wall time                        = 514.793643
+0:The maximum resident set size (KB)                   = 502328
 
 Test 040 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_restart_dyn32_phy32
 Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1388,21 +1388,21 @@ Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 177.350305
-0:The maximum resident set size (KB)                   = 500292
+0:The total amount of wall time                        = 175.681065
+0:The maximum resident set size (KB)                   = 500176
 
 Test 041 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn64_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_control_dyn64_phy32
 Checking test 042 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1442,75 +1442,75 @@ Checking test 042 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 405.774824
-0:The maximum resident set size (KB)                   = 685020
+0:The total amount of wall time                        = 405.915445
+0:The maximum resident set size (KB)                   = 685000
 
 Test 042 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_control_debug_dyn32_phy32
 Checking test 043 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.671093
-0:The maximum resident set size (KB)                   = 682112
+0:The total amount of wall time                        = 147.154456
+0:The maximum resident set size (KB)                   = 682032
 
 Test 043 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/hrrr_control_debug_dyn32_phy32
 Checking test 044 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.457977
-0:The maximum resident set size (KB)                   = 679084
+0:The total amount of wall time                        = 144.736829
+0:The maximum resident set size (KB)                   = 679048
 
 Test 044 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/rap_control_dyn64_phy32_debug
 Checking test 045 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 151.344667
-0:The maximum resident set size (KB)                   = 702532
+0:The total amount of wall time                        = 150.328771
+0:The maximum resident set size (KB)                   = 702452
 
 Test 045 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/cpld_control_p8
 Checking test 046 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1556,33 +1556,33 @@ Checking test 046 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 484.149410
-0:The maximum resident set size (KB)                   = 3141696
+0:The total amount of wall time                        = 498.228200
+0:The maximum resident set size (KB)                   = 3141828
 
 Test 046 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/cpld_control_nowave_noaero_p8
 Checking test 047 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1625,21 +1625,21 @@ Checking test 047 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 243.047653
-0:The maximum resident set size (KB)                   = 1225416
+0:The total amount of wall time                        = 242.966747
+0:The maximum resident set size (KB)                   = 1226124
 
 Test 047 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/cpld_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/cpld_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/cpld_debug_p8
 Checking test 048 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1685,25 +1685,25 @@ Checking test 048 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 272.798041
-0:The maximum resident set size (KB)                   = 3162676
+0:The total amount of wall time                        = 274.215402
+0:The maximum resident set size (KB)                   = 3159844
 
 Test 048 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_71876/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/GNU/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_7710/datm_cdeps_control_cfsr
 Checking test 049 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 179.345198
-0:The maximum resident set size (KB)                   = 683104
+0:The total amount of wall time                        = 179.908757
+0:The maximum resident set size (KB)                   = 683696
 
 Test 049 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 25 15:45:07 MST 2023
-Elapsed time: 00h:30m:55s. Have a nice day!
+Thu Jan 26 12:28:27 MST 2023
+Elapsed time: 00h:30m:42s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,37 +1,37 @@
-Wed Jan 25 18:14:16 MST 2023
+Thu Jan 26 17:59:21 MST 2023
 Start Regression test
 
-Compile 001 elapsed time 1514 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1470 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1354 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 412 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 390 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1075 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1095 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 1007 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 1032 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 933 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 818 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1527 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1417 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1356 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 416 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 388 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1073 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1103 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1012 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1042 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 964 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 832 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 012 elapsed time 382 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 248 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 825 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 837 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 245 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 244 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 1114 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 1572 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 1120 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 429 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 022 elapsed time 208 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 023 elapsed time 104 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 980 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 997 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 915 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 877 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 283 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 245 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 826 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 840 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 247 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 251 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 1139 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 1578 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 1109 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 435 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 022 elapsed time 206 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 023 elapsed time 108 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 979 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 988 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 920 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 890 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 280 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8_mixedmode
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_p8_mixedmode
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -96,33 +96,33 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 317.002009
-0:The maximum resident set size (KB)                   = 2703780
+0:The total amount of wall time                        = 319.077876
+0:The maximum resident set size (KB)                   = 2703608
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_gfsv17
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_gfsv17
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_gfsv17
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -167,33 +167,33 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 282.156547
-0:The maximum resident set size (KB)                   = 1441744
+0:The total amount of wall time                        = 282.610799
+0:The maximum resident set size (KB)                   = 1441456
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -239,21 +239,21 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 320.718449
-0:The maximum resident set size (KB)                   = 2719812
+0:The total amount of wall time                        = 320.099013
+0:The maximum resident set size (KB)                   = 2719644
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -299,21 +299,21 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 184.974122
-0:The maximum resident set size (KB)                   = 2580884
+0:The total amount of wall time                        = 184.892182
+0:The maximum resident set size (KB)                   = 2581092
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_2threads_p8
 Checking test 005 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -359,21 +359,21 @@ Checking test 005 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 252.677649
-0:The maximum resident set size (KB)                   = 3179816
+0:The total amount of wall time                        = 248.423609
+0:The maximum resident set size (KB)                   = 3179580
 
 Test 005 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_esmfthreads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_esmfthreads_p8
 Checking test 006 cpld_esmfthreads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -419,21 +419,21 @@ Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 256.021710
-0:The maximum resident set size (KB)                   = 2886656
+0:The total amount of wall time                        = 253.953550
+0:The maximum resident set size (KB)                   = 2886372
 
 Test 006 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -479,21 +479,21 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 312.305804
-0:The maximum resident set size (KB)                   = 2724172
+0:The total amount of wall time                        = 321.116588
+0:The maximum resident set size (KB)                   = 2726276
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_mpi_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -539,33 +539,33 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 269.072002
-0:The maximum resident set size (KB)                   = 2685080
+0:The total amount of wall time                        = 277.681732
+0:The maximum resident set size (KB)                   = 2684812
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_ciceC_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_ciceC_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -611,21 +611,21 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 319.795956
-0:The maximum resident set size (KB)                   = 2719892
+0:The total amount of wall time                        = 320.930815
+0:The maximum resident set size (KB)                   = 2719984
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -671,21 +671,21 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 625.232935
-0:The maximum resident set size (KB)                   = 3352868
+0:The total amount of wall time                        = 629.315341
+0:The maximum resident set size (KB)                   = 3352376
 
 Test 010 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_restart_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -731,33 +731,33 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 400.905629
-0:The maximum resident set size (KB)                   = 3275704
+0:The total amount of wall time                        = 394.035557
+0:The maximum resident set size (KB)                   = 3275432
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_noaero_p8
 Checking test 012 cpld_control_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -802,33 +802,33 @@ Checking test 012 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 282.282631
-0:The maximum resident set size (KB)                   = 1440584
+0:The total amount of wall time                        = 293.785450
+0:The maximum resident set size (KB)                   = 1440464
 
 Test 012 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_nowave_noaero_p8
 Checking test 013 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -871,21 +871,21 @@ Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 181.979127
-0:The maximum resident set size (KB)                   = 1456700
+0:The total amount of wall time                        = 190.998095
+0:The maximum resident set size (KB)                   = 1456344
 
 Test 013 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_debug_p8
 Checking test 014 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -931,21 +931,21 @@ Checking test 014 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 472.380272
-0:The maximum resident set size (KB)                   = 2791764
+0:The total amount of wall time                        = 471.909356
+0:The maximum resident set size (KB)                   = 2791812
 
 Test 014 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_debug_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_debug_noaero_p8
 Checking test 015 cpld_debug_noaero_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -990,33 +990,33 @@ Checking test 015 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 348.963525
-0:The maximum resident set size (KB)                   = 1463920
+0:The total amount of wall time                        = 348.592297
+0:The maximum resident set size (KB)                   = 1463916
 
 Test 015 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_noaero_p8_agrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_noaero_p8_agrid
 Checking test 016 cpld_control_noaero_p8_agrid results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1059,21 +1059,21 @@ Checking test 016 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 249.296636
-0:The maximum resident set size (KB)                   = 1459504
+0:The total amount of wall time                        = 252.362136
+0:The maximum resident set size (KB)                   = 1459404
 
 Test 016 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_control_c48
 Checking test 017 cpld_control_c48 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1116,21 +1116,21 @@ Checking test 017 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 603.431855
-0:The maximum resident set size (KB)                   = 2583464
+0:The total amount of wall time                        = 605.054107
+0:The maximum resident set size (KB)                   = 2583428
 
 Test 017 cpld_control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_warmstart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_warmstart_c48
 Checking test 018 cpld_warmstart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1173,21 +1173,21 @@ Checking test 018 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 160.160736
-0:The maximum resident set size (KB)                   = 2600232
+0:The total amount of wall time                        = 161.798796
+0:The maximum resident set size (KB)                   = 2600188
 
 Test 018 cpld_warmstart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/cpld_restart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/cpld_restart_c48
 Checking test 019 cpld_restart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1230,14 +1230,14 @@ Checking test 019 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 83.487439
-0:The maximum resident set size (KB)                   = 2017592
+0:The total amount of wall time                        = 84.371637
+0:The maximum resident set size (KB)                   = 2017696
 
 Test 019 cpld_restart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_CubedSphereGrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1264,28 +1264,28 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.103871
-0:The maximum resident set size (KB)                   = 456476
+0:The total amount of wall time                        = 142.419604
+0:The maximum resident set size (KB)                   = 456504
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_parallel
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_CubedSphereGrid_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_CubedSphereGrid_parallel
 Checking test 021 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 139.535597
+0:The total amount of wall time                        = 138.903279
 0:The maximum resident set size (KB)                   = 456388
 
 Test 021 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_latlon
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_latlon
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_latlon
 Checking test 022 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1296,32 +1296,32 @@ Checking test 022 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 141.827733
-0:The maximum resident set size (KB)                   = 456648
+0:The total amount of wall time                        = 145.509349
+0:The maximum resident set size (KB)                   = 456616
 
 Test 022 control_latlon PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 145.018574
-0:The maximum resident set size (KB)                   = 456556
+0:The total amount of wall time                        = 149.916791
+0:The maximum resident set size (KB)                   = 456692
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1360,14 +1360,14 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 444.924184
-0:The maximum resident set size (KB)                   = 628472
+0:The total amount of wall time                        = 446.272603
+0:The maximum resident set size (KB)                   = 628504
 
 Test 024 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c192
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_c192
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1378,14 +1378,14 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 597.488443
-0:The maximum resident set size (KB)                   = 560364
+0:The total amount of wall time                        = 599.856781
+0:The maximum resident set size (KB)                   = 560324
 
 Test 025 control_c192 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_c384
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1396,14 +1396,14 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 597.519568
-0:The maximum resident set size (KB)                   = 857504
+0:The total amount of wall time                        = 596.376922
+0:The maximum resident set size (KB)                   = 857424
 
 Test 026 control_c384 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384gdas
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_c384gdas
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1446,14 +1446,14 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 521.043448
-0:The maximum resident set size (KB)                   = 993436
+0:The total amount of wall time                        = 528.490027
+0:The maximum resident set size (KB)                   = 994972
 
 Test 027 control_c384gdas PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1464,28 +1464,28 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 96.597773
-0:The maximum resident set size (KB)                   = 458664
+0:The total amount of wall time                        = 95.580119
+0:The maximum resident set size (KB)                   = 458680
 
 Test 028 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_stochy_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 51.893298
-0:The maximum resident set size (KB)                   = 225964
+0:The total amount of wall time                        = 51.545786
+0:The maximum resident set size (KB)                   = 225980
 
 Test 029 control_stochy_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1496,14 +1496,14 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 89.516662
-0:The maximum resident set size (KB)                   = 460728
+0:The total amount of wall time                        = 89.538533
+0:The maximum resident set size (KB)                   = 460772
 
 Test 030 control_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr4
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_iovr4
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_iovr4
 Checking test 031 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1518,14 +1518,14 @@ Checking test 031 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.429990
-0:The maximum resident set size (KB)                   = 456536
+0:The total amount of wall time                        = 149.370532
+0:The maximum resident set size (KB)                   = 456608
 
 Test 031 control_iovr4 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr5
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_iovr5
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_iovr5
 Checking test 032 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1540,14 +1540,14 @@ Checking test 032 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.606201
-0:The maximum resident set size (KB)                   = 456684
+0:The total amount of wall time                        = 147.563639
+0:The maximum resident set size (KB)                   = 456660
 
 Test 032 control_iovr5 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_p8
 Checking test 033 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1594,14 +1594,14 @@ Checking test 033 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 179.421953
-0:The maximum resident set size (KB)                   = 1426420
+0:The total amount of wall time                        = 179.892087
+0:The maximum resident set size (KB)                   = 1426460
 
 Test 033 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_lndp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_p8_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_p8_lndp
 Checking test 034 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1620,14 +1620,14 @@ Checking test 034 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 333.335020
-0:The maximum resident set size (KB)                   = 1426640
+0:The total amount of wall time                        = 325.816940
+0:The maximum resident set size (KB)                   = 1426688
 
 Test 034 control_p8_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1666,14 +1666,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 94.346531
-0:The maximum resident set size (KB)                   = 583368
+0:The total amount of wall time                        = 95.493908
+0:The maximum resident set size (KB)                   = 583364
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1716,14 +1716,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 185.914848
-0:The maximum resident set size (KB)                   = 1420340
+0:The total amount of wall time                        = 184.637143
+0:The maximum resident set size (KB)                   = 1420404
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1766,14 +1766,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 176.486682
-0:The maximum resident set size (KB)                   = 1508492
+0:The total amount of wall time                        = 176.022831
+0:The maximum resident set size (KB)                   = 1508416
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_p8_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_p8_rrtmgp
 Checking test 038 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1820,14 +1820,14 @@ Checking test 038 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 247.286971
-0:The maximum resident set size (KB)                   = 1542236
+0:The total amount of wall time                        = 247.140199
+0:The maximum resident set size (KB)                   = 1542200
 
 Test 038 control_p8_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/merra2_thompson
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/merra2_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/merra2_thompson
 Checking test 039 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1874,14 +1874,14 @@ Checking test 039 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 206.869892
-0:The maximum resident set size (KB)                   = 1433048
+0:The total amount of wall time                        = 205.222155
+0:The maximum resident set size (KB)                   = 1433036
 
 Test 039 merra2_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_control
 Checking test 040 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1892,28 +1892,28 @@ Checking test 040 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 337.370446
-0:The maximum resident set size (KB)                   = 608208
+0:The total amount of wall time                        = 339.610976
+0:The maximum resident set size (KB)                   = 608308
 
 Test 040 regional_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_restart
 Checking test 041 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 171.610542
-0:The maximum resident set size (KB)                   = 594644
+0:The total amount of wall time                        = 171.735639
+0:The maximum resident set size (KB)                   = 594544
 
 Test 041 regional_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_decomp
 Checking test 042 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 042 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 353.670263
-0:The maximum resident set size (KB)                   = 598468
+0:The total amount of wall time                        = 349.758084
+0:The maximum resident set size (KB)                   = 598452
 
 Test 042 regional_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1942,14 +1942,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 205.151704
-0:The maximum resident set size (KB)                   = 606280
+0:The total amount of wall time                        = 198.699156
+0:The maximum resident set size (KB)                   = 606292
 
 Test 043 regional_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_noquilt
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_noquilt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_noquilt
 Checking test 044 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1957,28 +1957,28 @@ Checking test 044 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 362.413523
-0:The maximum resident set size (KB)                   = 601180
+0:The total amount of wall time                        = 362.684374
+0:The maximum resident set size (KB)                   = 601184
 
 Test 044 regional_noquilt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_netcdf_parallel
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_netcdf_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf006.nc ............ALT CHECK......OK
- Comparing phyf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 333.435507
-0:The maximum resident set size (KB)                   = 593688
+0:The total amount of wall time                        = 333.609686
+0:The maximum resident set size (KB)                   = 593668
 
 Test 045 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_2dwrtdecomp
 Checking test 046 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1989,14 +1989,14 @@ Checking test 046 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 340.192112
-0:The maximum resident set size (KB)                   = 608228
+0:The total amount of wall time                        = 327.031388
+0:The maximum resident set size (KB)                   = 608288
 
 Test 046 regional_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/fv3_regional_wofs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_wofs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_wofs
 Checking test 047 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2007,14 +2007,14 @@ Checking test 047 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 424.835129
-0:The maximum resident set size (KB)                   = 273764
+0:The total amount of wall time                        = 425.197008
+0:The maximum resident set size (KB)                   = 273852
 
 Test 047 regional_wofs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_control
 Checking test 048 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2061,14 +2061,14 @@ Checking test 048 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 477.025880
-0:The maximum resident set size (KB)                   = 830092
+0:The total amount of wall time                        = 476.496408
+0:The maximum resident set size (KB)                   = 829964
 
 Test 048 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_rrtmgp
 Checking test 049 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2115,14 +2115,14 @@ Checking test 049 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 535.411891
-0:The maximum resident set size (KB)                   = 953588
+0:The total amount of wall time                        = 536.254928
+0:The maximum resident set size (KB)                   = 953624
 
 Test 049 rap_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_spp_sppt_shum_skeb
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_spp_sppt_shum_skeb
 Checking test 050 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2133,14 +2133,14 @@ Checking test 050 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 326.000369
-0:The maximum resident set size (KB)                   = 952420
+0:The total amount of wall time                        = 322.798026
+0:The maximum resident set size (KB)                   = 952432
 
 Test 050 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_decomp
 Checking test 051 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2187,14 +2187,14 @@ Checking test 051 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 501.032156
-0:The maximum resident set size (KB)                   = 826100
+0:The total amount of wall time                        = 501.350010
+0:The maximum resident set size (KB)                   = 826180
 
 Test 051 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_2threads
 Checking test 052 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2241,14 +2241,14 @@ Checking test 052 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 464.935352
-0:The maximum resident set size (KB)                   = 895828
+0:The total amount of wall time                        = 467.607733
+0:The maximum resident set size (KB)                   = 897928
 
 Test 052 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_restart
 Checking test 053 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2287,14 +2287,14 @@ Checking test 053 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 240.650838
-0:The maximum resident set size (KB)                   = 573816
+0:The total amount of wall time                        = 243.467927
+0:The maximum resident set size (KB)                   = 573852
 
 Test 053 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_sfcdiff
 Checking test 054 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2341,14 +2341,14 @@ Checking test 054 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 468.006986
-0:The maximum resident set size (KB)                   = 826460
+0:The total amount of wall time                        = 470.652615
+0:The maximum resident set size (KB)                   = 826580
 
 Test 054 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_sfcdiff_decomp
 Checking test 055 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2395,14 +2395,14 @@ Checking test 055 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 495.051989
-0:The maximum resident set size (KB)                   = 826028
+0:The total amount of wall time                        = 506.413114
+0:The maximum resident set size (KB)                   = 826004
 
 Test 055 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_sfcdiff_restart
 Checking test 056 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2441,14 +2441,14 @@ Checking test 056 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 348.853279
-0:The maximum resident set size (KB)                   = 573180
+0:The total amount of wall time                        = 353.478397
+0:The maximum resident set size (KB)                   = 573164
 
 Test 056 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control
 Checking test 057 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2495,14 +2495,14 @@ Checking test 057 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 455.128809
-0:The maximum resident set size (KB)                   = 824956
+0:The total amount of wall time                        = 452.156718
+0:The maximum resident set size (KB)                   = 824896
 
 Test 057 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_decomp
 Checking test 058 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2549,14 +2549,14 @@ Checking test 058 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 471.564528
-0:The maximum resident set size (KB)                   = 823912
+0:The total amount of wall time                        = 474.859263
+0:The maximum resident set size (KB)                   = 823960
 
 Test 058 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_2threads
 Checking test 059 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2603,14 +2603,14 @@ Checking test 059 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 427.860889
-0:The maximum resident set size (KB)                   = 891364
+0:The total amount of wall time                        = 434.259060
+0:The maximum resident set size (KB)                   = 890828
 
 Test 059 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_restart
 Checking test 060 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2649,14 +2649,14 @@ Checking test 060 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 344.137905
-0:The maximum resident set size (KB)                   = 569008
+0:The total amount of wall time                        = 341.797316
+0:The maximum resident set size (KB)                   = 568664
 
 Test 060 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_v1beta
 Checking test 061 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2703,14 +2703,14 @@ Checking test 061 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 465.951858
-0:The maximum resident set size (KB)                   = 823172
+0:The total amount of wall time                        = 463.579219
+0:The maximum resident set size (KB)                   = 823248
 
 Test 061 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_v1nssl
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_v1nssl
 Checking test 062 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2725,14 +2725,14 @@ Checking test 062 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 572.589245
-0:The maximum resident set size (KB)                   = 511436
+0:The total amount of wall time                        = 571.486627
+0:The maximum resident set size (KB)                   = 511564
 
 Test 062 rrfs_v1nssl PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_v1nssl_nohailnoccn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_v1nssl_nohailnoccn
 Checking test 063 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2747,14 +2747,14 @@ Checking test 063 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 555.996892
-0:The maximum resident set size (KB)                   = 506624
+0:The total amount of wall time                        = 558.182090
+0:The maximum resident set size (KB)                   = 506636
 
 Test 063 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_conus13km_hrrr_warm
 Checking test 064 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2763,14 +2763,14 @@ Checking test 064 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 126.725636
-0:The maximum resident set size (KB)                   = 641448
+0:The total amount of wall time                        = 129.029441
+0:The maximum resident set size (KB)                   = 641336
 
 Test 064 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_smoke_conus13km_hrrr_warm
 Checking test 065 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2779,14 +2779,14 @@ Checking test 065 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 143.849125
-0:The maximum resident set size (KB)                   = 656324
+0:The total amount of wall time                        = 144.446554
+0:The maximum resident set size (KB)                   = 656348
 
 Test 065 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_conus13km_radar_tten_warm
 Checking test 066 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2795,14 +2795,14 @@ Checking test 066 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 128.837730
-0:The maximum resident set size (KB)                   = 644216
+0:The total amount of wall time                        = 129.039357
+0:The maximum resident set size (KB)                   = 644128
 
 Test 066 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_conus13km_hrrr_warm_2threads
 Checking test 067 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2811,14 +2811,14 @@ Checking test 067 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 81.051844
-0:The maximum resident set size (KB)                   = 659808
+0:The total amount of wall time                        = 81.082615
+0:The maximum resident set size (KB)                   = 659768
 
 Test 067 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 068 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2827,108 +2827,108 @@ Checking test 068 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 81.981699
-0:The maximum resident set size (KB)                   = 662564
+0:The total amount of wall time                        = 81.925834
+0:The maximum resident set size (KB)                   = 662396
 
 Test 068 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_csawmg
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_csawmg
 Checking test 069 control_csawmg results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 396.641914
-0:The maximum resident set size (KB)                   = 532504
+0:The total amount of wall time                        = 379.152599
+0:The maximum resident set size (KB)                   = 532600
 
 Test 069 control_csawmg PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_csawmgt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_csawmgt
 Checking test 070 control_csawmgt results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 392.253960
-0:The maximum resident set size (KB)                   = 531720
+0:The total amount of wall time                        = 391.706790
+0:The maximum resident set size (KB)                   = 531820
 
 Test 070 control_csawmgt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_ras
 Checking test 071 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 205.974208
-0:The maximum resident set size (KB)                   = 490948
+0:The total amount of wall time                        = 205.381299
+0:The maximum resident set size (KB)                   = 491044
 
 Test 071 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_wam
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_wam
 Checking test 072 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 129.010112
-0:The maximum resident set size (KB)                   = 207812
+0:The total amount of wall time                        = 129.052796
+0:The maximum resident set size (KB)                   = 207720
 
 Test 072 control_wam PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_conus13km_hrrr_warm_debug
 Checking test 073 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 756.022394
-0:The maximum resident set size (KB)                   = 670172
+0:The total amount of wall time                        = 756.134798
+0:The maximum resident set size (KB)                   = 670052
 
 Test 073 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_conus13km_radar_tten_warm_debug
 Checking test 074 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 756.168655
-0:The maximum resident set size (KB)                   = 673420
+0:The total amount of wall time                        = 756.041219
+0:The maximum resident set size (KB)                   = 673540
 
 Test 074 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_CubedSphereGrid_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_CubedSphereGrid_debug
 Checking test 075 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2955,348 +2955,348 @@ Checking test 075 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 175.423439
-0:The maximum resident set size (KB)                   = 624972
+0:The total amount of wall time                        = 173.851543
+0:The maximum resident set size (KB)                   = 624920
 
 Test 075 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_wrtGauss_netcdf_parallel_debug
 Checking test 076 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 161.933234
-0:The maximum resident set size (KB)                   = 624984
+0:The total amount of wall time                        = 162.600165
+0:The maximum resident set size (KB)                   = 624996
 
 Test 076 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_stochy_debug
 Checking test 077 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 181.234076
-0:The maximum resident set size (KB)                   = 628580
+0:The total amount of wall time                        = 182.188744
+0:The maximum resident set size (KB)                   = 628556
 
 Test 077 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_lndp_debug
 Checking test 078 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.275421
+0:The total amount of wall time                        = 164.132670
 0:The maximum resident set size (KB)                   = 629208
 
 Test 078 control_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_csawmg_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_csawmg_debug
 Checking test 079 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 256.436796
+0:The total amount of wall time                        = 255.753801
 0:The maximum resident set size (KB)                   = 674008
 
 Test 079 control_csawmg_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_csawmgt_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_csawmgt_debug
 Checking test 080 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 251.820251
-0:The maximum resident set size (KB)                   = 674948
+0:The total amount of wall time                        = 252.458986
+0:The maximum resident set size (KB)                   = 674916
 
 Test 080 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_ras_debug
 Checking test 081 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 165.337528
-0:The maximum resident set size (KB)                   = 636260
+0:The total amount of wall time                        = 166.259395
+0:The maximum resident set size (KB)                   = 636048
 
 Test 081 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_diag_debug
 Checking test 082 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 167.305720
-0:The maximum resident set size (KB)                   = 681384
+0:The total amount of wall time                        = 168.204531
+0:The maximum resident set size (KB)                   = 681300
 
 Test 082 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_debug_p8
 Checking test 083 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.870049
-0:The maximum resident set size (KB)                   = 1447844
+0:The total amount of wall time                        = 182.489541
+0:The maximum resident set size (KB)                   = 1447816
 
 Test 083 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_debug
 Checking test 084 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 1033.526670
-0:The maximum resident set size (KB)                   = 625876
+0:The total amount of wall time                        = 1032.962117
+0:The maximum resident set size (KB)                   = 625912
 
 Test 084 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_control_debug
 Checking test 085 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.196879
-0:The maximum resident set size (KB)                   = 993372
+0:The total amount of wall time                        = 293.295407
+0:The maximum resident set size (KB)                   = 993336
 
 Test 085 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_debug
 Checking test 086 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.035978
-0:The maximum resident set size (KB)                   = 992872
+0:The total amount of wall time                        = 288.651587
+0:The maximum resident set size (KB)                   = 992380
 
 Test 086 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_unified_drag_suite_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_unified_drag_suite_debug
 Checking test 087 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 300.641203
-0:The maximum resident set size (KB)                   = 993476
+0:The total amount of wall time                        = 293.286616
+0:The maximum resident set size (KB)                   = 993236
 
 Test 087 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_diag_debug
 Checking test 088 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 307.646359
-0:The maximum resident set size (KB)                   = 1077556
+0:The total amount of wall time                        = 307.806004
+0:The maximum resident set size (KB)                   = 1077840
 
 Test 088 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_cires_ugwp_debug
 Checking test 089 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 299.061233
-0:The maximum resident set size (KB)                   = 992168
+0:The total amount of wall time                        = 298.397007
+0:The maximum resident set size (KB)                   = 992100
 
 Test 089 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_unified_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_unified_ugwp_debug
 Checking test 090 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 298.680705
-0:The maximum resident set size (KB)                   = 994208
+0:The total amount of wall time                        = 299.615985
+0:The maximum resident set size (KB)                   = 994224
 
 Test 090 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_lndp_debug
 Checking test 091 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 295.846692
-0:The maximum resident set size (KB)                   = 994080
+0:The total amount of wall time                        = 295.901984
+0:The maximum resident set size (KB)                   = 994312
 
 Test 091 rap_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_flake_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_flake_debug
 Checking test 092 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 293.882049
-0:The maximum resident set size (KB)                   = 993392
+0:The total amount of wall time                        = 293.778895
+0:The maximum resident set size (KB)                   = 993408
 
 Test 092 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 293.770798
-0:The maximum resident set size (KB)                   = 993364
+0:The total amount of wall time                        = 294.153070
+0:The maximum resident set size (KB)                   = 993372
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_noah_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_noah_debug
 Checking test 094 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.849246
-0:The maximum resident set size (KB)                   = 993276
+0:The total amount of wall time                        = 286.999854
+0:The maximum resident set size (KB)                   = 993232
 
 Test 094 rap_noah_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_rrtmgp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_rrtmgp_debug
 Checking test 095 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 490.154040
-0:The maximum resident set size (KB)                   = 1122712
+0:The total amount of wall time                        = 491.567135
+0:The maximum resident set size (KB)                   = 1122632
 
 Test 095 rap_rrtmgp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_sfcdiff_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_sfcdiff_debug
 Checking test 096 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 293.291557
-0:The maximum resident set size (KB)                   = 994584
+0:The total amount of wall time                        = 293.408913
+0:The maximum resident set size (KB)                   = 994600
 
 Test 096 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 097 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 477.880413
-0:The maximum resident set size (KB)                   = 992616
+0:The total amount of wall time                        = 478.691280
+0:The maximum resident set size (KB)                   = 992344
 
 Test 097 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rrfs_v1beta_debug
 Checking test 098 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.584577
-0:The maximum resident set size (KB)                   = 989804
+0:The total amount of wall time                        = 288.416142
+0:The maximum resident set size (KB)                   = 989864
 
 Test 098 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_wam_debug
 Checking test 099 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 296.627961
-0:The maximum resident set size (KB)                   = 241440
+0:The total amount of wall time                        = 296.301428
+0:The maximum resident set size (KB)                   = 241468
 
 Test 099 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 100 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3307,14 +3307,14 @@ Checking test 100 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 300.327028
-0:The maximum resident set size (KB)                   = 850808
+0:The total amount of wall time                        = 301.442677
+0:The maximum resident set size (KB)                   = 850900
 
 Test 100 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_control_dyn32_phy32
 Checking test 101 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3361,14 +3361,14 @@ Checking test 101 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 385.283595
-0:The maximum resident set size (KB)                   = 710632
+0:The total amount of wall time                        = 386.812055
+0:The maximum resident set size (KB)                   = 710600
 
 Test 101 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_dyn32_phy32
 Checking test 102 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3415,14 +3415,14 @@ Checking test 102 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 200.280372
-0:The maximum resident set size (KB)                   = 709176
+0:The total amount of wall time                        = 205.382959
+0:The maximum resident set size (KB)                   = 709236
 
 Test 102 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_2threads_dyn32_phy32
 Checking test 103 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3469,14 +3469,14 @@ Checking test 103 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 373.320067
-0:The maximum resident set size (KB)                   = 760660
+0:The total amount of wall time                        = 374.791455
+0:The maximum resident set size (KB)                   = 760616
 
 Test 103 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_2threads_dyn32_phy32
 Checking test 104 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3523,14 +3523,14 @@ Checking test 104 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 200.591598
-0:The maximum resident set size (KB)                   = 762880
+0:The total amount of wall time                        = 200.727906
+0:The maximum resident set size (KB)                   = 762848
 
 Test 104 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_decomp_dyn32_phy32
 Checking test 105 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3577,14 +3577,14 @@ Checking test 105 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 214.348172
-0:The maximum resident set size (KB)                   = 708228
+0:The total amount of wall time                        = 215.045816
+0:The maximum resident set size (KB)                   = 708216
 
 Test 105 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_restart_dyn32_phy32
 Checking test 106 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3623,14 +3623,14 @@ Checking test 106 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 290.041251
-0:The maximum resident set size (KB)                   = 547956
+0:The total amount of wall time                        = 291.241323
+0:The maximum resident set size (KB)                   = 547552
 
 Test 106 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_restart_dyn32_phy32
 Checking test 107 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3669,21 +3669,21 @@ Checking test 107 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 104.718515
-0:The maximum resident set size (KB)                   = 543808
+0:The total amount of wall time                        = 104.749187
+0:The maximum resident set size (KB)                   = 543764
 
 Test 107 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn64_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_control_dyn64_phy32
 Checking test 108 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3723,81 +3723,81 @@ Checking test 108 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 267.506059
-0:The maximum resident set size (KB)                   = 731932
+0:The total amount of wall time                        = 268.337359
+0:The maximum resident set size (KB)                   = 731908
 
 Test 108 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_control_debug_dyn32_phy32
 Checking test 109 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.373825
-0:The maximum resident set size (KB)                   = 879888
+0:The total amount of wall time                        = 289.943365
+0:The maximum resident set size (KB)                   = 879852
 
 Test 109 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hrrr_control_debug_dyn32_phy32
 Checking test 110 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.560657
-0:The maximum resident set size (KB)                   = 878664
+0:The total amount of wall time                        = 285.480165
+0:The maximum resident set size (KB)                   = 878600
 
 Test 110 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/rap_control_dyn64_phy32_debug
 Checking test 111 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.827326
-0:The maximum resident set size (KB)                   = 896728
+0:The total amount of wall time                        = 292.614245
+0:The maximum resident set size (KB)                   = 896656
 
 Test 111 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_atm
 Checking test 112 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 247.525256
-0:The maximum resident set size (KB)                   = 713268
+0:The total amount of wall time                        = 248.041402
+0:The maximum resident set size (KB)                   = 712312
 
 Test 112 hafs_regional_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_atm_thompson_gfdlsf
 Checking test 113 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 277.946939
-0:The maximum resident set size (KB)                   = 1075664
+0:The total amount of wall time                        = 289.879405
+0:The maximum resident set size (KB)                   = 1075752
 
 Test 113 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_atm_ocn
 Checking test 114 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3806,14 +3806,14 @@ Checking test 114 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 442.681891
-0:The maximum resident set size (KB)                   = 720928
+0:The total amount of wall time                        = 445.006283
+0:The maximum resident set size (KB)                   = 720976
 
 Test 114 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_atm_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_atm_wav
 Checking test 115 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3822,14 +3822,14 @@ Checking test 115 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1057.918317
-0:The maximum resident set size (KB)                   = 751996
+0:The total amount of wall time                        = 1003.694816
+0:The maximum resident set size (KB)                   = 752160
 
 Test 115 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_atm_ocn_wav
 Checking test 116 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3840,28 +3840,28 @@ Checking test 116 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1144.051633
-0:The maximum resident set size (KB)                   = 770412
+0:The total amount of wall time                        = 1104.005227
+0:The maximum resident set size (KB)                   = 770580
 
 Test 116 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_1nest_atm
 Checking test 117 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 374.505881
-0:The maximum resident set size (KB)                   = 287760
+0:The total amount of wall time                        = 375.894538
+0:The maximum resident set size (KB)                   = 287812
 
 Test 117 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_telescopic_2nests_atm
 Checking test 118 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3870,28 +3870,28 @@ Checking test 118 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 427.111086
-0:The maximum resident set size (KB)                   = 303104
+0:The total amount of wall time                        = 427.342646
+0:The maximum resident set size (KB)                   = 301892
 
 Test 118 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_global_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_global_1nest_atm
 Checking test 119 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 171.407575
-0:The maximum resident set size (KB)                   = 205352
+0:The total amount of wall time                        = 170.042491
+0:The maximum resident set size (KB)                   = 205328
 
 Test 119 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_global_multiple_4nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_global_multiple_4nests_atm
 Checking test 120 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3909,14 +3909,14 @@ Checking test 120 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-0:The total amount of wall time                        = 485.823245
-0:The maximum resident set size (KB)                   = 292764
+0:The total amount of wall time                        = 484.897259
+0:The maximum resident set size (KB)                   = 292652
 
 Test 120 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_specified_moving_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_specified_moving_1nest_atm
 Checking test 121 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3925,28 +3925,28 @@ Checking test 121 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 238.777915
-0:The maximum resident set size (KB)                   = 306080
+0:The total amount of wall time                        = 236.587907
+0:The maximum resident set size (KB)                   = 306224
 
 Test 121 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_storm_following_1nest_atm
 Checking test 122 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 225.617280
-0:The maximum resident set size (KB)                   = 305228
+0:The total amount of wall time                        = 225.683277
+0:The maximum resident set size (KB)                   = 305612
 
 Test 122 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 123 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3955,28 +3955,28 @@ Checking test 123 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 276.306600
-0:The maximum resident set size (KB)                   = 350760
+0:The total amount of wall time                        = 278.027959
+0:The maximum resident set size (KB)                   = 350828
 
 Test 123 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_global_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_global_storm_following_1nest_atm
 Checking test 124 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 65.954148
-0:The maximum resident set size (KB)                   = 219944
+0:The total amount of wall time                        = 65.819954
+0:The maximum resident set size (KB)                   = 219936
 
 Test 124 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 125 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3987,14 +3987,14 @@ Checking test 125 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 763.993166
-0:The maximum resident set size (KB)                   = 414268
+0:The total amount of wall time                        = 754.865884
+0:The maximum resident set size (KB)                   = 414300
 
 Test 125 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_docn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_docn
 Checking test 126 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4002,14 +4002,14 @@ Checking test 126 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 371.266025
-0:The maximum resident set size (KB)                   = 738476
+0:The total amount of wall time                        = 383.212719
+0:The maximum resident set size (KB)                   = 738556
 
 Test 126 hafs_regional_docn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_docn_oisst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_docn_oisst
 Checking test 127 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4017,131 +4017,131 @@ Checking test 127 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 380.967943
-0:The maximum resident set size (KB)                   = 718052
+0:The total amount of wall time                        = 384.495373
+0:The maximum resident set size (KB)                   = 718072
 
 Test 127 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/hafs_regional_datm_cdeps
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/hafs_regional_datm_cdeps
 Checking test 128 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1276.925906
-0:The maximum resident set size (KB)                   = 891356
+0:The total amount of wall time                        = 1277.572913
+0:The maximum resident set size (KB)                   = 891336
 
 Test 128 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_control_cfsr
 Checking test 129 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.387339
-0:The maximum resident set size (KB)                   = 720292
+0:The total amount of wall time                        = 167.926954
+0:The maximum resident set size (KB)                   = 720296
 
 Test 129 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_restart_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_restart_cfsr
 Checking test 130 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 101.368178
-0:The maximum resident set size (KB)                   = 708396
+0:The total amount of wall time                        = 100.849163
+0:The maximum resident set size (KB)                   = 719588
 
 Test 130 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_control_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_control_gefs
 Checking test 131 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.239811
-0:The maximum resident set size (KB)                   = 610916
+0:The total amount of wall time                        = 161.225092
+0:The maximum resident set size (KB)                   = 610936
 
 Test 131 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_iau_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_iau_gefs
 Checking test 132 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.469568
-0:The maximum resident set size (KB)                   = 610968
+0:The total amount of wall time                        = 165.038890
+0:The maximum resident set size (KB)                   = 610912
 
 Test 132 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_stochy_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_stochy_gefs
 Checking test 133 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 164.571000
-0:The maximum resident set size (KB)                   = 610932
+0:The total amount of wall time                        = 165.213084
+0:The maximum resident set size (KB)                   = 610948
 
 Test 133 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_ciceC_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_ciceC_cfsr
 Checking test 134 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.453058
-0:The maximum resident set size (KB)                   = 731380
+0:The total amount of wall time                        = 163.687119
+0:The maximum resident set size (KB)                   = 731384
 
 Test 134 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_bulk_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_bulk_cfsr
 Checking test 135 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 162.892983
-0:The maximum resident set size (KB)                   = 720768
+0:The total amount of wall time                        = 169.397945
+0:The maximum resident set size (KB)                   = 720316
 
 Test 135 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_bulk_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_bulk_gefs
 Checking test 136 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.843397
-0:The maximum resident set size (KB)                   = 611104
+0:The total amount of wall time                        = 162.816861
+0:The maximum resident set size (KB)                   = 610952
 
 Test 136 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_mx025_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_mx025_cfsr
 Checking test 137 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4150,14 +4150,14 @@ Checking test 137 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 421.268456
-0:The maximum resident set size (KB)                   = 518136
+0:The total amount of wall time                        = 422.887669
+0:The maximum resident set size (KB)                   = 518636
 
 Test 137 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_mx025_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_mx025_gefs
 Checking test 138 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4166,64 +4166,64 @@ Checking test 138 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 421.427548
-0:The maximum resident set size (KB)                   = 498744
+0:The total amount of wall time                        = 428.916424
+0:The maximum resident set size (KB)                   = 498272
 
 Test 138 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_multiple_files_cfsr
 Checking test 139 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.912198
-0:The maximum resident set size (KB)                   = 720816
+0:The total amount of wall time                        = 167.925076
+0:The maximum resident set size (KB)                   = 731388
 
 Test 139 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_3072x1536_cfsr
 Checking test 140 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 255.333264
-0:The maximum resident set size (KB)                   = 1945680
+0:The total amount of wall time                        = 255.192272
+0:The maximum resident set size (KB)                   = 1945596
 
 Test 140 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_gfs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_gfs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_gfs
 Checking test 141 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 254.867176
-0:The maximum resident set size (KB)                   = 1944912
+0:The total amount of wall time                        = 255.776671
+0:The maximum resident set size (KB)                   = 1944944
 
 Test 141 datm_cdeps_gfs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_debug_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_debug_cfsr
 Checking test 142 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 459.704482
-0:The maximum resident set size (KB)                   = 710148
+0:The total amount of wall time                        = 459.420026
+0:The maximum resident set size (KB)                   = 710328
 
 Test 142 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_lnd_gswp3
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_lnd_gswp3
 Checking test 143 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4232,14 +4232,14 @@ Checking test 143 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 10.954551
-0:The maximum resident set size (KB)                   = 212224
+0:The total amount of wall time                        = 10.976950
+0:The maximum resident set size (KB)                   = 220368
 
 Test 143 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/datm_cdeps_lnd_gswp3_rst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/datm_cdeps_lnd_gswp3_rst
 Checking test 144 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4248,33 +4248,33 @@ Checking test 144 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 15.723488
-0:The maximum resident set size (KB)                   = 212236
+0:The total amount of wall time                        = 16.210821
+0:The maximum resident set size (KB)                   = 212200
 
 Test 144 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_atmlnd_sbs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_p8_atmlnd_sbs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_p8_atmlnd_sbs
 Checking test 145 control_p8_atmlnd_sbs results ....
- Comparing sfcf000.tile1.nc ............ALT CHECK......OK
- Comparing sfcf000.tile2.nc ............ALT CHECK......OK
- Comparing sfcf000.tile3.nc ............ALT CHECK......OK
- Comparing sfcf000.tile4.nc ............ALT CHECK......OK
- Comparing sfcf000.tile5.nc ............ALT CHECK......OK
- Comparing sfcf000.tile6.nc ............ALT CHECK......OK
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf000.tile1.nc .........OK
  Comparing atmf000.tile2.nc .........OK
  Comparing atmf000.tile3.nc .........OK
@@ -4340,14 +4340,14 @@ Checking test 145 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-0:The total amount of wall time                        = 232.478157
+0:The total amount of wall time                        = 229.400439
 0:The maximum resident set size (KB)                   = 1466268
 
 Test 145 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/control_atmwav
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/control_atmwav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/control_atmwav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/control_atmwav
 Checking test 146 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4391,14 +4391,14 @@ Checking test 146 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 99.069539
-0:The maximum resident set size (KB)                   = 482016
+0:The total amount of wall time                        = 99.340703
+0:The maximum resident set size (KB)                   = 481940
 
 Test 146 control_atmwav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/atmaero_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/atmaero_control_p8
 Checking test 147 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4442,14 +4442,14 @@ Checking test 147 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 248.584751
-0:The maximum resident set size (KB)                   = 2706736
+0:The total amount of wall time                        = 251.687684
+0:The maximum resident set size (KB)                   = 2706676
 
 Test 147 atmaero_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/atmaero_control_p8_rad
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/atmaero_control_p8_rad
 Checking test 148 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4493,14 +4493,14 @@ Checking test 148 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 305.245905
-0:The maximum resident set size (KB)                   = 2761904
+0:The total amount of wall time                        = 299.885846
+0:The maximum resident set size (KB)                   = 2761972
 
 Test 148 atmaero_control_p8_rad PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad_micro
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/atmaero_control_p8_rad_micro
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/atmaero_control_p8_rad_micro
 Checking test 149 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4544,21 +4544,21 @@ Checking test 149 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 308.071736
-0:The maximum resident set size (KB)                   = 2767328
+0:The total amount of wall time                        = 305.586800
+0:The maximum resident set size (KB)                   = 2767232
 
 Test 149 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_atmaq
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_35450/regional_atmaq
 Checking test 150 regional_atmaq results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf003.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf003.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4567,19 +4567,31 @@ Checking test 150 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 971.222229
-0:The maximum resident set size (KB)                   = 1143432
+0:The total amount of wall time                        = 980.940564
+0:The maximum resident set size (KB)                   = 1143268
 
 Test 150 regional_atmaq PASS
 
+Test 151 regional_atmaq_debug FAIL
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_57225/regional_atmaq_debug
-Checking test 151 regional_atmaq_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+FAILED TESTS: 
+Test regional_atmaq_debug 151 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Thu Jan 26 19:40:13 MST 2023
+Elapsed time: 01h:40m:52s. Have a nice day!
+Thu Jan 26 20:32:52 MST 2023
+Start Regression test
+
+Compile 001 elapsed time 280 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq_debug
+working dir  = /glade/scratch/jongkim/rt-1582-intel/jongkim/FV3_RT/rt_3795/regional_atmaq_debug
+Checking test 001 regional_atmaq_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4588,12 +4600,12 @@ Checking test 151 regional_atmaq_debug results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 1803.138964
-0:The maximum resident set size (KB)                   = 1183344
+0:The total amount of wall time                        = 1815.998299
+0:The maximum resident set size (KB)                   = 1183340
 
-Test 151 regional_atmaq_debug PASS
+Test 001 regional_atmaq_debug PASS Tries: 2
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 25 19:26:15 MST 2023
-Elapsed time: 01h:12m:00s. Have a nice day!
+Thu Jan 26 21:45:26 MST 2023
+Elapsed time: 01h:12m:34s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,37 +1,37 @@
-Wed Jan 25 18:58:43 EST 2023
+Thu Jan 26 18:51:07 EST 2023
 Start Regression test
 
-Compile 001 elapsed time 893 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 872 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 839 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 316 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 277 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 787 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 738 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 714 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 726 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 722 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 657 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 241 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 674 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 622 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 200 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 743 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 878 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 860 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 827 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 302 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 260 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 763 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 749 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 732 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 715 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 664 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 658 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 233 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 640 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 631 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 851 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 019 elapsed time 893 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 717 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 271 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 022 elapsed time 197 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 023 elapsed time 97 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 715 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 695 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 709 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 658 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 205 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 763 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 261 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 022 elapsed time 152 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 023 elapsed time 93 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 732 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 667 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 665 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 648 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 194 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8_mixedmode
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_p8_mixedmode
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -96,33 +96,33 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 322.880840
-  0: The maximum resident set size (KB)                   = 1567292
+  0: The total amount of wall time                        = 327.202063
+  0: The maximum resident set size (KB)                   = 1567476
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_gfsv17
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_gfsv17
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_gfsv17
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -167,33 +167,33 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 239.277612
-  0: The maximum resident set size (KB)                   = 1455560
+  0: The total amount of wall time                        = 237.061071
+  0: The maximum resident set size (KB)                   = 1455760
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -239,21 +239,21 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 373.204721
-  0: The maximum resident set size (KB)                   = 1600924
+  0: The total amount of wall time                        = 376.789455
+  0: The maximum resident set size (KB)                   = 1582944
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -299,21 +299,21 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 214.134064
-  0: The maximum resident set size (KB)                   = 1022576
+  0: The total amount of wall time                        = 211.172549
+  0: The maximum resident set size (KB)                   = 1022472
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_2threads_p8
 Checking test 005 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -359,21 +359,21 @@ Checking test 005 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 385.958280
-  0: The maximum resident set size (KB)                   = 1792260
+  0: The total amount of wall time                        = 390.995188
+  0: The maximum resident set size (KB)                   = 1790908
 
 Test 005 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_esmfthreads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_esmfthreads_p8
 Checking test 006 cpld_esmfthreads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -419,21 +419,21 @@ Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 388.310583
-  0: The maximum resident set size (KB)                   = 1776568
+  0: The total amount of wall time                        = 390.268559
+  0: The maximum resident set size (KB)                   = 1791684
 
 Test 006 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -479,21 +479,21 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 373.911216
-  0: The maximum resident set size (KB)                   = 1579212
+  0: The total amount of wall time                        = 369.446496
+  0: The maximum resident set size (KB)                   = 1593372
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -539,33 +539,33 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 315.744437
-  0: The maximum resident set size (KB)                   = 1544184
+  0: The total amount of wall time                        = 312.924150
+  0: The maximum resident set size (KB)                   = 1544332
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_ciceC_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_ciceC_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -611,21 +611,21 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 370.852800
-  0: The maximum resident set size (KB)                   = 1585992
+  0: The total amount of wall time                        = 374.668674
+  0: The maximum resident set size (KB)                   = 1600056
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -671,21 +671,21 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 737.285769
-  0: The maximum resident set size (KB)                   = 1779568
+  0: The total amount of wall time                        = 739.983509
+  0: The maximum resident set size (KB)                   = 1775324
 
 Test 010 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_restart_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -731,17 +731,17 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 516.700728
-  0: The maximum resident set size (KB)                   = 1929528
+  0: The total amount of wall time                        = 468.747040
+  0: The maximum resident set size (KB)                   = 1933236
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_bmark_p8
 Checking test 012 cpld_bmark_p8 results ....
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing GFSFLX.GrbF06 .........OK
  Comparing GFSPRS.GrbF06 .........OK
  Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
@@ -786,17 +786,17 @@ Checking test 012 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 753.796466
-   0: The maximum resident set size (KB)                   = 2520244
+   0: The total amount of wall time                        = 779.131583
+   0: The maximum resident set size (KB)                   = 2536668
 
 Test 012 cpld_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_restart_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_restart_bmark_p8
 Checking test 013 cpld_restart_bmark_p8 results ....
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing GFSFLX.GrbF06 .........OK
  Comparing GFSPRS.GrbF06 .........OK
  Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
@@ -841,33 +841,33 @@ Checking test 013 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 579.493003
-   0: The maximum resident set size (KB)                   = 2337600
+   0: The total amount of wall time                        = 447.471403
+   0: The maximum resident set size (KB)                   = 2337148
 
 Test 013 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_noaero_p8
 Checking test 014 cpld_control_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -912,33 +912,33 @@ Checking test 014 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 281.344714
-  0: The maximum resident set size (KB)                   = 1440548
+  0: The total amount of wall time                        = 278.311976
+  0: The maximum resident set size (KB)                   = 1466696
 
 Test 014 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_nowave_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_nowave_noaero_p8
 Checking test 015 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -981,21 +981,21 @@ Checking test 015 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 287.195201
-  0: The maximum resident set size (KB)                   = 1487744
+  0: The total amount of wall time                        = 287.792904
+  0: The maximum resident set size (KB)                   = 1501552
 
 Test 015 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_debug_p8
 Checking test 016 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1041,21 +1041,21 @@ Checking test 016 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 580.604431
-  0: The maximum resident set size (KB)                   = 1633084
+  0: The total amount of wall time                        = 580.646648
+  0: The maximum resident set size (KB)                   = 1625900
 
 Test 016 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_debug_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_noaero_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_debug_noaero_p8
 Checking test 017 cpld_debug_noaero_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1100,33 +1100,33 @@ Checking test 017 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 395.833728
-  0: The maximum resident set size (KB)                   = 1488100
+  0: The total amount of wall time                        = 399.154565
+  0: The maximum resident set size (KB)                   = 1464004
 
 Test 017 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_noaero_p8_agrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_noaero_p8_agrid
 Checking test 018 cpld_control_noaero_p8_agrid results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1169,21 +1169,21 @@ Checking test 018 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 296.373194
-  0: The maximum resident set size (KB)                   = 1490328
+  0: The total amount of wall time                        = 293.615646
+  0: The maximum resident set size (KB)                   = 1490780
 
 Test 018 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_control_c48
 Checking test 019 cpld_control_c48 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1226,21 +1226,21 @@ Checking test 019 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 599.101464
- 0: The maximum resident set size (KB)                   = 2556656
+ 0: The total amount of wall time                        = 600.814787
+ 0: The maximum resident set size (KB)                   = 2568784
 
 Test 019 cpld_control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_warmstart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_warmstart_c48
 Checking test 020 cpld_warmstart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1283,21 +1283,21 @@ Checking test 020 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 159.183199
- 0: The maximum resident set size (KB)                   = 2569592
+ 0: The total amount of wall time                        = 159.696807
+ 0: The maximum resident set size (KB)                   = 2569676
 
 Test 020 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/cpld_restart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/cpld_restart_c48
 Checking test 021 cpld_restart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1340,14 +1340,14 @@ Checking test 021 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 83.326568
- 0: The maximum resident set size (KB)                   = 1991396
+ 0: The total amount of wall time                        = 83.421066
+ 0: The maximum resident set size (KB)                   = 1991164
 
 Test 021 cpld_restart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1374,28 +1374,28 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 137.065837
-  0: The maximum resident set size (KB)                   = 437396
+  0: The total amount of wall time                        = 138.092815
+  0: The maximum resident set size (KB)                   = 437344
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_CubedSphereGrid_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_CubedSphereGrid_parallel
 Checking test 023 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 137.453074
-  0: The maximum resident set size (KB)                   = 437444
+  0: The total amount of wall time                        = 143.614643
+  0: The maximum resident set size (KB)                   = 437328
 
 Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_latlon
 Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1406,14 +1406,14 @@ Checking test 024 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.725498
-  0: The maximum resident set size (KB)                   = 436560
+  0: The total amount of wall time                        = 140.627594
+  0: The maximum resident set size (KB)                   = 436460
 
 Test 024 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_wrtGauss_netcdf_parallel
 Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1424,14 +1424,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 151.237360
-  0: The maximum resident set size (KB)                   = 436520
+  0: The total amount of wall time                        = 148.330659
+  0: The maximum resident set size (KB)                   = 436660
 
 Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_c48
 Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1470,14 +1470,14 @@ Checking test 026 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 423.342205
-0: The maximum resident set size (KB)                   = 629820
+0: The total amount of wall time                        = 420.307312
+0: The maximum resident set size (KB)                   = 631012
 
 Test 026 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c192
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_c192
 Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 027 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 571.922777
-  0: The maximum resident set size (KB)                   = 541456
+  0: The total amount of wall time                        = 590.521691
+  0: The maximum resident set size (KB)                   = 541616
 
 Test 027 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_c384
 Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1506,14 +1506,14 @@ Checking test 028 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1080.582665
-  0: The maximum resident set size (KB)                   = 805388
+  0: The total amount of wall time                        = 1090.580407
+  0: The maximum resident set size (KB)                   = 805740
 
 Test 028 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_c384gdas
 Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1556,14 +1556,14 @@ Checking test 029 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 894.186298
-  0: The maximum resident set size (KB)                   = 923456
+  0: The total amount of wall time                        = 889.975006
+  0: The maximum resident set size (KB)                   = 923660
 
 Test 029 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_stochy
 Checking test 030 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1574,28 +1574,28 @@ Checking test 030 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 96.698634
-  0: The maximum resident set size (KB)                   = 439608
+  0: The total amount of wall time                        = 97.261054
+  0: The maximum resident set size (KB)                   = 439500
 
 Test 030 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_stochy_restart
 Checking test 031 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 52.105410
-  0: The maximum resident set size (KB)                   = 192128
+  0: The total amount of wall time                        = 54.435505
+  0: The maximum resident set size (KB)                   = 186640
 
 Test 031 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_lndp
 Checking test 032 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1606,14 +1606,14 @@ Checking test 032 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 85.114902
-  0: The maximum resident set size (KB)                   = 440216
+  0: The total amount of wall time                        = 89.419807
+  0: The maximum resident set size (KB)                   = 440108
 
 Test 032 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_iovr4
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_iovr4
 Checking test 033 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1628,14 +1628,14 @@ Checking test 033 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 146.014833
-  0: The maximum resident set size (KB)                   = 436680
+  0: The total amount of wall time                        = 144.025763
+  0: The maximum resident set size (KB)                   = 436500
 
 Test 033 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_iovr5
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_iovr5
 Checking test 034 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1650,14 +1650,14 @@ Checking test 034 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.238927
-  0: The maximum resident set size (KB)                   = 436524
+  0: The total amount of wall time                        = 144.625524
+  0: The maximum resident set size (KB)                   = 436620
 
 Test 034 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_p8
 Checking test 035 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1704,14 +1704,14 @@ Checking test 035 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.002184
-  0: The maximum resident set size (KB)                   = 1379780
+  0: The total amount of wall time                        = 175.025837
+  0: The maximum resident set size (KB)                   = 1379716
 
 Test 035 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_p8_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_p8_lndp
 Checking test 036 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1730,14 +1730,14 @@ Checking test 036 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 326.147210
-  0: The maximum resident set size (KB)                   = 1379952
+  0: The total amount of wall time                        = 335.858875
+  0: The maximum resident set size (KB)                   = 1379776
 
 Test 036 control_p8_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_restart_p8
 Checking test 037 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1776,14 +1776,14 @@ Checking test 037 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 91.041568
-  0: The maximum resident set size (KB)                   = 549396
+  0: The total amount of wall time                        = 91.640971
+  0: The maximum resident set size (KB)                   = 549628
 
 Test 037 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_decomp_p8
 Checking test 038 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1826,14 +1826,14 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.312487
-  0: The maximum resident set size (KB)                   = 1397356
+  0: The total amount of wall time                        = 181.165185
+  0: The maximum resident set size (KB)                   = 1373364
 
 Test 038 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_2threads_p8
 Checking test 039 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1876,14 +1876,14 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.144506
-  0: The maximum resident set size (KB)                   = 1458520
+  0: The total amount of wall time                        = 171.403984
+  0: The maximum resident set size (KB)                   = 1483388
 
 Test 039 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_p8_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_p8_rrtmgp
 Checking test 040 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1930,14 +1930,14 @@ Checking test 040 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.950543
-  0: The maximum resident set size (KB)                   = 1518908
+  0: The total amount of wall time                        = 235.200782
+  0: The maximum resident set size (KB)                   = 1518856
 
 Test 040 control_p8_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/merra2_thompson
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/merra2_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/merra2_thompson
 Checking test 041 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1984,14 +1984,14 @@ Checking test 041 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 202.287935
-  0: The maximum resident set size (KB)                   = 1407312
+  0: The total amount of wall time                        = 199.692468
+  0: The maximum resident set size (KB)                   = 1407408
 
 Test 041 merra2_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_control
 Checking test 042 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2002,28 +2002,28 @@ Checking test 042 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 329.083558
-  0: The maximum resident set size (KB)                   = 575408
+  0: The total amount of wall time                        = 330.553230
+  0: The maximum resident set size (KB)                   = 575504
 
 Test 042 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_restart
 Checking test 043 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 166.558161
-  0: The maximum resident set size (KB)                   = 575104
+  0: The total amount of wall time                        = 168.906453
+  0: The maximum resident set size (KB)                   = 575688
 
 Test 043 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_decomp
 Checking test 044 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2034,14 +2034,14 @@ Checking test 044 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 344.700032
-  0: The maximum resident set size (KB)                   = 575716
+  0: The total amount of wall time                        = 345.752716
+  0: The maximum resident set size (KB)                   = 575812
 
 Test 044 regional_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_2threads
 Checking test 045 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2052,14 +2052,14 @@ Checking test 045 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 198.623911
-  0: The maximum resident set size (KB)                   = 576372
+  0: The total amount of wall time                        = 199.145749
+  0: The maximum resident set size (KB)                   = 576732
 
 Test 045 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_noquilt
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_noquilt
 Checking test 046 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2067,28 +2067,28 @@ Checking test 046 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 356.928680
-  0: The maximum resident set size (KB)                   = 569772
+  0: The total amount of wall time                        = 359.341623
+  0: The maximum resident set size (KB)                   = 585272
 
 Test 046 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_netcdf_parallel
 Checking test 047 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 332.657556
-  0: The maximum resident set size (KB)                   = 570144
+  0: The total amount of wall time                        = 330.375361
+  0: The maximum resident set size (KB)                   = 569944
 
 Test 047 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_2dwrtdecomp
 Checking test 048 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 048 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 329.528368
-  0: The maximum resident set size (KB)                   = 575488
+  0: The total amount of wall time                        = 329.899896
+  0: The maximum resident set size (KB)                   = 575496
 
 Test 048 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/fv3_regional_wofs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_wofs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_wofs
 Checking test 049 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2117,14 +2117,14 @@ Checking test 049 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 414.743507
-  0: The maximum resident set size (KB)                   = 257308
+  0: The total amount of wall time                        = 422.555289
+  0: The maximum resident set size (KB)                   = 257160
 
 Test 049 regional_wofs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_control
 Checking test 050 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2171,14 +2171,14 @@ Checking test 050 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 473.857698
-  0: The maximum resident set size (KB)                   = 807516
+  0: The total amount of wall time                        = 472.189687
+  0: The maximum resident set size (KB)                   = 807456
 
 Test 050 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_rrtmgp
 Checking test 051 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2225,14 +2225,14 @@ Checking test 051 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 521.588219
-  0: The maximum resident set size (KB)                   = 925300
+  0: The total amount of wall time                        = 523.754176
+  0: The maximum resident set size (KB)                   = 925332
 
 Test 051 rap_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_spp_sppt_shum_skeb
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_spp_sppt_shum_skeb
 Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2243,14 +2243,14 @@ Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 320.309623
-  0: The maximum resident set size (KB)                   = 887380
+  0: The total amount of wall time                        = 321.822816
+  0: The maximum resident set size (KB)                   = 887316
 
 Test 052 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_decomp
 Checking test 053 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2297,14 +2297,14 @@ Checking test 053 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 498.965776
-  0: The maximum resident set size (KB)                   = 807004
+  0: The total amount of wall time                        = 498.982741
+  0: The maximum resident set size (KB)                   = 806964
 
 Test 053 rap_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_2threads
 Checking test 054 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2351,14 +2351,14 @@ Checking test 054 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.797813
-  0: The maximum resident set size (KB)                   = 877088
+  0: The total amount of wall time                        = 456.600848
+  0: The maximum resident set size (KB)                   = 876884
 
 Test 054 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_restart
 Checking test 055 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2397,14 +2397,14 @@ Checking test 055 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 241.943921
-  0: The maximum resident set size (KB)                   = 552100
+  0: The total amount of wall time                        = 239.292476
+  0: The maximum resident set size (KB)                   = 551900
 
 Test 055 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_sfcdiff
 Checking test 056 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2451,14 +2451,14 @@ Checking test 056 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 468.048482
-  0: The maximum resident set size (KB)                   = 807452
+  0: The total amount of wall time                        = 471.625212
+  0: The maximum resident set size (KB)                   = 807348
 
 Test 056 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_sfcdiff_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_sfcdiff_decomp
 Checking test 057 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2505,14 +2505,14 @@ Checking test 057 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 499.374903
-  0: The maximum resident set size (KB)                   = 806840
+  0: The total amount of wall time                        = 493.178095
+  0: The maximum resident set size (KB)                   = 806816
 
 Test 057 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_sfcdiff_restart
 Checking test 058 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2551,14 +2551,14 @@ Checking test 058 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 351.393633
-  0: The maximum resident set size (KB)                   = 552136
+  0: The total amount of wall time                        = 352.334328
+  0: The maximum resident set size (KB)                   = 552208
 
 Test 058 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control
 Checking test 059 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2605,14 +2605,14 @@ Checking test 059 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 448.439512
-  0: The maximum resident set size (KB)                   = 807480
+  0: The total amount of wall time                        = 451.622681
+  0: The maximum resident set size (KB)                   = 807344
 
 Test 059 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_decomp
 Checking test 060 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2659,14 +2659,14 @@ Checking test 060 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 471.996466
-  0: The maximum resident set size (KB)                   = 806260
+  0: The total amount of wall time                        = 478.294127
+  0: The maximum resident set size (KB)                   = 806200
 
 Test 060 hrrr_control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_2threads
 Checking test 061 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2713,14 +2713,14 @@ Checking test 061 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 431.019239
-  0: The maximum resident set size (KB)                   = 872280
+  0: The total amount of wall time                        = 428.809516
+  0: The maximum resident set size (KB)                   = 868780
 
 Test 061 hrrr_control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_restart
 Checking test 062 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2759,14 +2759,14 @@ Checking test 062 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 338.856932
-  0: The maximum resident set size (KB)                   = 546848
+  0: The total amount of wall time                        = 352.038258
+  0: The maximum resident set size (KB)                   = 546748
 
 Test 062 hrrr_control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_v1beta
 Checking test 063 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2813,14 +2813,14 @@ Checking test 063 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 468.841267
-  0: The maximum resident set size (KB)                   = 803552
+  0: The total amount of wall time                        = 460.857048
+  0: The maximum resident set size (KB)                   = 803632
 
 Test 063 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_v1nssl
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_v1nssl
 Checking test 064 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2835,14 +2835,14 @@ Checking test 064 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 571.700286
-  0: The maximum resident set size (KB)                   = 491760
+  0: The total amount of wall time                        = 566.551459
+  0: The maximum resident set size (KB)                   = 491932
 
 Test 064 rrfs_v1nssl PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_v1nssl_nohailnoccn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_v1nssl_nohailnoccn
 Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2857,14 +2857,14 @@ Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 564.090525
-  0: The maximum resident set size (KB)                   = 486320
+  0: The total amount of wall time                        = 548.021810
+  0: The maximum resident set size (KB)                   = 486212
 
 Test 065 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_conus13km_hrrr_warm
 Checking test 066 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2873,14 +2873,14 @@ Checking test 066 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 127.271949
-  0: The maximum resident set size (KB)                   = 616904
+  0: The total amount of wall time                        = 126.846750
+  0: The maximum resident set size (KB)                   = 616456
 
 Test 066 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_smoke_conus13km_hrrr_warm
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2889,14 +2889,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 142.737537
-  0: The maximum resident set size (KB)                   = 627644
+  0: The total amount of wall time                        = 142.227918
+  0: The maximum resident set size (KB)                   = 627640
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_conus13km_radar_tten_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_conus13km_radar_tten_warm
 Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2905,14 +2905,14 @@ Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 128.407739
-  0: The maximum resident set size (KB)                   = 620352
+  0: The total amount of wall time                        = 129.977773
+  0: The maximum resident set size (KB)                   = 619984
 
 Test 068 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_conus13km_hrrr_warm_2threads
 Checking test 069 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2921,14 +2921,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 83.466147
-  0: The maximum resident set size (KB)                   = 629332
+  0: The total amount of wall time                        = 84.765663
+  0: The maximum resident set size (KB)                   = 629084
 
 Test 069 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 070 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2937,90 +2937,90 @@ Checking test 070 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 84.452683
-  0: The maximum resident set size (KB)                   = 632792
+  0: The total amount of wall time                        = 86.035030
+  0: The maximum resident set size (KB)                   = 632672
 
 Test 070 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_csawmgt
 Checking test 071 control_csawmgt results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 380.938535
-  0: The maximum resident set size (KB)                   = 505520
+  0: The total amount of wall time                        = 372.487943
+  0: The maximum resident set size (KB)                   = 505352
 
 Test 071 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_ras
 Checking test 072 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.687889
-  0: The maximum resident set size (KB)                   = 471568
+  0: The total amount of wall time                        = 195.243491
+  0: The maximum resident set size (KB)                   = 471664
 
 Test 072 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_wam
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_wam
 Checking test 073 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 134.535338
-  0: The maximum resident set size (KB)                   = 186348
+  0: The total amount of wall time                        = 125.734249
+  0: The maximum resident set size (KB)                   = 186456
 
 Test 073 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_conus13km_hrrr_warm_debug
 Checking test 074 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 755.617556
-  0: The maximum resident set size (KB)                   = 645836
+  0: The total amount of wall time                        = 759.431983
+  0: The maximum resident set size (KB)                   = 645788
 
 Test 074 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_conus13km_radar_tten_warm_debug
 Checking test 075 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 756.364071
-  0: The maximum resident set size (KB)                   = 648636
+  0: The total amount of wall time                        = 756.452592
+  0: The maximum resident set size (KB)                   = 648688
 
 Test 075 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_CubedSphereGrid_debug
 Checking test 076 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3047,348 +3047,348 @@ Checking test 076 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 162.000577
-  0: The maximum resident set size (KB)                   = 601200
+  0: The total amount of wall time                        = 162.557735
+  0: The maximum resident set size (KB)                   = 601176
 
 Test 076 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_wrtGauss_netcdf_parallel_debug
 Checking test 077 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.071606
-  0: The maximum resident set size (KB)                   = 601472
+  0: The total amount of wall time                        = 163.558068
+  0: The maximum resident set size (KB)                   = 601524
 
 Test 077 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_stochy_debug
 Checking test 078 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.377322
-  0: The maximum resident set size (KB)                   = 608512
+  0: The total amount of wall time                        = 173.885616
+  0: The maximum resident set size (KB)                   = 608508
 
 Test 078 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_lndp_debug
 Checking test 079 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.691392
-  0: The maximum resident set size (KB)                   = 605760
+  0: The total amount of wall time                        = 156.565072
+  0: The maximum resident set size (KB)                   = 605800
 
 Test 079 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_csawmg_debug
 Checking test 080 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 247.053144
-  0: The maximum resident set size (KB)                   = 642484
+  0: The total amount of wall time                        = 245.428689
+  0: The maximum resident set size (KB)                   = 642412
 
 Test 080 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_csawmgt_debug
 Checking test 081 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 243.693528
-  0: The maximum resident set size (KB)                   = 642560
+  0: The total amount of wall time                        = 241.834533
+  0: The maximum resident set size (KB)                   = 642544
 
 Test 081 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_ras_debug
 Checking test 082 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.976278
-  0: The maximum resident set size (KB)                   = 614008
+  0: The total amount of wall time                        = 158.130019
+  0: The maximum resident set size (KB)                   = 613960
 
 Test 082 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_diag_debug
 Checking test 083 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.187645
-  0: The maximum resident set size (KB)                   = 658896
+  0: The total amount of wall time                        = 160.645603
+  0: The maximum resident set size (KB)                   = 658692
 
 Test 083 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_debug_p8
 Checking test 084 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.195139
-  0: The maximum resident set size (KB)                   = 1422392
+  0: The total amount of wall time                        = 174.777854
+  0: The maximum resident set size (KB)                   = 1422336
 
 Test 084 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_debug
 Checking test 085 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1036.585486
-  0: The maximum resident set size (KB)                   = 600124
+  0: The total amount of wall time                        = 1035.395787
+  0: The maximum resident set size (KB)                   = 600040
 
 Test 085 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_control_debug
 Checking test 086 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.489368
-  0: The maximum resident set size (KB)                   = 971776
+  0: The total amount of wall time                        = 286.461614
+  0: The maximum resident set size (KB)                   = 971756
 
 Test 086 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_debug
 Checking test 087 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.349222
-  0: The maximum resident set size (KB)                   = 966568
+  0: The total amount of wall time                        = 280.426436
+  0: The maximum resident set size (KB)                   = 966400
 
 Test 087 hrrr_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_unified_drag_suite_debug
 Checking test 088 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.835671
-  0: The maximum resident set size (KB)                   = 971764
+  0: The total amount of wall time                        = 285.197903
+  0: The maximum resident set size (KB)                   = 971804
 
 Test 088 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_diag_debug
 Checking test 089 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 299.273114
-  0: The maximum resident set size (KB)                   = 1056088
+  0: The total amount of wall time                        = 302.227813
+  0: The maximum resident set size (KB)                   = 1056008
 
 Test 089 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_cires_ugwp_debug
 Checking test 090 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.842305
-  0: The maximum resident set size (KB)                   = 971044
+  0: The total amount of wall time                        = 291.043196
+  0: The maximum resident set size (KB)                   = 970980
 
 Test 090 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_unified_ugwp_debug
 Checking test 091 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.504908
-  0: The maximum resident set size (KB)                   = 973288
+  0: The total amount of wall time                        = 291.045488
+  0: The maximum resident set size (KB)                   = 973168
 
 Test 091 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_lndp_debug
 Checking test 092 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.499932
-  0: The maximum resident set size (KB)                   = 972468
+  0: The total amount of wall time                        = 288.681031
+  0: The maximum resident set size (KB)                   = 972684
 
 Test 092 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_flake_debug
 Checking test 093 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.722138
-  0: The maximum resident set size (KB)                   = 971840
+  0: The total amount of wall time                        = 285.314625
+  0: The maximum resident set size (KB)                   = 971892
 
 Test 093 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_progcld_thompson_debug
 Checking test 094 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.354923
-  0: The maximum resident set size (KB)                   = 971832
+  0: The total amount of wall time                        = 285.598238
+  0: The maximum resident set size (KB)                   = 971820
 
 Test 094 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_noah_debug
 Checking test 095 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.432637
-  0: The maximum resident set size (KB)                   = 970512
+  0: The total amount of wall time                        = 279.322577
+  0: The maximum resident set size (KB)                   = 970384
 
 Test 095 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_rrtmgp_debug
 Checking test 096 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 483.374373
-  0: The maximum resident set size (KB)                   = 1092592
+  0: The total amount of wall time                        = 482.412094
+  0: The maximum resident set size (KB)                   = 1092596
 
 Test 096 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_sfcdiff_debug
 Checking test 097 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.285257
-  0: The maximum resident set size (KB)                   = 971616
+  0: The total amount of wall time                        = 285.296309
+  0: The maximum resident set size (KB)                   = 971612
 
 Test 097 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 098 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 469.781263
-  0: The maximum resident set size (KB)                   = 970960
+  0: The total amount of wall time                        = 469.992629
+  0: The maximum resident set size (KB)                   = 970976
 
 Test 098 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rrfs_v1beta_debug
 Checking test 099 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.404172
-  0: The maximum resident set size (KB)                   = 967800
+  0: The total amount of wall time                        = 281.239460
+  0: The maximum resident set size (KB)                   = 967708
 
 Test 099 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_wam_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_wam_debug
 Checking test 100 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 291.177480
-  0: The maximum resident set size (KB)                   = 216964
+  0: The total amount of wall time                        = 290.914138
+  0: The maximum resident set size (KB)                   = 217056
 
 Test 100 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 101 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3399,14 +3399,14 @@ Checking test 101 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 298.014129
-  0: The maximum resident set size (KB)                   = 798136
+  0: The total amount of wall time                        = 310.543428
+  0: The maximum resident set size (KB)                   = 798068
 
 Test 101 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_control_dyn32_phy32
 Checking test 102 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3453,14 +3453,14 @@ Checking test 102 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 391.961288
-  0: The maximum resident set size (KB)                   = 690420
+  0: The total amount of wall time                        = 386.456104
+  0: The maximum resident set size (KB)                   = 690292
 
 Test 102 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_dyn32_phy32
 Checking test 103 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3507,14 +3507,14 @@ Checking test 103 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 206.707952
-  0: The maximum resident set size (KB)                   = 688384
+  0: The total amount of wall time                        = 210.329990
+  0: The maximum resident set size (KB)                   = 688300
 
 Test 103 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_2threads_dyn32_phy32
 Checking test 104 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3561,14 +3561,14 @@ Checking test 104 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 367.746580
-  0: The maximum resident set size (KB)                   = 740552
+  0: The total amount of wall time                        = 374.821086
+  0: The maximum resident set size (KB)                   = 740556
 
 Test 104 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_2threads_dyn32_phy32
 Checking test 105 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3615,14 +3615,14 @@ Checking test 105 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.878325
-  0: The maximum resident set size (KB)                   = 743024
+  0: The total amount of wall time                        = 198.300164
+  0: The maximum resident set size (KB)                   = 743084
 
 Test 105 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_decomp_dyn32_phy32
 Checking test 106 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3669,14 +3669,14 @@ Checking test 106 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.540886
-  0: The maximum resident set size (KB)                   = 688868
+  0: The total amount of wall time                        = 209.974391
+  0: The maximum resident set size (KB)                   = 688996
 
 Test 106 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_restart_dyn32_phy32
 Checking test 107 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3715,14 +3715,14 @@ Checking test 107 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 289.901287
-  0: The maximum resident set size (KB)                   = 524964
+  0: The total amount of wall time                        = 294.301093
+  0: The maximum resident set size (KB)                   = 525064
 
 Test 107 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_restart_dyn32_phy32
 Checking test 108 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3761,21 +3761,21 @@ Checking test 108 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 106.031922
-  0: The maximum resident set size (KB)                   = 521196
+  0: The total amount of wall time                        = 103.802192
+  0: The maximum resident set size (KB)                   = 521384
 
 Test 108 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn64_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_control_dyn64_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_control_dyn64_phy32
 Checking test 109 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3815,81 +3815,81 @@ Checking test 109 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 259.331746
-  0: The maximum resident set size (KB)                   = 711676
+  0: The total amount of wall time                        = 263.554884
+  0: The maximum resident set size (KB)                   = 711508
 
 Test 109 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_control_debug_dyn32_phy32
 Checking test 110 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.892739
-  0: The maximum resident set size (KB)                   = 857556
+  0: The total amount of wall time                        = 281.729362
+  0: The maximum resident set size (KB)                   = 857672
 
 Test 110 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hrrr_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hrrr_control_debug_dyn32_phy32
 Checking test 111 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.497684
-  0: The maximum resident set size (KB)                   = 856252
+  0: The total amount of wall time                        = 277.451315
+  0: The maximum resident set size (KB)                   = 855928
 
 Test 111 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/rap_control_dyn64_phy32_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/rap_control_dyn64_phy32_debug
 Checking test 112 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.885183
-  0: The maximum resident set size (KB)                   = 876832
+  0: The total amount of wall time                        = 286.258495
+  0: The maximum resident set size (KB)                   = 876888
 
 Test 112 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_atm
 Checking test 113 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 254.817027
-  0: The maximum resident set size (KB)                   = 653120
+  0: The total amount of wall time                        = 250.379159
+  0: The maximum resident set size (KB)                   = 652936
 
 Test 113 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_atm_thompson_gfdlsf
 Checking test 114 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 291.288707
-  0: The maximum resident set size (KB)                   = 1019532
+  0: The total amount of wall time                        = 286.365859
+  0: The maximum resident set size (KB)                   = 1016348
 
 Test 114 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_atm_ocn
 Checking test 115 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3898,14 +3898,14 @@ Checking test 115 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 427.255940
-  0: The maximum resident set size (KB)                   = 692076
+  0: The total amount of wall time                        = 420.052130
+  0: The maximum resident set size (KB)                   = 691572
 
 Test 115 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_atm_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_atm_wav
 Checking test 116 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3914,14 +3914,14 @@ Checking test 116 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 911.719343
-  0: The maximum resident set size (KB)                   = 727836
+  0: The total amount of wall time                        = 913.038703
+  0: The maximum resident set size (KB)                   = 726280
 
 Test 116 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_atm_ocn_wav
 Checking test 117 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3932,28 +3932,28 @@ Checking test 117 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1019.491863
-  0: The maximum resident set size (KB)                   = 740956
+  0: The total amount of wall time                        = 1019.495833
+  0: The maximum resident set size (KB)                   = 740572
 
 Test 117 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_1nest_atm
 Checking test 118 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 379.104736
-  0: The maximum resident set size (KB)                   = 270932
+  0: The total amount of wall time                        = 375.482183
+  0: The maximum resident set size (KB)                   = 270764
 
 Test 118 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_telescopic_2nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_telescopic_2nests_atm
 Checking test 119 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3962,28 +3962,28 @@ Checking test 119 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 431.021095
-  0: The maximum resident set size (KB)                   = 274372
+  0: The total amount of wall time                        = 420.244829
+  0: The maximum resident set size (KB)                   = 271936
 
 Test 119 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_global_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_global_1nest_atm
 Checking test 120 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 169.785941
-  0: The maximum resident set size (KB)                   = 172468
+  0: The total amount of wall time                        = 171.584989
+  0: The maximum resident set size (KB)                   = 172560
 
 Test 120 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_global_multiple_4nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_global_multiple_4nests_atm
 Checking test 121 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4001,14 +4001,14 @@ Checking test 121 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 496.628071
-  0: The maximum resident set size (KB)                   = 206304
+  0: The total amount of wall time                        = 496.011267
+  0: The maximum resident set size (KB)                   = 206896
 
 Test 121 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_specified_moving_1nest_atm
 Checking test 122 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4017,28 +4017,28 @@ Checking test 122 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 235.274320
-  0: The maximum resident set size (KB)                   = 282184
+  0: The total amount of wall time                        = 231.425564
+  0: The maximum resident set size (KB)                   = 282352
 
 Test 122 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_storm_following_1nest_atm
 Checking test 123 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 220.860233
-  0: The maximum resident set size (KB)                   = 281848
+  0: The total amount of wall time                        = 218.201952
+  0: The maximum resident set size (KB)                   = 282432
 
 Test 123 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 124 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4047,28 +4047,28 @@ Checking test 124 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 265.041829
-  0: The maximum resident set size (KB)                   = 317016
+  0: The total amount of wall time                        = 255.383547
+  0: The maximum resident set size (KB)                   = 317452
 
 Test 124 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_global_storm_following_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_global_storm_following_1nest_atm
 Checking test 125 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 66.928950
-  0: The maximum resident set size (KB)                   = 187492
+  0: The total amount of wall time                        = 65.479812
+  0: The maximum resident set size (KB)                   = 187548
 
 Test 125 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 126 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4079,14 +4079,14 @@ Checking test 126 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 739.086146
-  0: The maximum resident set size (KB)                   = 360252
+  0: The total amount of wall time                        = 730.920460
+  0: The maximum resident set size (KB)                   = 359932
 
 Test 126 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_docn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_docn
 Checking test 127 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4094,14 +4094,14 @@ Checking test 127 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 382.693697
-  0: The maximum resident set size (KB)                   = 707280
+  0: The total amount of wall time                        = 372.328373
+  0: The maximum resident set size (KB)                   = 707172
 
 Test 127 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_docn_oisst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_docn_oisst
 Checking test 128 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4109,131 +4109,131 @@ Checking test 128 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 387.620960
-  0: The maximum resident set size (KB)                   = 694940
+  0: The total amount of wall time                        = 373.003920
+  0: The maximum resident set size (KB)                   = 694752
 
 Test 128 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/hafs_regional_datm_cdeps
 Checking test 129 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1166.245772
-  0: The maximum resident set size (KB)                   = 808952
+  0: The total amount of wall time                        = 1167.093788
+  0: The maximum resident set size (KB)                   = 809004
 
 Test 129 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_control_cfsr
 Checking test 130 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 168.949473
- 0: The maximum resident set size (KB)                   = 721192
+ 0: The total amount of wall time                        = 167.605208
+ 0: The maximum resident set size (KB)                   = 721084
 
 Test 130 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_restart_cfsr
 Checking test 131 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.469633
- 0: The maximum resident set size (KB)                   = 708968
+ 0: The total amount of wall time                        = 96.112149
+ 0: The maximum resident set size (KB)                   = 715888
 
 Test 131 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_control_gefs
 Checking test 132 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.929793
- 0: The maximum resident set size (KB)                   = 601084
+ 0: The total amount of wall time                        = 160.510906
+ 0: The maximum resident set size (KB)                   = 602868
 
 Test 132 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_iau_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_iau_gefs
 Checking test 133 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 166.617941
- 0: The maximum resident set size (KB)                   = 604928
+ 0: The total amount of wall time                        = 163.053002
+ 0: The maximum resident set size (KB)                   = 601060
 
 Test 133 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_stochy_gefs
 Checking test 134 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 165.953224
- 0: The maximum resident set size (KB)                   = 603008
+ 0: The total amount of wall time                        = 162.200483
+ 0: The maximum resident set size (KB)                   = 600976
 
 Test 134 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_ciceC_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_ciceC_cfsr
 Checking test 135 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 168.681493
- 0: The maximum resident set size (KB)                   = 721184
+ 0: The total amount of wall time                        = 165.285799
+ 0: The maximum resident set size (KB)                   = 721160
 
 Test 135 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_bulk_cfsr
 Checking test 136 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 166.162372
- 0: The maximum resident set size (KB)                   = 721260
+ 0: The total amount of wall time                        = 164.300910
+ 0: The maximum resident set size (KB)                   = 721208
 
 Test 136 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_bulk_gefs
 Checking test 137 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 159.378504
- 0: The maximum resident set size (KB)                   = 603092
+ 0: The total amount of wall time                        = 158.170526
+ 0: The maximum resident set size (KB)                   = 601016
 
 Test 137 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_mx025_cfsr
 Checking test 138 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4242,14 +4242,14 @@ Checking test 138 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 424.437498
-  0: The maximum resident set size (KB)                   = 496628
+  0: The total amount of wall time                        = 419.055103
+  0: The maximum resident set size (KB)                   = 497100
 
 Test 138 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_mx025_gefs
 Checking test 139 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4258,64 +4258,64 @@ Checking test 139 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 438.337625
-  0: The maximum resident set size (KB)                   = 476368
+  0: The total amount of wall time                        = 432.151337
+  0: The maximum resident set size (KB)                   = 476092
 
 Test 139 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_multiple_files_cfsr
 Checking test 140 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 168.151312
- 0: The maximum resident set size (KB)                   = 721180
+ 0: The total amount of wall time                        = 168.649542
+ 0: The maximum resident set size (KB)                   = 721132
 
 Test 140 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_3072x1536_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_3072x1536_cfsr
 Checking test 141 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 252.776505
- 0: The maximum resident set size (KB)                   = 1947908
+ 0: The total amount of wall time                        = 250.912586
+ 0: The maximum resident set size (KB)                   = 1948464
 
 Test 141 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_gfs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_gfs
 Checking test 142 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 253.654453
- 0: The maximum resident set size (KB)                   = 1948332
+ 0: The total amount of wall time                        = 251.064541
+ 0: The maximum resident set size (KB)                   = 1948228
 
 Test 142 datm_cdeps_gfs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_debug_cfsr
 Checking test 143 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 376.587524
- 0: The maximum resident set size (KB)                   = 714760
+ 0: The total amount of wall time                        = 375.076407
+ 0: The maximum resident set size (KB)                   = 714836
 
 Test 143 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_lnd_gswp3
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_lnd_gswp3
 Checking test 144 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4324,14 +4324,14 @@ Checking test 144 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.032565
-  0: The maximum resident set size (KB)                   = 145908
+  0: The total amount of wall time                        = 16.868334
+  0: The maximum resident set size (KB)                   = 153996
 
 Test 144 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/datm_cdeps_lnd_gswp3_rst
 Checking test 145 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4340,33 +4340,33 @@ Checking test 145 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 15.675134
-  0: The maximum resident set size (KB)                   = 153936
+  0: The total amount of wall time                        = 18.489947
+  0: The maximum resident set size (KB)                   = 149960
 
 Test 145 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_atmlnd_sbs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_p8_atmlnd_sbs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_p8_atmlnd_sbs
 Checking test 146 control_p8_atmlnd_sbs results ....
- Comparing sfcf000.tile1.nc ............ALT CHECK......OK
- Comparing sfcf000.tile2.nc ............ALT CHECK......OK
- Comparing sfcf000.tile3.nc ............ALT CHECK......OK
- Comparing sfcf000.tile4.nc ............ALT CHECK......OK
- Comparing sfcf000.tile5.nc ............ALT CHECK......OK
- Comparing sfcf000.tile6.nc ............ALT CHECK......OK
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf000.tile1.nc .........OK
  Comparing atmf000.tile2.nc .........OK
  Comparing atmf000.tile3.nc .........OK
@@ -4432,14 +4432,14 @@ Checking test 146 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 247.884753
-  0: The maximum resident set size (KB)                   = 1425144
+  0: The total amount of wall time                        = 226.564899
+  0: The maximum resident set size (KB)                   = 1425264
 
 Test 146 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/control_atmwav
 Checking test 147 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4483,14 +4483,14 @@ Checking test 147 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 95.664574
-  0: The maximum resident set size (KB)                   = 450280
+  0: The total amount of wall time                        = 92.289163
+  0: The maximum resident set size (KB)                   = 450364
 
 Test 147 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/atmaero_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/atmaero_control_p8
 Checking test 148 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4534,14 +4534,14 @@ Checking test 148 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 261.020198
-  0: The maximum resident set size (KB)                   = 1478596
+  0: The total amount of wall time                        = 243.941188
+  0: The maximum resident set size (KB)                   = 1478188
 
 Test 148 atmaero_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/atmaero_control_p8_rad
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/atmaero_control_p8_rad
 Checking test 149 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4585,14 +4585,14 @@ Checking test 149 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 302.574517
-  0: The maximum resident set size (KB)                   = 1482012
+  0: The total amount of wall time                        = 295.801887
+  0: The maximum resident set size (KB)                   = 1498844
 
 Test 149 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/atmaero_control_p8_rad_micro
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/atmaero_control_p8_rad_micro
 Checking test 150 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4636,21 +4636,21 @@ Checking test 150 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 303.416278
-  0: The maximum resident set size (KB)                   = 1487220
+  0: The total amount of wall time                        = 296.979892
+  0: The maximum resident set size (KB)                   = 1503368
 
 Test 150 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_28836/regional_atmaq
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_27636/regional_atmaq
 Checking test 151 regional_atmaq results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf003.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf003.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4659,12 +4659,12 @@ Checking test 151 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 665.526029
-  0: The maximum resident set size (KB)                   = 1082052
+  0: The total amount of wall time                        = 639.433884
+  0: The maximum resident set size (KB)                   = 1082676
 
 Test 151 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 25 21:06:37 EST 2023
-Elapsed time: 02h:07m:55s. Have a nice day!
+Thu Jan 26 20:01:12 EST 2023
+Elapsed time: 01h:10m:05s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,26 +1,26 @@
-Wed Jan 25 20:17:24 UTC 2023
+Thu Jan 26 19:15:24 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 198 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 314 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 98 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 392 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 311 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 318 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 260 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 229 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 139 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 115 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 317 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 106 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 388 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 318 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 316 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 265 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 232 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 143 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 113 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_c48
 Checking test 001 control_c48 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -54,57 +54,57 @@ Checking test 001 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 685.166482
-0: The maximum resident set size (KB)                   = 700560
+0: The total amount of wall time                        = 685.644864
+0: The maximum resident set size (KB)                   = 699380
 
 Test 001 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_stochy
 Checking test 002 control_stochy results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 649.425751
-  0: The maximum resident set size (KB)                   = 479516
+  0: The total amount of wall time                        = 647.837026
+  0: The maximum resident set size (KB)                   = 477592
 
 Test 002 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_ras
 Checking test 003 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 826.155799
-  0: The maximum resident set size (KB)                   = 485548
+  0: The total amount of wall time                        = 838.202937
+  0: The maximum resident set size (KB)                   = 487552
 
 Test 003 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_p8
 Checking test 004 control_p8 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -144,14 +144,14 @@ Checking test 004 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 884.905035
-  0: The maximum resident set size (KB)                   = 1232264
+  0: The total amount of wall time                        = 888.977300
+  0: The maximum resident set size (KB)                   = 1232520
 
 Test 004 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_control
 Checking test 005 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 005 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1484.981440
-  0: The maximum resident set size (KB)                   = 832956
+  0: The total amount of wall time                        = 1438.737476
+  0: The maximum resident set size (KB)                   = 832232
 
 Test 005 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_decomp
 Checking test 006 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -252,14 +252,14 @@ Checking test 006 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1441.976975
-  0: The maximum resident set size (KB)                   = 828904
+  0: The total amount of wall time                        = 1452.733765
+  0: The maximum resident set size (KB)                   = 830872
 
 Test 006 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_2threads
 Checking test 007 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -306,14 +306,14 @@ Checking test 007 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1325.893597
-  0: The maximum resident set size (KB)                   = 899680
+  0: The total amount of wall time                        = 1361.520156
+  0: The maximum resident set size (KB)                   = 896708
 
 Test 007 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_restart
 Checking test 008 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 720.258269
-  0: The maximum resident set size (KB)                   = 549120
+  0: The total amount of wall time                        = 729.111415
+  0: The maximum resident set size (KB)                   = 544612
 
 Test 008 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_sfcdiff
 Checking test 009 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1485.771119
-  0: The maximum resident set size (KB)                   = 833516
+  0: The total amount of wall time                        = 1498.198691
+  0: The maximum resident set size (KB)                   = 828320
 
 Test 009 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_sfcdiff_decomp
 Checking test 010 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -460,14 +460,14 @@ Checking test 010 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1447.339045
-  0: The maximum resident set size (KB)                   = 829704
+  0: The total amount of wall time                        = 1453.550484
+  0: The maximum resident set size (KB)                   = 826068
 
 Test 010 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_sfcdiff_restart
 Checking test 011 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1064.034806
-  0: The maximum resident set size (KB)                   = 546860
+  0: The total amount of wall time                        = 1064.285428
+  0: The maximum resident set size (KB)                   = 546172
 
 Test 011 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control
 Checking test 012 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1417.388737
-  0: The maximum resident set size (KB)                   = 830388
+  0: The total amount of wall time                        = 1430.145819
+  0: The maximum resident set size (KB)                   = 831292
 
 Test 012 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_2threads
 Checking test 013 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -614,14 +614,14 @@ Checking test 013 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1352.688893
-  0: The maximum resident set size (KB)                   = 888604
+  0: The total amount of wall time                        = 1330.194527
+  0: The maximum resident set size (KB)                   = 893952
 
 Test 013 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_decomp
 Checking test 014 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -668,14 +668,14 @@ Checking test 014 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1411.814943
-  0: The maximum resident set size (KB)                   = 826804
+  0: The total amount of wall time                        = 1429.982240
+  0: The maximum resident set size (KB)                   = 832252
 
 Test 014 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_restart
 Checking test 015 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1063.825873
-  0: The maximum resident set size (KB)                   = 540332
+  0: The total amount of wall time                        = 1056.168553
+  0: The maximum resident set size (KB)                   = 543020
 
 Test 015 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1460.401655
-  0: The maximum resident set size (KB)                   = 826048
+  0: The total amount of wall time                        = 1442.160907
+  0: The maximum resident set size (KB)                   = 826520
 
 Test 016 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_conus13km_hrrr_warm
 Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -784,14 +784,14 @@ Checking test 017 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 710.440941
-  0: The maximum resident set size (KB)                   = 637652
+  0: The total amount of wall time                        = 772.515743
+  0: The maximum resident set size (KB)                   = 636108
 
 Test 017 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_smoke_conus13km_hrrr_warm
 Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -800,14 +800,14 @@ Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 775.478775
-  0: The maximum resident set size (KB)                   = 651656
+  0: The total amount of wall time                        = 742.377825
+  0: The maximum resident set size (KB)                   = 652116
 
 Test 018 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -816,14 +816,14 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 773.650950
-  0: The maximum resident set size (KB)                   = 638820
+  0: The total amount of wall time                        = 765.859489
+  0: The maximum resident set size (KB)                   = 640084
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 020 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -832,208 +832,208 @@ Checking test 020 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 926.974536
-  0: The maximum resident set size (KB)                   = 637192
+  0: The total amount of wall time                        = 897.046678
+  0: The maximum resident set size (KB)                   = 636556
 
 Test 020 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 126.461124
-  0: The maximum resident set size (KB)                   = 529832
+  0: The total amount of wall time                        = 125.666781
+  0: The maximum resident set size (KB)                   = 530960
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 749.366951
-  0: The maximum resident set size (KB)                   = 589100
+  0: The total amount of wall time                        = 754.428186
+  0: The maximum resident set size (KB)                   = 589116
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.948723
-  0: The maximum resident set size (KB)                   = 843416
+  0: The total amount of wall time                        = 174.819364
+  0: The maximum resident set size (KB)                   = 844680
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_debug
 Checking test 024 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.099587
-  0: The maximum resident set size (KB)                   = 843752
+  0: The total amount of wall time                        = 169.874503
+  0: The maximum resident set size (KB)                   = 842676
 
 Test 024 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_diag_debug
 Checking test 025 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 212.002641
-  0: The maximum resident set size (KB)                   = 925372
+  0: The total amount of wall time                        = 215.354829
+  0: The maximum resident set size (KB)                   = 928132
 
 Test 025 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 026 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.460812
-  0: The maximum resident set size (KB)                   = 843208
+  0: The total amount of wall time                        = 271.255239
+  0: The maximum resident set size (KB)                   = 842384
 
 Test 026 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_progcld_thompson_debug
 Checking test 027 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.225280
-  0: The maximum resident set size (KB)                   = 848832
+  0: The total amount of wall time                        = 172.772475
+  0: The maximum resident set size (KB)                   = 840800
 
 Test 027 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_v1beta_debug
 Checking test 028 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.578070
-  0: The maximum resident set size (KB)                   = 844800
+  0: The total amount of wall time                        = 177.965593
+  0: The maximum resident set size (KB)                   = 839568
 
 Test 028 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_ras_debug
 Checking test 029 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 102.418438
-  0: The maximum resident set size (KB)                   = 485844
+  0: The total amount of wall time                        = 100.456482
+  0: The maximum resident set size (KB)                   = 481584
 
 Test 029 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_stochy_debug
 Checking test 030 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 118.754366
-  0: The maximum resident set size (KB)                   = 478752
+  0: The total amount of wall time                        = 119.164884
+  0: The maximum resident set size (KB)                   = 476360
 
 Test 030 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_debug_p8
 Checking test 031 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 117.208475
-  0: The maximum resident set size (KB)                   = 1232828
+  0: The total amount of wall time                        = 117.188922
+  0: The maximum resident set size (KB)                   = 1235436
 
 Test 031 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_conus13km_hrrr_warm_debug
 Checking test 032 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 568.010435
-  0: The maximum resident set size (KB)                   = 647228
+  0: The total amount of wall time                        = 580.258332
+  0: The maximum resident set size (KB)                   = 646928
 
 Test 032 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rrfs_conus13km_radar_tten_warm_debug
 Checking test 033 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 566.878450
-  0: The maximum resident set size (KB)                   = 650544
+  0: The total amount of wall time                        = 540.687417
+  0: The maximum resident set size (KB)                   = 649028
 
 Test 033 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/control_wam_debug
 Checking test 034 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 180.898777
-  0: The maximum resident set size (KB)                   = 192944
+  0: The total amount of wall time                        = 182.094319
+  0: The maximum resident set size (KB)                   = 194504
 
 Test 034 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_control_dyn32_phy32
 Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1080,14 +1080,14 @@ Checking test 035 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1456.780477
-  0: The maximum resident set size (KB)                   = 683964
+  0: The total amount of wall time                        = 1469.190696
+  0: The maximum resident set size (KB)                   = 687540
 
 Test 035 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_dyn32_phy32
 Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1134,14 +1134,14 @@ Checking test 036 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 731.812622
-  0: The maximum resident set size (KB)                   = 682980
+  0: The total amount of wall time                        = 738.459059
+  0: The maximum resident set size (KB)                   = 687840
 
 Test 036 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_2threads_dyn32_phy32
 Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1188,14 +1188,14 @@ Checking test 037 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1309.096840
-  0: The maximum resident set size (KB)                   = 727780
+  0: The total amount of wall time                        = 1317.087179
+  0: The maximum resident set size (KB)                   = 729252
 
 Test 037 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_2threads_dyn32_phy32
 Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1242,14 +1242,14 @@ Checking test 038 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 655.883845
-  0: The maximum resident set size (KB)                   = 727176
+  0: The total amount of wall time                        = 668.316260
+  0: The maximum resident set size (KB)                   = 728120
 
 Test 038 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_decomp_dyn32_phy32
 Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1296,14 +1296,14 @@ Checking test 039 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 720.616904
-  0: The maximum resident set size (KB)                   = 680336
+  0: The total amount of wall time                        = 724.480843
+  0: The maximum resident set size (KB)                   = 684716
 
 Test 039 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_restart_dyn32_phy32
 Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 040 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1052.749118
-  0: The maximum resident set size (KB)                   = 510464
+  0: The total amount of wall time                        = 1086.576190
+  0: The maximum resident set size (KB)                   = 509916
 
 Test 040 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_restart_dyn32_phy32
 Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1388,21 +1388,21 @@ Checking test 041 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 359.230674
-  0: The maximum resident set size (KB)                   = 510624
+  0: The total amount of wall time                        = 357.461163
+  0: The maximum resident set size (KB)                   = 510880
 
 Test 041 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_control_dyn64_phy32
 Checking test 042 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1442,147 +1442,77 @@ Checking test 042 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1051.084805
-  0: The maximum resident set size (KB)                   = 711360
+  0: The total amount of wall time                        = 1048.984302
+  0: The maximum resident set size (KB)                   = 708844
 
 Test 042 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_control_debug_dyn32_phy32
 Checking test 043 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.235129
-  0: The maximum resident set size (KB)                   = 701672
+  0: The total amount of wall time                        = 173.616337
+  0: The maximum resident set size (KB)                   = 707964
 
 Test 043 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/hrrr_control_debug_dyn32_phy32
 Checking test 044 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.338732
-  0: The maximum resident set size (KB)                   = 703552
+  0: The total amount of wall time                        = 167.714656
+  0: The maximum resident set size (KB)                   = 706720
 
 Test 044 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/rap_control_dyn64_phy32_debug
 Checking test 045 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 199.978670
-  0: The maximum resident set size (KB)                   = 724036
+  0: The total amount of wall time                        = 204.452097
+  0: The maximum resident set size (KB)                   = 721368
 
 Test 045 rap_control_dyn64_phy32_debug PASS
 
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/cpld_control_p8
-Checking test 046 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 1754.729127
-  0: The maximum resident set size (KB)                   = 1425640
-
-Test 046 cpld_control_p8 PASS
+Test 046 cpld_control_p8 FAIL
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/cpld_control_nowave_noaero_p8
 Checking test 047 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1625,21 +1555,21 @@ Checking test 047 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1216.556783
-  0: The maximum resident set size (KB)                   = 1331820
+  0: The total amount of wall time                        = 1237.530612
+  0: The maximum resident set size (KB)                   = 1332780
 
 Test 047 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/cpld_debug_p8
 Checking test 048 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1685,25 +1615,107 @@ Checking test 048 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 898.551617
-  0: The maximum resident set size (KB)                   = 1447460
+  0: The total amount of wall time                        = 965.265781
+  0: The maximum resident set size (KB)                   = 1445976
 
 Test 048 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22023/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_14451/datm_cdeps_control_cfsr
 Checking test 049 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 171.068923
- 0: The maximum resident set size (KB)                   = 662264
+ 0: The total amount of wall time                        = 174.726143
+ 0: The maximum resident set size (KB)                   = 661648
 
 Test 049 datm_cdeps_control_cfsr PASS
 
+FAILED TESTS: 
+Test cpld_control_p8 046 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Thu Jan 26 20:25:04 UTC 2023
+Elapsed time: 01h:09m:41s. Have a nice day!
+Thu Jan 26 22:48:05 UTC 2023
+Start Regression test
+
+Compile 001 elapsed time 265 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/GNU/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_15892/cpld_control_p8
+Checking test 001 cpld_control_p8 results ....
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 1748.279400
+  0: The maximum resident set size (KB)                   = 1428552
+
+Test 001 cpld_control_p8 PASS
+
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jan 26 02:59:55 UTC 2023
-Elapsed time: 06h:42m:31s. Have a nice day!
+Thu Jan 26 23:27:41 UTC 2023
+Elapsed time: 00h:39m:37s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,37 +1,37 @@
-Wed Jan 25 20:04:23 UTC 2023
+Thu Jan 26 20:24:30 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 612 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 618 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 002 elapsed time 615 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 582 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 216 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 193 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 519 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 523 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 491 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 474 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 454 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 195 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 457 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 565 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 224 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 201 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 517 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 533 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 486 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 493 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 479 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 442 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 197 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 148 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 452 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 015 elapsed time 459 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 555 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 665 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 609 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 181 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 022 elapsed time 115 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 023 elapsed time 69 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 489 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 539 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 501 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 483 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 162 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 149 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 151 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 551 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 663 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 536 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 178 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 022 elapsed time 113 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 023 elapsed time 60 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 485 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 530 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 485 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 466 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 177 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8_mixedmode
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_p8_mixedmode
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -96,33 +96,33 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 305.723764
-  0: The maximum resident set size (KB)                   = 3133952
+  0: The total amount of wall time                        = 303.390327
+  0: The maximum resident set size (KB)                   = 3140860
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_gfsv17
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_gfsv17
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_gfsv17
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -167,33 +167,33 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 219.989915
-  0: The maximum resident set size (KB)                   = 1727860
+  0: The total amount of wall time                        = 221.074792
+  0: The maximum resident set size (KB)                   = 1728136
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -239,21 +239,21 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 336.627219
-  0: The maximum resident set size (KB)                   = 3183584
+  0: The total amount of wall time                        = 333.343744
+  0: The maximum resident set size (KB)                   = 3183196
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -299,21 +299,21 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 192.412869
-  0: The maximum resident set size (KB)                   = 3053396
+  0: The total amount of wall time                        = 193.634804
+  0: The maximum resident set size (KB)                   = 3057940
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_2threads_p8
 Checking test 005 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -359,21 +359,21 @@ Checking test 005 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 349.005201
-  0: The maximum resident set size (KB)                   = 3516844
+  0: The total amount of wall time                        = 345.836449
+  0: The maximum resident set size (KB)                   = 3520568
 
 Test 005 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_esmfthreads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_esmfthreads_p8
 Checking test 006 cpld_esmfthreads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -419,21 +419,21 @@ Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 348.795103
-  0: The maximum resident set size (KB)                   = 3520420
+  0: The total amount of wall time                        = 350.258023
+  0: The maximum resident set size (KB)                   = 3522364
 
 Test 006 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -479,21 +479,21 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 333.089667
-  0: The maximum resident set size (KB)                   = 3172960
+  0: The total amount of wall time                        = 332.250295
+  0: The maximum resident set size (KB)                   = 3172652
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -539,33 +539,33 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 277.829885
-  0: The maximum resident set size (KB)                   = 3028664
+  0: The total amount of wall time                        = 275.564582
+  0: The maximum resident set size (KB)                   = 3025092
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_ciceC_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_ciceC_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -611,21 +611,21 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 337.206002
-  0: The maximum resident set size (KB)                   = 3185204
+  0: The total amount of wall time                        = 334.354232
+  0: The maximum resident set size (KB)                   = 3180700
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -671,21 +671,21 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 574.842900
-  0: The maximum resident set size (KB)                   = 3258592
+  0: The total amount of wall time                        = 568.686169
+  0: The maximum resident set size (KB)                   = 3259332
 
 Test 010 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -731,17 +731,17 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 400.350855
-  0: The maximum resident set size (KB)                   = 3157344
+  0: The total amount of wall time                        = 399.597761
+  0: The maximum resident set size (KB)                   = 3159488
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_bmark_p8
 Checking test 012 cpld_bmark_p8 results ....
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing GFSFLX.GrbF06 .........OK
  Comparing GFSPRS.GrbF06 .........OK
  Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
@@ -786,17 +786,17 @@ Checking test 012 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 686.276523
-   0: The maximum resident set size (KB)                   = 4039560
+   0: The total amount of wall time                        = 697.638713
+   0: The maximum resident set size (KB)                   = 4031968
 
 Test 012 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_restart_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_restart_bmark_p8
 Checking test 013 cpld_restart_bmark_p8 results ....
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing GFSFLX.GrbF06 .........OK
  Comparing GFSPRS.GrbF06 .........OK
  Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
@@ -841,33 +841,33 @@ Checking test 013 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 421.852267
-   0: The maximum resident set size (KB)                   = 3981432
+   0: The total amount of wall time                        = 418.856527
+   0: The maximum resident set size (KB)                   = 3975960
 
 Test 013 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_noaero_p8
 Checking test 014 cpld_control_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -912,33 +912,33 @@ Checking test 014 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 260.718019
-  0: The maximum resident set size (KB)                   = 1728096
+  0: The total amount of wall time                        = 258.999525
+  0: The maximum resident set size (KB)                   = 1721120
 
 Test 014 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_nowave_noaero_p8
 Checking test 015 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -981,21 +981,21 @@ Checking test 015 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 253.929927
-  0: The maximum resident set size (KB)                   = 1771308
+  0: The total amount of wall time                        = 254.295478
+  0: The maximum resident set size (KB)                   = 1768356
 
 Test 015 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_debug_p8
 Checking test 016 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1041,21 +1041,21 @@ Checking test 016 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 661.686730
-  0: The maximum resident set size (KB)                   = 3246528
+  0: The total amount of wall time                        = 659.276340
+  0: The maximum resident set size (KB)                   = 3245072
 
 Test 016 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_debug_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_debug_noaero_p8
 Checking test 017 cpld_debug_noaero_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1100,33 +1100,33 @@ Checking test 017 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 410.244646
-  0: The maximum resident set size (KB)                   = 1741324
+  0: The total amount of wall time                        = 399.646271
+  0: The maximum resident set size (KB)                   = 1742932
 
 Test 017 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_noaero_p8_agrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_noaero_p8_agrid
 Checking test 018 cpld_control_noaero_p8_agrid results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1169,21 +1169,21 @@ Checking test 018 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 260.597258
-  0: The maximum resident set size (KB)                   = 1766944
+  0: The total amount of wall time                        = 261.764993
+  0: The maximum resident set size (KB)                   = 1758448
 
 Test 018 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_control_c48
 Checking test 019 cpld_control_c48 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1226,21 +1226,21 @@ Checking test 019 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 576.206216
- 0: The maximum resident set size (KB)                   = 2803140
+ 0: The total amount of wall time                        = 582.693335
+ 0: The maximum resident set size (KB)                   = 2804352
 
 Test 019 cpld_control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_warmstart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_warmstart_c48
 Checking test 020 cpld_warmstart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1283,21 +1283,21 @@ Checking test 020 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 154.611923
- 0: The maximum resident set size (KB)                   = 2801772
+ 0: The total amount of wall time                        = 152.497535
+ 0: The maximum resident set size (KB)                   = 2800484
 
 Test 020 cpld_warmstart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/cpld_restart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/cpld_restart_c48
 Checking test 021 cpld_restart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1340,14 +1340,14 @@ Checking test 021 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 81.724252
- 0: The maximum resident set size (KB)                   = 2239132
+ 0: The total amount of wall time                        = 80.496209
+ 0: The maximum resident set size (KB)                   = 2239476
 
 Test 021 cpld_restart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1374,28 +1374,28 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.193040
-  0: The maximum resident set size (KB)                   = 632316
+  0: The total amount of wall time                        = 129.652371
+  0: The maximum resident set size (KB)                   = 624540
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_CubedSphereGrid_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_CubedSphereGrid_parallel
 Checking test 023 control_CubedSphereGrid_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 126.502480
-  0: The maximum resident set size (KB)                   = 624936
+  0: The total amount of wall time                        = 126.462678
+  0: The maximum resident set size (KB)                   = 629716
 
 Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_latlon
 Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1406,14 +1406,14 @@ Checking test 024 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.697382
-  0: The maximum resident set size (KB)                   = 627688
+  0: The total amount of wall time                        = 130.939615
+  0: The maximum resident set size (KB)                   = 624260
 
 Test 024 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_wrtGauss_netcdf_parallel
 Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1424,14 +1424,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.621211
-  0: The maximum resident set size (KB)                   = 628856
+  0: The total amount of wall time                        = 134.594461
+  0: The maximum resident set size (KB)                   = 627548
 
 Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_c48
 Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1470,14 +1470,14 @@ Checking test 026 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 366.036020
-0: The maximum resident set size (KB)                   = 815528
+0: The total amount of wall time                        = 367.801361
+0: The maximum resident set size (KB)                   = 814332
 
 Test 026 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_c192
 Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 027 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 523.998333
-  0: The maximum resident set size (KB)                   = 776696
+  0: The total amount of wall time                        = 523.476498
+  0: The maximum resident set size (KB)                   = 761708
 
 Test 027 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_c384
 Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1506,14 +1506,14 @@ Checking test 028 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 527.531825
-  0: The maximum resident set size (KB)                   = 1211072
+  0: The total amount of wall time                        = 527.731247
+  0: The maximum resident set size (KB)                   = 1206524
 
 Test 028 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_c384gdas
 Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1556,14 +1556,14 @@ Checking test 029 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 449.597295
-  0: The maximum resident set size (KB)                   = 1343272
+  0: The total amount of wall time                        = 453.547095
+  0: The maximum resident set size (KB)                   = 1341160
 
 Test 029 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_stochy
 Checking test 030 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1574,28 +1574,28 @@ Checking test 030 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 87.195043
-  0: The maximum resident set size (KB)                   = 627052
+  0: The total amount of wall time                        = 87.411053
+  0: The maximum resident set size (KB)                   = 626304
 
 Test 030 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_stochy_restart
 Checking test 031 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.805798
-  0: The maximum resident set size (KB)                   = 479520
+  0: The total amount of wall time                        = 45.974718
+  0: The maximum resident set size (KB)                   = 485728
 
 Test 031 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_lndp
 Checking test 032 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1606,14 +1606,14 @@ Checking test 032 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 80.055458
-  0: The maximum resident set size (KB)                   = 628020
+  0: The total amount of wall time                        = 79.601740
+  0: The maximum resident set size (KB)                   = 629684
 
 Test 032 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_iovr4
 Checking test 033 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1628,14 +1628,14 @@ Checking test 033 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.469430
-  0: The maximum resident set size (KB)                   = 630812
+  0: The total amount of wall time                        = 132.677292
+  0: The maximum resident set size (KB)                   = 629068
 
 Test 033 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_iovr5
 Checking test 034 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1650,14 +1650,14 @@ Checking test 034 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.621098
-  0: The maximum resident set size (KB)                   = 621604
+  0: The total amount of wall time                        = 132.687381
+  0: The maximum resident set size (KB)                   = 629756
 
 Test 034 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_p8
 Checking test 035 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1704,14 +1704,14 @@ Checking test 035 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 164.681324
-  0: The maximum resident set size (KB)                   = 1603308
+  0: The total amount of wall time                        = 163.582110
+  0: The maximum resident set size (KB)                   = 1607624
 
 Test 035 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_p8_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_p8_lndp
 Checking test 036 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1730,14 +1730,14 @@ Checking test 036 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 309.074505
-  0: The maximum resident set size (KB)                   = 1606452
+  0: The total amount of wall time                        = 306.931959
+  0: The maximum resident set size (KB)                   = 1605080
 
 Test 036 control_p8_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_restart_p8
 Checking test 037 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1776,14 +1776,14 @@ Checking test 037 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 86.215036
-  0: The maximum resident set size (KB)                   = 863432
+  0: The total amount of wall time                        = 85.379825
+  0: The maximum resident set size (KB)                   = 866304
 
 Test 037 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_decomp_p8
 Checking test 038 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1826,14 +1826,14 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.696584
-  0: The maximum resident set size (KB)                   = 1591196
+  0: The total amount of wall time                        = 170.130434
+  0: The maximum resident set size (KB)                   = 1584576
 
 Test 038 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_2threads_p8
 Checking test 039 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1876,14 +1876,14 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.371609
-  0: The maximum resident set size (KB)                   = 1691604
+  0: The total amount of wall time                        = 160.771198
+  0: The maximum resident set size (KB)                   = 1686732
 
 Test 039 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_p8_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_p8_rrtmgp
 Checking test 040 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1930,14 +1930,14 @@ Checking test 040 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.234814
-  0: The maximum resident set size (KB)                   = 1730624
+  0: The total amount of wall time                        = 201.120096
+  0: The maximum resident set size (KB)                   = 1723656
 
 Test 040 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/merra2_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/merra2_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/merra2_thompson
 Checking test 041 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1984,14 +1984,14 @@ Checking test 041 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.127781
-  0: The maximum resident set size (KB)                   = 1620084
+  0: The total amount of wall time                        = 188.799765
+  0: The maximum resident set size (KB)                   = 1615472
 
 Test 041 merra2_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_control
 Checking test 042 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2002,28 +2002,28 @@ Checking test 042 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 297.018236
-  0: The maximum resident set size (KB)                   = 864696
+  0: The total amount of wall time                        = 295.989990
+  0: The maximum resident set size (KB)                   = 864200
 
 Test 042 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_restart
 Checking test 043 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 147.411576
-  0: The maximum resident set size (KB)                   = 860980
+  0: The total amount of wall time                        = 148.051042
+  0: The maximum resident set size (KB)                   = 861564
 
 Test 043 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_decomp
 Checking test 044 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2034,14 +2034,14 @@ Checking test 044 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 310.140839
-  0: The maximum resident set size (KB)                   = 851936
+  0: The total amount of wall time                        = 311.593933
+  0: The maximum resident set size (KB)                   = 855976
 
 Test 044 regional_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_2threads
 Checking test 045 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2052,14 +2052,14 @@ Checking test 045 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 179.994537
-  0: The maximum resident set size (KB)                   = 836680
+  0: The total amount of wall time                        = 179.339215
+  0: The maximum resident set size (KB)                   = 838664
 
 Test 045 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_noquilt
 Checking test 046 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2067,28 +2067,28 @@ Checking test 046 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 324.174751
-  0: The maximum resident set size (KB)                   = 854076
+  0: The total amount of wall time                        = 319.651264
+  0: The maximum resident set size (KB)                   = 855912
 
 Test 046 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_netcdf_parallel
 Checking test 047 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 291.857390
-  0: The maximum resident set size (KB)                   = 857200
+  0: The total amount of wall time                        = 291.795460
+  0: The maximum resident set size (KB)                   = 861280
 
 Test 047 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_2dwrtdecomp
 Checking test 048 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 048 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 293.881392
-  0: The maximum resident set size (KB)                   = 863604
+  0: The total amount of wall time                        = 293.316406
+  0: The maximum resident set size (KB)                   = 864964
 
 Test 048 regional_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/fv3_regional_wofs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_wofs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_wofs
 Checking test 049 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2117,14 +2117,14 @@ Checking test 049 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 373.208293
-  0: The maximum resident set size (KB)                   = 622564
+  0: The total amount of wall time                        = 370.867278
+  0: The maximum resident set size (KB)                   = 617724
 
 Test 049 regional_wofs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_control
 Checking test 050 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2171,14 +2171,14 @@ Checking test 050 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 456.519598
-  0: The maximum resident set size (KB)                   = 1052820
+  0: The total amount of wall time                        = 457.186825
+  0: The maximum resident set size (KB)                   = 1060240
 
 Test 050 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_rrtmgp
 Checking test 051 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2225,14 +2225,14 @@ Checking test 051 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 489.047953
-  0: The maximum resident set size (KB)                   = 1218788
+  0: The total amount of wall time                        = 488.515377
+  0: The maximum resident set size (KB)                   = 1220892
 
 Test 051 rap_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_spp_sppt_shum_skeb
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_spp_sppt_shum_skeb
 Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2243,14 +2243,14 @@ Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 279.970852
-  0: The maximum resident set size (KB)                   = 1181168
+  0: The total amount of wall time                        = 281.670550
+  0: The maximum resident set size (KB)                   = 1176828
 
 Test 052 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_decomp
 Checking test 053 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2297,14 +2297,14 @@ Checking test 053 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 478.445883
-  0: The maximum resident set size (KB)                   = 999472
+  0: The total amount of wall time                        = 476.808039
+  0: The maximum resident set size (KB)                   = 1003096
 
 Test 053 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_2threads
 Checking test 054 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2351,14 +2351,14 @@ Checking test 054 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 439.411182
-  0: The maximum resident set size (KB)                   = 1123344
+  0: The total amount of wall time                        = 441.302185
+  0: The maximum resident set size (KB)                   = 1125944
 
 Test 054 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_restart
 Checking test 055 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2397,14 +2397,14 @@ Checking test 055 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.861180
-  0: The maximum resident set size (KB)                   = 965880
+  0: The total amount of wall time                        = 230.211593
+  0: The maximum resident set size (KB)                   = 970000
 
 Test 055 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_sfcdiff
 Checking test 056 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2451,14 +2451,14 @@ Checking test 056 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.602377
-  0: The maximum resident set size (KB)                   = 1078268
+  0: The total amount of wall time                        = 450.350797
+  0: The maximum resident set size (KB)                   = 1061396
 
 Test 056 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_sfcdiff_decomp
 Checking test 057 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2505,14 +2505,14 @@ Checking test 057 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 478.221609
-  0: The maximum resident set size (KB)                   = 1001096
+  0: The total amount of wall time                        = 476.446344
+  0: The maximum resident set size (KB)                   = 996476
 
 Test 057 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_sfcdiff_restart
 Checking test 058 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2551,14 +2551,14 @@ Checking test 058 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 338.628580
-  0: The maximum resident set size (KB)                   = 992388
+  0: The total amount of wall time                        = 340.034183
+  0: The maximum resident set size (KB)                   = 977384
 
 Test 058 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control
 Checking test 059 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2605,14 +2605,14 @@ Checking test 059 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 433.884033
-  0: The maximum resident set size (KB)                   = 1059440
+  0: The total amount of wall time                        = 438.592875
+  0: The maximum resident set size (KB)                   = 1055132
 
 Test 059 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_decomp
 Checking test 060 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2659,14 +2659,14 @@ Checking test 060 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 454.886451
-  0: The maximum resident set size (KB)                   = 1000244
+  0: The total amount of wall time                        = 458.363023
+  0: The maximum resident set size (KB)                   = 1004828
 
 Test 060 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_2threads
 Checking test 061 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2713,14 +2713,14 @@ Checking test 061 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 416.166619
-  0: The maximum resident set size (KB)                   = 1127004
+  0: The total amount of wall time                        = 415.867309
+  0: The maximum resident set size (KB)                   = 1125832
 
 Test 061 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_restart
 Checking test 062 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2759,14 +2759,14 @@ Checking test 062 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 329.285938
-  0: The maximum resident set size (KB)                   = 976244
+  0: The total amount of wall time                        = 327.302582
+  0: The maximum resident set size (KB)                   = 970868
 
 Test 062 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_v1beta
 Checking test 063 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2813,14 +2813,14 @@ Checking test 063 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 445.618096
-  0: The maximum resident set size (KB)                   = 1056260
+  0: The total amount of wall time                        = 444.586050
+  0: The maximum resident set size (KB)                   = 1055224
 
 Test 063 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_v1nssl
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_v1nssl
 Checking test 064 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2835,14 +2835,14 @@ Checking test 064 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 525.123202
-  0: The maximum resident set size (KB)                   = 694216
+  0: The total amount of wall time                        = 524.236520
+  0: The maximum resident set size (KB)                   = 690120
 
 Test 064 rrfs_v1nssl PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_v1nssl_nohailnoccn
 Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2857,14 +2857,14 @@ Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 511.767735
-  0: The maximum resident set size (KB)                   = 757308
+  0: The total amount of wall time                        = 511.813259
+  0: The maximum resident set size (KB)                   = 755852
 
 Test 065 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_conus13km_hrrr_warm
 Checking test 066 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2873,14 +2873,14 @@ Checking test 066 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 123.033689
-  0: The maximum resident set size (KB)                   = 925060
+  0: The total amount of wall time                        = 122.365320
+  0: The maximum resident set size (KB)                   = 924644
 
 Test 066 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_smoke_conus13km_hrrr_warm
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2889,14 +2889,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 138.657427
-  0: The maximum resident set size (KB)                   = 956224
+  0: The total amount of wall time                        = 137.816658
+  0: The maximum resident set size (KB)                   = 949432
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_conus13km_radar_tten_warm
 Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2905,14 +2905,14 @@ Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 123.026517
-  0: The maximum resident set size (KB)                   = 931912
+  0: The total amount of wall time                        = 123.345652
+  0: The maximum resident set size (KB)                   = 937340
 
 Test 068 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_conus13km_hrrr_warm_2threads
 Checking test 069 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2921,14 +2921,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 77.240019
-  0: The maximum resident set size (KB)                   = 870536
+  0: The total amount of wall time                        = 78.201220
+  0: The maximum resident set size (KB)                   = 876232
 
 Test 069 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 070 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2937,108 +2937,108 @@ Checking test 070 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 77.899963
-  0: The maximum resident set size (KB)                   = 879720
+  0: The total amount of wall time                        = 78.222463
+  0: The maximum resident set size (KB)                   = 878168
 
 Test 070 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_csawmg
 Checking test 071 control_csawmg results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 342.307967
-  0: The maximum resident set size (KB)                   = 727512
+  0: The total amount of wall time                        = 341.177005
+  0: The maximum resident set size (KB)                   = 718748
 
 Test 071 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_csawmgt
 Checking test 072 control_csawmgt results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 336.143223
-  0: The maximum resident set size (KB)                   = 723432
+  0: The total amount of wall time                        = 334.304047
+  0: The maximum resident set size (KB)                   = 728816
 
 Test 072 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_ras
 Checking test 073 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 179.382010
-  0: The maximum resident set size (KB)                   = 718676
+  0: The total amount of wall time                        = 177.969353
+  0: The maximum resident set size (KB)                   = 708644
 
 Test 073 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_wam
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_wam
 Checking test 074 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 112.390137
-  0: The maximum resident set size (KB)                   = 639760
+  0: The total amount of wall time                        = 112.320415
+  0: The maximum resident set size (KB)                   = 634492
 
 Test 074 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_conus13km_hrrr_warm_debug
 Checking test 075 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 723.538036
-  0: The maximum resident set size (KB)                   = 955244
+  0: The total amount of wall time                        = 717.214067
+  0: The maximum resident set size (KB)                   = 951992
 
 Test 075 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_conus13km_radar_tten_warm_debug
 Checking test 076 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 721.272200
-  0: The maximum resident set size (KB)                   = 958912
+  0: The total amount of wall time                        = 718.267102
+  0: The maximum resident set size (KB)                   = 959224
 
 Test 076 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_CubedSphereGrid_debug
 Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3065,348 +3065,348 @@ Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 163.625008
-  0: The maximum resident set size (KB)                   = 798688
+  0: The total amount of wall time                        = 159.183714
+  0: The maximum resident set size (KB)                   = 794112
 
 Test 077 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_wrtGauss_netcdf_parallel_debug
 Checking test 078 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.654981
-  0: The maximum resident set size (KB)                   = 794344
+  0: The total amount of wall time                        = 147.947639
+  0: The maximum resident set size (KB)                   = 795916
 
 Test 078 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_stochy_debug
 Checking test 079 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.976439
-  0: The maximum resident set size (KB)                   = 798688
+  0: The total amount of wall time                        = 169.898261
+  0: The maximum resident set size (KB)                   = 800776
 
 Test 079 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_lndp_debug
 Checking test 080 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.084941
-  0: The maximum resident set size (KB)                   = 806296
+  0: The total amount of wall time                        = 150.003746
+  0: The maximum resident set size (KB)                   = 800320
 
 Test 080 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_csawmg_debug
 Checking test 081 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 229.676914
-  0: The maximum resident set size (KB)                   = 850296
+  0: The total amount of wall time                        = 230.021519
+  0: The maximum resident set size (KB)                   = 848972
 
 Test 081 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_csawmgt_debug
 Checking test 082 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.082700
-  0: The maximum resident set size (KB)                   = 844580
+  0: The total amount of wall time                        = 227.240384
+  0: The maximum resident set size (KB)                   = 843344
 
 Test 082 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_ras_debug
 Checking test 083 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.266932
-  0: The maximum resident set size (KB)                   = 810588
+  0: The total amount of wall time                        = 155.226909
+  0: The maximum resident set size (KB)                   = 808876
 
 Test 083 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_diag_debug
 Checking test 084 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.297997
-  0: The maximum resident set size (KB)                   = 850912
+  0: The total amount of wall time                        = 160.158634
+  0: The maximum resident set size (KB)                   = 854584
 
 Test 084 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_debug_p8
 Checking test 085 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.694411
-  0: The maximum resident set size (KB)                   = 1623616
+  0: The total amount of wall time                        = 170.345529
+  0: The maximum resident set size (KB)                   = 1621872
 
 Test 085 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_debug
 Checking test 086 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 969.330053
-  0: The maximum resident set size (KB)                   = 899380
+  0: The total amount of wall time                        = 983.855895
+  0: The maximum resident set size (KB)                   = 882776
 
 Test 086 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_control_debug
 Checking test 087 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.037841
-  0: The maximum resident set size (KB)                   = 1175132
+  0: The total amount of wall time                        = 271.517833
+  0: The maximum resident set size (KB)                   = 1176968
 
 Test 087 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_debug
 Checking test 088 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.142378
-  0: The maximum resident set size (KB)                   = 1172564
+  0: The total amount of wall time                        = 268.182734
+  0: The maximum resident set size (KB)                   = 1172476
 
 Test 088 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_unified_drag_suite_debug
 Checking test 089 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.375841
-  0: The maximum resident set size (KB)                   = 1172400
+  0: The total amount of wall time                        = 277.365217
+  0: The maximum resident set size (KB)                   = 1176992
 
 Test 089 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_diag_debug
 Checking test 090 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.490833
-  0: The maximum resident set size (KB)                   = 1262056
+  0: The total amount of wall time                        = 293.051036
+  0: The maximum resident set size (KB)                   = 1255764
 
 Test 090 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_cires_ugwp_debug
 Checking test 091 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.542723
-  0: The maximum resident set size (KB)                   = 1176400
+  0: The total amount of wall time                        = 277.761979
+  0: The maximum resident set size (KB)                   = 1178464
 
 Test 091 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_unified_ugwp_debug
 Checking test 092 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.452657
-  0: The maximum resident set size (KB)                   = 1177704
+  0: The total amount of wall time                        = 283.192881
+  0: The maximum resident set size (KB)                   = 1174484
 
 Test 092 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_lndp_debug
 Checking test 093 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.865627
-  0: The maximum resident set size (KB)                   = 1180580
+  0: The total amount of wall time                        = 274.920192
+  0: The maximum resident set size (KB)                   = 1172764
 
 Test 093 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_flake_debug
 Checking test 094 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.733673
-  0: The maximum resident set size (KB)                   = 1172788
+  0: The total amount of wall time                        = 273.124609
+  0: The maximum resident set size (KB)                   = 1184608
 
 Test 094 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_progcld_thompson_debug
 Checking test 095 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.553015
-  0: The maximum resident set size (KB)                   = 1172768
+  0: The total amount of wall time                        = 273.387931
+  0: The maximum resident set size (KB)                   = 1171916
 
 Test 095 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_noah_debug
 Checking test 096 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.617823
-  0: The maximum resident set size (KB)                   = 1180672
+  0: The total amount of wall time                        = 271.598078
+  0: The maximum resident set size (KB)                   = 1174212
 
 Test 096 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_rrtmgp_debug
 Checking test 097 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 464.040558
-  0: The maximum resident set size (KB)                   = 1305500
+  0: The total amount of wall time                        = 455.076485
+  0: The maximum resident set size (KB)                   = 1304752
 
 Test 097 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_sfcdiff_debug
 Checking test 098 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.223080
-  0: The maximum resident set size (KB)                   = 1176132
+  0: The total amount of wall time                        = 274.942907
+  0: The maximum resident set size (KB)                   = 1172724
 
 Test 098 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 099 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 453.141318
-  0: The maximum resident set size (KB)                   = 1174240
+  0: The total amount of wall time                        = 452.828815
+  0: The maximum resident set size (KB)                   = 1175064
 
 Test 099 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rrfs_v1beta_debug
 Checking test 100 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.906670
-  0: The maximum resident set size (KB)                   = 1171560
+  0: The total amount of wall time                        = 271.100693
+  0: The maximum resident set size (KB)                   = 1173548
 
 Test 100 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_wam_debug
 Checking test 101 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 279.227265
-  0: The maximum resident set size (KB)                   = 523396
+  0: The total amount of wall time                        = 282.332682
+  0: The maximum resident set size (KB)                   = 518812
 
 Test 101 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3417,14 +3417,14 @@ Checking test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 260.607604
-  0: The maximum resident set size (KB)                   = 1075928
+  0: The total amount of wall time                        = 259.862225
+  0: The maximum resident set size (KB)                   = 1068280
 
 Test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_control_dyn32_phy32
 Checking test 103 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3471,14 +3471,14 @@ Checking test 103 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 369.189470
-  0: The maximum resident set size (KB)                   = 1001584
+  0: The total amount of wall time                        = 368.212109
+  0: The maximum resident set size (KB)                   = 1001328
 
 Test 103 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_dyn32_phy32
 Checking test 104 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3525,14 +3525,14 @@ Checking test 104 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.038140
-  0: The maximum resident set size (KB)                   = 953512
+  0: The total amount of wall time                        = 192.691017
+  0: The maximum resident set size (KB)                   = 953688
 
 Test 104 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_2threads_dyn32_phy32
 Checking test 105 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3579,14 +3579,14 @@ Checking test 105 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 357.499776
-  0: The maximum resident set size (KB)                   = 1021340
+  0: The total amount of wall time                        = 356.635454
+  0: The maximum resident set size (KB)                   = 1027784
 
 Test 105 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_2threads_dyn32_phy32
 Checking test 106 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3633,14 +3633,14 @@ Checking test 106 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.731442
-  0: The maximum resident set size (KB)                   = 1007360
+  0: The total amount of wall time                        = 190.771162
+  0: The maximum resident set size (KB)                   = 1007304
 
 Test 106 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_decomp_dyn32_phy32
 Checking test 107 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3687,14 +3687,14 @@ Checking test 107 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.789288
-  0: The maximum resident set size (KB)                   = 895016
+  0: The total amount of wall time                        = 204.093607
+  0: The maximum resident set size (KB)                   = 895920
 
 Test 107 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_restart_dyn32_phy32
 Checking test 108 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3733,14 +3733,14 @@ Checking test 108 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 277.725556
-  0: The maximum resident set size (KB)                   = 941432
+  0: The total amount of wall time                        = 279.498134
+  0: The maximum resident set size (KB)                   = 946036
 
 Test 108 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_restart_dyn32_phy32
 Checking test 109 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3779,21 +3779,21 @@ Checking test 109 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 99.373624
-  0: The maximum resident set size (KB)                   = 862176
+  0: The total amount of wall time                        = 99.536994
+  0: The maximum resident set size (KB)                   = 849724
 
 Test 109 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_control_dyn64_phy32
 Checking test 110 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3833,81 +3833,81 @@ Checking test 110 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.909612
-  0: The maximum resident set size (KB)                   = 964472
+  0: The total amount of wall time                        = 239.690133
+  0: The maximum resident set size (KB)                   = 961432
 
 Test 110 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_control_debug_dyn32_phy32
 Checking test 111 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.323177
-  0: The maximum resident set size (KB)                   = 1058252
+  0: The total amount of wall time                        = 273.545061
+  0: The maximum resident set size (KB)                   = 1062840
 
 Test 111 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hrrr_control_debug_dyn32_phy32
 Checking test 112 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.425363
-  0: The maximum resident set size (KB)                   = 1060348
+  0: The total amount of wall time                        = 266.351874
+  0: The maximum resident set size (KB)                   = 1059532
 
 Test 112 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/rap_control_dyn64_phy32_debug
 Checking test 113 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.614249
-  0: The maximum resident set size (KB)                   = 1107664
+  0: The total amount of wall time                        = 275.530952
+  0: The maximum resident set size (KB)                   = 1097744
 
 Test 113 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_atm
 Checking test 114 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 218.778379
-  0: The maximum resident set size (KB)                   = 1022364
+  0: The total amount of wall time                        = 219.616081
+  0: The maximum resident set size (KB)                   = 1021280
 
 Test 114 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_atm_thompson_gfdlsf
 Checking test 115 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 303.831140
-  0: The maximum resident set size (KB)                   = 1394764
+  0: The total amount of wall time                        = 299.868551
+  0: The maximum resident set size (KB)                   = 1400880
 
 Test 115 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_atm_ocn
 Checking test 116 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3916,14 +3916,14 @@ Checking test 116 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.749286
-  0: The maximum resident set size (KB)                   = 1196972
+  0: The total amount of wall time                        = 359.140121
+  0: The maximum resident set size (KB)                   = 1202408
 
 Test 116 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_atm_wav
 Checking test 117 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3932,14 +3932,14 @@ Checking test 117 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 718.412019
-  0: The maximum resident set size (KB)                   = 1231988
+  0: The total amount of wall time                        = 719.989492
+  0: The maximum resident set size (KB)                   = 1233356
 
 Test 117 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_atm_ocn_wav
 Checking test 118 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3950,28 +3950,28 @@ Checking test 118 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 819.666054
-  0: The maximum resident set size (KB)                   = 1244032
+  0: The total amount of wall time                        = 819.950538
+  0: The maximum resident set size (KB)                   = 1244328
 
 Test 118 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_1nest_atm
 Checking test 119 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 317.018595
-  0: The maximum resident set size (KB)                   = 505732
+  0: The total amount of wall time                        = 314.718376
+  0: The maximum resident set size (KB)                   = 500684
 
 Test 119 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_telescopic_2nests_atm
 Checking test 120 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3980,28 +3980,28 @@ Checking test 120 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 363.815114
-  0: The maximum resident set size (KB)                   = 509184
+  0: The total amount of wall time                        = 363.687528
+  0: The maximum resident set size (KB)                   = 512976
 
 Test 120 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_global_1nest_atm
 Checking test 121 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 144.069599
-  0: The maximum resident set size (KB)                   = 345876
+  0: The total amount of wall time                        = 144.157214
+  0: The maximum resident set size (KB)                   = 345652
 
 Test 121 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_global_multiple_4nests_atm
 Checking test 122 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4019,14 +4019,14 @@ Checking test 122 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 413.437685
-  0: The maximum resident set size (KB)                   = 416072
+  0: The total amount of wall time                        = 411.519014
+  0: The maximum resident set size (KB)                   = 419904
 
 Test 122 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_specified_moving_1nest_atm
 Checking test 123 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4035,28 +4035,28 @@ Checking test 123 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 196.503078
-  0: The maximum resident set size (KB)                   = 516404
+  0: The total amount of wall time                        = 200.437688
+  0: The maximum resident set size (KB)                   = 510688
 
 Test 123 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_storm_following_1nest_atm
 Checking test 124 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 186.527525
-  0: The maximum resident set size (KB)                   = 515296
+  0: The total amount of wall time                        = 186.622501
+  0: The maximum resident set size (KB)                   = 507276
 
 Test 124 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 125 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4065,28 +4065,28 @@ Checking test 125 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 218.805920
-  0: The maximum resident set size (KB)                   = 550684
+  0: The total amount of wall time                        = 217.152195
+  0: The maximum resident set size (KB)                   = 546896
 
 Test 125 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_global_storm_following_1nest_atm
 Checking test 126 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 58.045202
-  0: The maximum resident set size (KB)                   = 360248
+  0: The total amount of wall time                        = 58.347049
+  0: The maximum resident set size (KB)                   = 359920
 
 Test 126 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 127 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4097,14 +4097,14 @@ Checking test 127 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 510.632475
-  0: The maximum resident set size (KB)                   = 646624
+  0: The total amount of wall time                        = 508.161580
+  0: The maximum resident set size (KB)                   = 646104
 
 Test 127 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_docn
 Checking test 128 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4112,14 +4112,14 @@ Checking test 128 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.074147
-  0: The maximum resident set size (KB)                   = 1208100
+  0: The total amount of wall time                        = 335.996041
+  0: The maximum resident set size (KB)                   = 1204788
 
 Test 128 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_docn_oisst
 Checking test 129 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4127,131 +4127,131 @@ Checking test 129 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 337.878752
-  0: The maximum resident set size (KB)                   = 1193820
+  0: The total amount of wall time                        = 339.323859
+  0: The maximum resident set size (KB)                   = 1194912
 
 Test 129 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/hafs_regional_datm_cdeps
 Checking test 130 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 950.501276
-  0: The maximum resident set size (KB)                   = 1036820
+  0: The total amount of wall time                        = 948.843747
+  0: The maximum resident set size (KB)                   = 1039324
 
 Test 130 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_control_cfsr
 Checking test 131 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.832690
- 0: The maximum resident set size (KB)                   = 1051812
+ 0: The total amount of wall time                        = 158.064096
+ 0: The maximum resident set size (KB)                   = 1075136
 
 Test 131 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_restart_cfsr
 Checking test 132 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 94.503834
- 0: The maximum resident set size (KB)                   = 1020308
+ 0: The total amount of wall time                        = 94.775733
+ 0: The maximum resident set size (KB)                   = 1023640
 
 Test 132 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_control_gefs
 Checking test 133 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.417049
- 0: The maximum resident set size (KB)                   = 960272
+ 0: The total amount of wall time                        = 151.948553
+ 0: The maximum resident set size (KB)                   = 969644
 
 Test 133 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_iau_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_iau_gefs
 Checking test 134 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.248444
- 0: The maximum resident set size (KB)                   = 958340
+ 0: The total amount of wall time                        = 154.886592
+ 0: The maximum resident set size (KB)                   = 963512
 
 Test 134 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_stochy_gefs
 Checking test 135 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.296392
- 0: The maximum resident set size (KB)                   = 976264
+ 0: The total amount of wall time                        = 154.252475
+ 0: The maximum resident set size (KB)                   = 959972
 
 Test 135 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_ciceC_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_ciceC_cfsr
 Checking test 136 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.241351
- 0: The maximum resident set size (KB)                   = 1055312
+ 0: The total amount of wall time                        = 152.464563
+ 0: The maximum resident set size (KB)                   = 1060536
 
 Test 136 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_bulk_cfsr
 Checking test 137 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.230138
- 0: The maximum resident set size (KB)                   = 1061516
+ 0: The total amount of wall time                        = 154.730148
+ 0: The maximum resident set size (KB)                   = 1052636
 
 Test 137 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_bulk_gefs
 Checking test 138 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.358357
- 0: The maximum resident set size (KB)                   = 963476
+ 0: The total amount of wall time                        = 148.731757
+ 0: The maximum resident set size (KB)                   = 968824
 
 Test 138 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_mx025_cfsr
 Checking test 139 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4260,14 +4260,14 @@ Checking test 139 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 400.547415
-  0: The maximum resident set size (KB)                   = 885000
+  0: The total amount of wall time                        = 406.862576
+  0: The maximum resident set size (KB)                   = 872992
 
 Test 139 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_mx025_gefs
 Checking test 140 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4276,64 +4276,64 @@ Checking test 140 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 402.222590
-  0: The maximum resident set size (KB)                   = 939580
+  0: The total amount of wall time                        = 389.792007
+  0: The maximum resident set size (KB)                   = 930404
 
 Test 140 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_multiple_files_cfsr
 Checking test 141 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.976316
- 0: The maximum resident set size (KB)                   = 1061372
+ 0: The total amount of wall time                        = 154.609423
+ 0: The maximum resident set size (KB)                   = 1056432
 
 Test 141 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_3072x1536_cfsr
 Checking test 142 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 217.467288
- 0: The maximum resident set size (KB)                   = 2364180
+ 0: The total amount of wall time                        = 215.612632
+ 0: The maximum resident set size (KB)                   = 2364388
 
 Test 142 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_gfs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_gfs
 Checking test 143 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 220.119645
- 0: The maximum resident set size (KB)                   = 2356912
+ 0: The total amount of wall time                        = 217.548958
+ 0: The maximum resident set size (KB)                   = 2367720
 
 Test 143 datm_cdeps_gfs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_debug_cfsr
 Checking test 144 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 442.286797
- 0: The maximum resident set size (KB)                   = 998208
+ 0: The total amount of wall time                        = 440.733069
+ 0: The maximum resident set size (KB)                   = 985124
 
 Test 144 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_lnd_gswp3
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_lnd_gswp3
 Checking test 145 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4342,14 +4342,14 @@ Checking test 145 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 6.297587
-  0: The maximum resident set size (KB)                   = 259624
+  0: The total amount of wall time                        = 7.588787
+  0: The maximum resident set size (KB)                   = 259976
 
 Test 145 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/datm_cdeps_lnd_gswp3_rst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/datm_cdeps_lnd_gswp3_rst
 Checking test 146 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4358,33 +4358,33 @@ Checking test 146 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.409256
-  0: The maximum resident set size (KB)                   = 263456
+  0: The total amount of wall time                        = 12.222936
+  0: The maximum resident set size (KB)                   = 258876
 
 Test 146 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_atmlnd_sbs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_p8_atmlnd_sbs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_p8_atmlnd_sbs
 Checking test 147 control_p8_atmlnd_sbs results ....
- Comparing sfcf000.tile1.nc ............ALT CHECK......OK
- Comparing sfcf000.tile2.nc ............ALT CHECK......OK
- Comparing sfcf000.tile3.nc ............ALT CHECK......OK
- Comparing sfcf000.tile4.nc ............ALT CHECK......OK
- Comparing sfcf000.tile5.nc ............ALT CHECK......OK
- Comparing sfcf000.tile6.nc ............ALT CHECK......OK
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf000.tile1.nc .........OK
  Comparing atmf000.tile2.nc .........OK
  Comparing atmf000.tile3.nc .........OK
@@ -4450,14 +4450,14 @@ Checking test 147 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.520697
-  0: The maximum resident set size (KB)                   = 1615000
+  0: The total amount of wall time                        = 201.845878
+  0: The maximum resident set size (KB)                   = 1608416
 
 Test 147 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/control_atmwav
 Checking test 148 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4501,14 +4501,14 @@ Checking test 148 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 85.705954
-  0: The maximum resident set size (KB)                   = 660216
+  0: The total amount of wall time                        = 85.101810
+  0: The maximum resident set size (KB)                   = 655676
 
 Test 148 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/atmaero_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/atmaero_control_p8
 Checking test 149 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4552,14 +4552,14 @@ Checking test 149 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.461415
-  0: The maximum resident set size (KB)                   = 2975996
+  0: The total amount of wall time                        = 224.601152
+  0: The maximum resident set size (KB)                   = 2978200
 
 Test 149 atmaero_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/atmaero_control_p8_rad
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/atmaero_control_p8_rad
 Checking test 150 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4603,14 +4603,14 @@ Checking test 150 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.632870
-  0: The maximum resident set size (KB)                   = 3048600
+  0: The total amount of wall time                        = 278.487592
+  0: The maximum resident set size (KB)                   = 3048476
 
 Test 150 atmaero_control_p8_rad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad_micro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/atmaero_control_p8_rad_micro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/atmaero_control_p8_rad_micro
 Checking test 151 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4654,21 +4654,21 @@ Checking test 151 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 280.442233
-  0: The maximum resident set size (KB)                   = 3058968
+  0: The total amount of wall time                        = 280.909526
+  0: The maximum resident set size (KB)                   = 3055576
 
 Test 151 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_atmaq
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_atmaq
 Checking test 152 regional_atmaq results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf003.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf003.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4677,19 +4677,19 @@ Checking test 152 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 614.279464
-  0: The maximum resident set size (KB)                   = 1545240
+  0: The total amount of wall time                        = 597.429135
+  0: The maximum resident set size (KB)                   = 1560716
 
 Test 152 regional_atmaq PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_11223/regional_atmaq_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_30853/regional_atmaq_debug
 Checking test 153 regional_atmaq_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4698,12 +4698,12 @@ Checking test 153 regional_atmaq_debug results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1313.824799
-  0: The maximum resident set size (KB)                   = 1508596
+  0: The total amount of wall time                        = 1313.939207
+  0: The maximum resident set size (KB)                   = 1513056
 
 Test 153 regional_atmaq_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jan 26 03:39:35 UTC 2023
-Elapsed time: 07h:35m:13s. Have a nice day!
+Thu Jan 26 22:43:36 UTC 2023
+Elapsed time: 02h:19m:07s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,37 +1,37 @@
-Wed Jan 25 20:01:58 GMT 2023
+Thu Jan 26 23:07:20 GMT 2023
 Start Regression test
 
-Compile 001 elapsed time 1870 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 1966 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 1721 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 004 elapsed time 299 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 266 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1598 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 007 elapsed time 1605 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 008 elapsed time 1559 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 009 elapsed time 1550 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 010 elapsed time 1526 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1373 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 274 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 227 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 1390 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 015 elapsed time 1447 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 016 elapsed time 233 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 220 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 1626 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 019 elapsed time 2247 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 020 elapsed time 1619 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 021 elapsed time 284 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 001 elapsed time 1845 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 1874 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 1717 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 004 elapsed time 275 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 253 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1562 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1561 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 008 elapsed time 1548 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 009 elapsed time 1548 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 010 elapsed time 1524 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1383 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 266 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 221 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 1396 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 015 elapsed time 1435 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 016 elapsed time 225 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 224 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 1637 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 019 elapsed time 2156 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 020 elapsed time 1637 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 021 elapsed time 285 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
 Compile 022 elapsed time 164 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 023 elapsed time 111 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 024 elapsed time 1585 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 025 elapsed time 1576 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 026 elapsed time 1411 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 027 elapsed time 1476 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 028 elapsed time 226 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 81 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 024 elapsed time 1569 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 025 elapsed time 1583 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 026 elapsed time 1437 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 027 elapsed time 1469 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 028 elapsed time 215 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_p8_mixedmode
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -96,33 +96,33 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 406.312236
-  0: The maximum resident set size (KB)                   = 1733288
+  0: The total amount of wall time                        = 407.435823
+  0: The maximum resident set size (KB)                   = 1746380
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_gfsv17
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_gfsv17
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_gfsv17
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -167,33 +167,33 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 299.462891
-  0: The maximum resident set size (KB)                   = 1627912
+  0: The total amount of wall time                        = 294.126556
+  0: The maximum resident set size (KB)                   = 1642996
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -239,21 +239,21 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 456.020689
-  0: The maximum resident set size (KB)                   = 1770688
+  0: The total amount of wall time                        = 450.602137
+  0: The maximum resident set size (KB)                   = 1801724
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -299,21 +299,21 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 260.492169
-  0: The maximum resident set size (KB)                   = 1491164
+  0: The total amount of wall time                        = 260.604622
+  0: The maximum resident set size (KB)                   = 1492324
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_2threads_p8
 Checking test 005 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -359,21 +359,21 @@ Checking test 005 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 483.755456
-  0: The maximum resident set size (KB)                   = 1988232
+  0: The total amount of wall time                        = 483.374499
+  0: The maximum resident set size (KB)                   = 1997620
 
 Test 005 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_esmfthreads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_esmfthreads_p8
 Checking test 006 cpld_esmfthreads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -419,21 +419,21 @@ Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 486.314158
-  0: The maximum resident set size (KB)                   = 1973732
+  0: The total amount of wall time                        = 493.356274
+  0: The maximum resident set size (KB)                   = 1974816
 
 Test 006 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -479,21 +479,21 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 463.692304
-  0: The maximum resident set size (KB)                   = 1762364
+  0: The total amount of wall time                        = 461.698059
+  0: The maximum resident set size (KB)                   = 1775620
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_mpi_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -539,33 +539,33 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 381.883020
-  0: The maximum resident set size (KB)                   = 1725820
+  0: The total amount of wall time                        = 378.681364
+  0: The maximum resident set size (KB)                   = 1731592
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_ciceC_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -611,33 +611,33 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 472.558716
-  0: The maximum resident set size (KB)                   = 1779684
+  0: The total amount of wall time                        = 461.111846
+  0: The maximum resident set size (KB)                   = 1781744
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_noaero_p8
 Checking test 010 cpld_control_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -682,33 +682,33 @@ Checking test 010 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 363.202124
-  0: The maximum resident set size (KB)                   = 1615448
+  0: The total amount of wall time                        = 352.981220
+  0: The maximum resident set size (KB)                   = 1620704
 
 Test 010 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_nowave_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_nowave_noaero_p8
 Checking test 011 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -751,21 +751,21 @@ Checking test 011 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 365.706435
-  0: The maximum resident set size (KB)                   = 1680732
+  0: The total amount of wall time                        = 353.084762
+  0: The maximum resident set size (KB)                   = 1672296
 
 Test 011 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -811,21 +811,21 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 853.617559
-  0: The maximum resident set size (KB)                   = 1819596
+  0: The total amount of wall time                        = 857.814035
+  0: The maximum resident set size (KB)                   = 1818840
 
 Test 012 cpld_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_debug_noaero_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_debug_noaero_p8
 Checking test 013 cpld_debug_noaero_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -870,33 +870,33 @@ Checking test 013 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 533.470133
-  0: The maximum resident set size (KB)                   = 1635416
+  0: The total amount of wall time                        = 564.974323
+  0: The maximum resident set size (KB)                   = 1639084
 
 Test 013 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_noaero_p8_agrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_noaero_p8_agrid
 Checking test 014 cpld_control_noaero_p8_agrid results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -939,21 +939,21 @@ Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 366.254934
-  0: The maximum resident set size (KB)                   = 1675352
+  0: The total amount of wall time                        = 361.942156
+  0: The maximum resident set size (KB)                   = 1675720
 
 Test 014 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_control_c48
 Checking test 015 cpld_control_c48 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -996,21 +996,21 @@ Checking test 015 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 797.049840
- 0: The maximum resident set size (KB)                   = 2764896
+ 0: The total amount of wall time                        = 802.167819
+ 0: The maximum resident set size (KB)                   = 2773608
 
 Test 015 cpld_control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_warmstart_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_warmstart_c48
 Checking test 016 cpld_warmstart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1053,21 +1053,21 @@ Checking test 016 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 215.587648
- 0: The maximum resident set size (KB)                   = 2764380
+ 0: The total amount of wall time                        = 214.385095
+ 0: The maximum resident set size (KB)                   = 2765164
 
 Test 016 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/cpld_restart_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/cpld_restart_c48
 Checking test 017 cpld_restart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1110,14 +1110,14 @@ Checking test 017 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 115.898079
- 0: The maximum resident set size (KB)                   = 2202444
+ 0: The total amount of wall time                        = 102.557739
+ 0: The maximum resident set size (KB)                   = 2210412
 
 Test 017 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1144,28 +1144,28 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.184024
-  0: The maximum resident set size (KB)                   = 570840
+  0: The total amount of wall time                        = 177.429790
+  0: The maximum resident set size (KB)                   = 568792
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_CubedSphereGrid_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_CubedSphereGrid_parallel
 Checking test 019 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 173.868547
-  0: The maximum resident set size (KB)                   = 566472
+  0: The total amount of wall time                        = 174.811353
+  0: The maximum resident set size (KB)                   = 570500
 
 Test 019 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_latlon
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 181.762335
-  0: The maximum resident set size (KB)                   = 567292
+  0: The total amount of wall time                        = 179.977037
+  0: The maximum resident set size (KB)                   = 572280
 
 Test 020 control_latlon PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.430755
-  0: The maximum resident set size (KB)                   = 577160
+  0: The total amount of wall time                        = 184.808462
+  0: The maximum resident set size (KB)                   = 569592
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 597.521773
-0: The maximum resident set size (KB)                   = 789120
+0: The total amount of wall time                        = 595.598524
+0: The maximum resident set size (KB)                   = 790572
 
 Test 022 control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1258,14 +1258,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 727.644348
-  0: The maximum resident set size (KB)                   = 692508
+  0: The total amount of wall time                        = 747.297747
+  0: The maximum resident set size (KB)                   = 691540
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1276,14 +1276,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 921.145767
-  0: The maximum resident set size (KB)                   = 1015616
+  0: The total amount of wall time                        = 925.606679
+  0: The maximum resident set size (KB)                   = 1011888
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1326,14 +1326,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 797.675582
-  0: The maximum resident set size (KB)                   = 1159076
+  0: The total amount of wall time                        = 802.199767
+  0: The maximum resident set size (KB)                   = 1162132
 
-Test 025 control_c384gdas PASS Tries: 2
+Test 025 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1344,28 +1344,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 125.631461
-  0: The maximum resident set size (KB)                   = 572244
+  0: The total amount of wall time                        = 122.839600
+  0: The maximum resident set size (KB)                   = 571932
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_stochy_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 68.488769
-  0: The maximum resident set size (KB)                   = 390092
+  0: The total amount of wall time                        = 61.646363
+  0: The maximum resident set size (KB)                   = 381604
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1376,14 +1376,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 112.575911
-  0: The maximum resident set size (KB)                   = 575860
+  0: The total amount of wall time                        = 107.388663
+  0: The maximum resident set size (KB)                   = 573844
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_iovr4
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1398,14 +1398,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 192.067053
-  0: The maximum resident set size (KB)                   = 570344
+  0: The total amount of wall time                        = 184.243020
+  0: The maximum resident set size (KB)                   = 569124
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_iovr5
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1420,14 +1420,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.982520
-  0: The maximum resident set size (KB)                   = 571572
+  0: The total amount of wall time                        = 185.760267
+  0: The maximum resident set size (KB)                   = 569060
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1474,14 +1474,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 225.701693
-  0: The maximum resident set size (KB)                   = 1536504
+  0: The total amount of wall time                        = 223.659368
+  0: The maximum resident set size (KB)                   = 1540480
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_p8_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1500,14 +1500,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 430.951722
-  0: The maximum resident set size (KB)                   = 1536064
+  0: The total amount of wall time                        = 429.521008
+  0: The maximum resident set size (KB)                   = 1547380
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1546,14 +1546,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.569448
-  0: The maximum resident set size (KB)                   = 774764
+  0: The total amount of wall time                        = 118.941429
+  0: The maximum resident set size (KB)                   = 766716
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1596,14 +1596,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.195593
-  0: The maximum resident set size (KB)                   = 1521248
+  0: The total amount of wall time                        = 232.859515
+  0: The maximum resident set size (KB)                   = 1528852
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1646,14 +1646,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 217.038210
-  0: The maximum resident set size (KB)                   = 1626704
+  0: The total amount of wall time                        = 216.180720
+  0: The maximum resident set size (KB)                   = 1625176
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_p8_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1700,14 +1700,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 269.980711
-  0: The maximum resident set size (KB)                   = 1659988
+  0: The total amount of wall time                        = 275.490346
+  0: The maximum resident set size (KB)                   = 1656760
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/merra2_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/merra2_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/merra2_thompson
 Checking test 037 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1754,14 +1754,14 @@ Checking test 037 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 258.959499
-  0: The maximum resident set size (KB)                   = 1554956
+  0: The total amount of wall time                        = 259.730655
+  0: The maximum resident set size (KB)                   = 1554968
 
 Test 037 merra2_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_control
 Checking test 038 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1772,28 +1772,28 @@ Checking test 038 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 410.073175
-  0: The maximum resident set size (KB)                   = 788248
+  0: The total amount of wall time                        = 400.771259
+  0: The maximum resident set size (KB)                   = 782700
 
 Test 038 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_restart
 Checking test 039 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 202.600543
-  0: The maximum resident set size (KB)                   = 775308
+  0: The total amount of wall time                        = 209.760033
+  0: The maximum resident set size (KB)                   = 774728
 
 Test 039 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_decomp
 Checking test 040 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1804,14 +1804,14 @@ Checking test 040 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 419.026076
-  0: The maximum resident set size (KB)                   = 772728
+  0: The total amount of wall time                        = 417.217703
+  0: The maximum resident set size (KB)                   = 773160
 
 Test 040 regional_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1822,14 +1822,14 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 249.261984
-  0: The maximum resident set size (KB)                   = 757600
+  0: The total amount of wall time                        = 251.011803
+  0: The maximum resident set size (KB)                   = 761628
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_noquilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1837,28 +1837,28 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 441.954501
-  0: The maximum resident set size (KB)                   = 765896
+  0: The total amount of wall time                        = 440.033791
+  0: The maximum resident set size (KB)                   = 769776
 
 Test 042 regional_noquilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_netcdf_parallel
 Checking test 043 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 395.463072
-  0: The maximum resident set size (KB)                   = 777136
+  0: The total amount of wall time                        = 395.048550
+  0: The maximum resident set size (KB)                   = 779440
 
 Test 043 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_2dwrtdecomp
 Checking test 044 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1869,14 +1869,14 @@ Checking test 044 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 402.318285
-  0: The maximum resident set size (KB)                   = 783600
+  0: The total amount of wall time                        = 400.438266
+  0: The maximum resident set size (KB)                   = 782408
 
 Test 044 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/fv3_regional_wofs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_wofs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_wofs
 Checking test 045 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1887,14 +1887,14 @@ Checking test 045 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 516.069409
-  0: The maximum resident set size (KB)                   = 512336
+  0: The total amount of wall time                        = 508.650626
+  0: The maximum resident set size (KB)                   = 513888
 
 Test 045 regional_wofs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_control
 Checking test 046 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1941,14 +1941,14 @@ Checking test 046 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 605.561365
-  0: The maximum resident set size (KB)                   = 944316
+  0: The total amount of wall time                        = 599.071962
+  0: The maximum resident set size (KB)                   = 958440
 
 Test 046 rap_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_rrtmgp
 Checking test 047 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1995,14 +1995,14 @@ Checking test 047 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 665.676206
-  0: The maximum resident set size (KB)                   = 1071880
+  0: The total amount of wall time                        = 645.807518
+  0: The maximum resident set size (KB)                   = 1072928
 
 Test 047 rap_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_spp_sppt_shum_skeb
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_spp_sppt_shum_skeb
 Checking test 048 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2013,14 +2013,14 @@ Checking test 048 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 453.753253
-  0: The maximum resident set size (KB)                   = 1073000
+  0: The total amount of wall time                        = 401.679358
+  0: The maximum resident set size (KB)                   = 1078508
 
 Test 048 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_decomp
 Checking test 049 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2067,14 +2067,14 @@ Checking test 049 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 641.192681
-  0: The maximum resident set size (KB)                   = 936192
+  0: The total amount of wall time                        = 638.248785
+  0: The maximum resident set size (KB)                   = 949252
 
 Test 049 rap_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_2threads
 Checking test 050 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2121,14 +2121,14 @@ Checking test 050 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 591.202159
-  0: The maximum resident set size (KB)                   = 1017676
+  0: The total amount of wall time                        = 599.504770
+  0: The maximum resident set size (KB)                   = 1018944
 
 Test 050 rap_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_restart
 Checking test 051 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 051 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 302.124072
-  0: The maximum resident set size (KB)                   = 823352
+  0: The total amount of wall time                        = 304.224227
+  0: The maximum resident set size (KB)                   = 828468
 
 Test 051 rap_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_sfcdiff
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_sfcdiff
 Checking test 052 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2221,14 +2221,14 @@ Checking test 052 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 611.304107
-  0: The maximum resident set size (KB)                   = 942028
+  0: The total amount of wall time                        = 602.787404
+  0: The maximum resident set size (KB)                   = 941068
 
 Test 052 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_sfcdiff_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_sfcdiff_decomp
 Checking test 053 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2275,14 +2275,14 @@ Checking test 053 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 657.904437
-  0: The maximum resident set size (KB)                   = 936600
+  0: The total amount of wall time                        = 638.665253
+  0: The maximum resident set size (KB)                   = 951244
 
 Test 053 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_sfcdiff_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_sfcdiff_restart
 Checking test 054 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2321,14 +2321,14 @@ Checking test 054 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 444.795079
-  0: The maximum resident set size (KB)                   = 828468
+  0: The total amount of wall time                        = 448.941473
+  0: The maximum resident set size (KB)                   = 823704
 
 Test 054 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control
 Checking test 055 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2375,14 +2375,14 @@ Checking test 055 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 583.275920
-  0: The maximum resident set size (KB)                   = 944832
+  0: The total amount of wall time                        = 595.784410
+  0: The maximum resident set size (KB)                   = 945180
 
 Test 055 hrrr_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_decomp
 Checking test 056 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2429,14 +2429,14 @@ Checking test 056 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 608.903707
-  0: The maximum resident set size (KB)                   = 949128
+  0: The total amount of wall time                        = 603.490037
+  0: The maximum resident set size (KB)                   = 945988
 
 Test 056 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_2threads
 Checking test 057 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2483,14 +2483,14 @@ Checking test 057 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 558.123653
-  0: The maximum resident set size (KB)                   = 1021548
+  0: The total amount of wall time                        = 559.314040
+  0: The maximum resident set size (KB)                   = 1021596
 
 Test 057 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_restart
 Checking test 058 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2529,14 +2529,14 @@ Checking test 058 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 429.161853
-  0: The maximum resident set size (KB)                   = 825536
+  0: The total amount of wall time                        = 431.180545
+  0: The maximum resident set size (KB)                   = 825404
 
 Test 058 hrrr_control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_v1beta
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_v1beta
 Checking test 059 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2583,14 +2583,14 @@ Checking test 059 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 599.831270
-  0: The maximum resident set size (KB)                   = 949148
+  0: The total amount of wall time                        = 600.487003
+  0: The maximum resident set size (KB)                   = 954744
 
 Test 059 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_v1nssl
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_v1nssl
 Checking test 060 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2605,14 +2605,14 @@ Checking test 060 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 710.300843
-  0: The maximum resident set size (KB)                   = 635616
+  0: The total amount of wall time                        = 713.995521
+  0: The maximum resident set size (KB)                   = 629980
 
 Test 060 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_v1nssl_nohailnoccn
 Checking test 061 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2627,14 +2627,14 @@ Checking test 061 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 709.153456
-  0: The maximum resident set size (KB)                   = 635792
+  0: The total amount of wall time                        = 705.146614
+  0: The maximum resident set size (KB)                   = 634120
 
 Test 061 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_conus13km_hrrr_warm
 Checking test 062 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2643,14 +2643,14 @@ Checking test 062 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 165.344162
-  0: The maximum resident set size (KB)                   = 854256
+  0: The total amount of wall time                        = 172.563325
+  0: The maximum resident set size (KB)                   = 851532
 
 Test 062 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_smoke_conus13km_hrrr_warm
 Checking test 063 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2659,14 +2659,14 @@ Checking test 063 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 185.937909
-  0: The maximum resident set size (KB)                   = 866704
+  0: The total amount of wall time                        = 190.877547
+  0: The maximum resident set size (KB)                   = 871472
 
 Test 063 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_conus13km_radar_tten_warm
 Checking test 064 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2675,14 +2675,14 @@ Checking test 064 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 170.612107
-  0: The maximum resident set size (KB)                   = 848252
+  0: The total amount of wall time                        = 169.758882
+  0: The maximum resident set size (KB)                   = 847768
 
 Test 064 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_conus13km_hrrr_warm_2threads
 Checking test 065 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2691,14 +2691,14 @@ Checking test 065 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 111.334465
-  0: The maximum resident set size (KB)                   = 819564
+  0: The total amount of wall time                        = 111.549279
+  0: The maximum resident set size (KB)                   = 816436
 
 Test 065 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 066 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2707,108 +2707,108 @@ Checking test 066 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 112.173013
-  0: The maximum resident set size (KB)                   = 829124
+  0: The total amount of wall time                        = 112.451130
+  0: The maximum resident set size (KB)                   = 830660
 
 Test 066 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_csawmg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_csawmg
 Checking test 067 control_csawmg results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 462.625438
-  0: The maximum resident set size (KB)                   = 666552
+  0: The total amount of wall time                        = 459.997506
+  0: The maximum resident set size (KB)                   = 665996
 
 Test 067 control_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_csawmgt
 Checking test 068 control_csawmgt results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 452.662886
-  0: The maximum resident set size (KB)                   = 668372
+  0: The total amount of wall time                        = 455.309855
+  0: The maximum resident set size (KB)                   = 669124
 
 Test 068 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_ras
 Checking test 069 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 246.717805
-  0: The maximum resident set size (KB)                   = 635052
+  0: The total amount of wall time                        = 242.538457
+  0: The maximum resident set size (KB)                   = 631756
 
 Test 069 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_wam
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_wam
 Checking test 070 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 149.210421
-  0: The maximum resident set size (KB)                   = 476988
+  0: The total amount of wall time                        = 147.276994
+  0: The maximum resident set size (KB)                   = 476052
 
 Test 070 control_wam PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_conus13km_hrrr_warm_debug
 Checking test 071 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 946.131716
-  0: The maximum resident set size (KB)                   = 873128
+  0: The total amount of wall time                        = 945.227958
+  0: The maximum resident set size (KB)                   = 878816
 
 Test 071 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_conus13km_radar_tten_warm_debug
 Checking test 072 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 949.020430
-  0: The maximum resident set size (KB)                   = 877596
+  0: The total amount of wall time                        = 948.685741
+  0: The maximum resident set size (KB)                   = 877212
 
 Test 072 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_CubedSphereGrid_debug
 Checking test 073 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2835,348 +2835,348 @@ Checking test 073 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 216.082579
-  0: The maximum resident set size (KB)                   = 729944
+  0: The total amount of wall time                        = 208.208730
+  0: The maximum resident set size (KB)                   = 736980
 
 Test 073 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_wrtGauss_netcdf_parallel_debug
 Checking test 074 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 198.151970
-  0: The maximum resident set size (KB)                   = 734232
+  0: The total amount of wall time                        = 197.188996
+  0: The maximum resident set size (KB)                   = 733796
 
 Test 074 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_stochy_debug
 Checking test 075 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 221.521132
-  0: The maximum resident set size (KB)                   = 739984
+  0: The total amount of wall time                        = 218.900678
+  0: The maximum resident set size (KB)                   = 740648
 
 Test 075 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_lndp_debug
 Checking test 076 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.878958
-  0: The maximum resident set size (KB)                   = 738728
+  0: The total amount of wall time                        = 195.979590
+  0: The maximum resident set size (KB)                   = 740636
 
 Test 076 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_csawmg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_csawmg_debug
 Checking test 077 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 307.070261
-  0: The maximum resident set size (KB)                   = 786176
+  0: The total amount of wall time                        = 307.421352
+  0: The maximum resident set size (KB)                   = 783272
 
 Test 077 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_csawmgt_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_csawmgt_debug
 Checking test 078 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 300.317301
-  0: The maximum resident set size (KB)                   = 787844
+  0: The total amount of wall time                        = 303.540867
+  0: The maximum resident set size (KB)                   = 787800
 
 Test 078 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_ras_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_ras_debug
 Checking test 079 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 200.851919
-  0: The maximum resident set size (KB)                   = 748120
+  0: The total amount of wall time                        = 199.228476
+  0: The maximum resident set size (KB)                   = 744764
 
 Test 079 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_diag_debug
 Checking test 080 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.885265
-  0: The maximum resident set size (KB)                   = 791352
+  0: The total amount of wall time                        = 203.824528
+  0: The maximum resident set size (KB)                   = 794364
 
 Test 080 control_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_debug_p8
 Checking test 081 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.733201
-  0: The maximum resident set size (KB)                   = 1551032
+  0: The total amount of wall time                        = 228.774670
+  0: The maximum resident set size (KB)                   = 1559728
 
 Test 081 control_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_debug
 Checking test 082 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1281.389152
-  0: The maximum resident set size (KB)                   = 796600
+  0: The total amount of wall time                        = 1283.388952
+  0: The maximum resident set size (KB)                   = 794480
 
 Test 082 regional_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_control_debug
 Checking test 083 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 363.019224
-  0: The maximum resident set size (KB)                   = 1112036
+  0: The total amount of wall time                        = 358.236575
+  0: The maximum resident set size (KB)                   = 1113632
 
 Test 083 rap_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_debug
 Checking test 084 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.797906
-  0: The maximum resident set size (KB)                   = 1114532
+  0: The total amount of wall time                        = 350.370113
+  0: The maximum resident set size (KB)                   = 1112688
 
 Test 084 hrrr_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_unified_drag_suite_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_unified_drag_suite_debug
 Checking test 085 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 361.643198
-  0: The maximum resident set size (KB)                   = 1110676
+  0: The total amount of wall time                        = 357.808897
+  0: The maximum resident set size (KB)                   = 1115280
 
 Test 085 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_diag_debug
 Checking test 086 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 378.118141
-  0: The maximum resident set size (KB)                   = 1191480
+  0: The total amount of wall time                        = 379.694652
+  0: The maximum resident set size (KB)                   = 1191576
 
 Test 086 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_cires_ugwp_debug
 Checking test 087 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 366.125884
-  0: The maximum resident set size (KB)                   = 1111400
+  0: The total amount of wall time                        = 364.728023
+  0: The maximum resident set size (KB)                   = 1115672
 
 Test 087 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_unified_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_unified_ugwp_debug
 Checking test 088 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 370.192532
-  0: The maximum resident set size (KB)                   = 1106968
+  0: The total amount of wall time                        = 364.992830
+  0: The maximum resident set size (KB)                   = 1116044
 
 Test 088 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 363.240018
-  0: The maximum resident set size (KB)                   = 1111564
+  0: The total amount of wall time                        = 361.652453
+  0: The maximum resident set size (KB)                   = 1110236
 
 Test 089 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_flake_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_flake_debug
 Checking test 090 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 360.918493
-  0: The maximum resident set size (KB)                   = 1109808
+  0: The total amount of wall time                        = 367.348905
+  0: The maximum resident set size (KB)                   = 1110736
 
 Test 090 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_progcld_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_progcld_thompson_debug
 Checking test 091 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 368.351865
-  0: The maximum resident set size (KB)                   = 1113208
+  0: The total amount of wall time                        = 359.696493
+  0: The maximum resident set size (KB)                   = 1113908
 
 Test 091 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_noah_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_noah_debug
 Checking test 092 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 354.085991
-  0: The maximum resident set size (KB)                   = 1109476
+  0: The total amount of wall time                        = 351.483874
+  0: The maximum resident set size (KB)                   = 1112136
 
 Test 092 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_rrtmgp_debug
 Checking test 093 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 601.801488
-  0: The maximum resident set size (KB)                   = 1230360
+  0: The total amount of wall time                        = 602.945318
+  0: The maximum resident set size (KB)                   = 1244180
 
 Test 093 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_sfcdiff_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_sfcdiff_debug
 Checking test 094 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 368.911209
-  0: The maximum resident set size (KB)                   = 1115952
+  0: The total amount of wall time                        = 363.013996
+  0: The maximum resident set size (KB)                   = 1108820
 
 Test 094 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 095 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 588.913390
-  0: The maximum resident set size (KB)                   = 1105844
+  0: The total amount of wall time                        = 588.529908
+  0: The maximum resident set size (KB)                   = 1113064
 
 Test 095 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rrfs_v1beta_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rrfs_v1beta_debug
 Checking test 096 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 359.154527
-  0: The maximum resident set size (KB)                   = 1103128
+  0: The total amount of wall time                        = 354.962121
+  0: The maximum resident set size (KB)                   = 1107568
 
 Test 096 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_wam_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_wam_debug
 Checking test 097 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 365.767232
-  0: The maximum resident set size (KB)                   = 435048
+  0: The total amount of wall time                        = 363.766834
+  0: The maximum resident set size (KB)                   = 435348
 
 Test 097 control_wam_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 098 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3187,14 +3187,14 @@ Checking test 098 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 420.582607
-  0: The maximum resident set size (KB)                   = 980328
+  0: The total amount of wall time                        = 381.763453
+  0: The maximum resident set size (KB)                   = 972012
 
 Test 098 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_control_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_control_dyn32_phy32
 Checking test 099 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3241,14 +3241,14 @@ Checking test 099 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 489.465562
-  0: The maximum resident set size (KB)                   = 840648
+  0: The total amount of wall time                        = 487.806563
+  0: The maximum resident set size (KB)                   = 841352
 
 Test 099 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_dyn32_phy32
 Checking test 100 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3295,14 +3295,14 @@ Checking test 100 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 259.021725
-  0: The maximum resident set size (KB)                   = 836020
+  0: The total amount of wall time                        = 257.104592
+  0: The maximum resident set size (KB)                   = 820996
 
 Test 100 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_2threads_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_2threads_dyn32_phy32
 Checking test 101 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3349,14 +3349,14 @@ Checking test 101 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 477.771807
-  0: The maximum resident set size (KB)                   = 878972
+  0: The total amount of wall time                        = 474.402922
+  0: The maximum resident set size (KB)                   = 889052
 
 Test 101 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_2threads_dyn32_phy32
 Checking test 102 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3403,14 +3403,14 @@ Checking test 102 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 252.257034
-  0: The maximum resident set size (KB)                   = 889440
+  0: The total amount of wall time                        = 260.004315
+  0: The maximum resident set size (KB)                   = 883004
 
 Test 102 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_decomp_dyn32_phy32
 Checking test 103 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3457,14 +3457,14 @@ Checking test 103 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 273.107074
-  0: The maximum resident set size (KB)                   = 830236
+  0: The total amount of wall time                        = 271.477463
+  0: The maximum resident set size (KB)                   = 826376
 
 Test 103 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_restart_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_restart_dyn32_phy32
 Checking test 104 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3503,14 +3503,14 @@ Checking test 104 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 361.010387
-  0: The maximum resident set size (KB)                   = 800224
+  0: The total amount of wall time                        = 361.182073
+  0: The maximum resident set size (KB)                   = 808232
 
 Test 104 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_restart_dyn32_phy32
 Checking test 105 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3549,21 +3549,21 @@ Checking test 105 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.805269
-  0: The maximum resident set size (KB)                   = 762068
+  0: The total amount of wall time                        = 128.531091
+  0: The maximum resident set size (KB)                   = 762836
 
 Test 105 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_control_dyn64_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_control_dyn64_phy32
 Checking test 106 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3603,81 +3603,81 @@ Checking test 106 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 310.724844
-  0: The maximum resident set size (KB)                   = 866864
+  0: The total amount of wall time                        = 317.161786
+  0: The maximum resident set size (KB)                   = 873352
 
 Test 106 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_control_debug_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_control_debug_dyn32_phy32
 Checking test 107 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 356.490816
-  0: The maximum resident set size (KB)                   = 1000596
+  0: The total amount of wall time                        = 356.911359
+  0: The maximum resident set size (KB)                   = 1001032
 
 Test 107 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hrrr_control_debug_dyn32_phy32
 Checking test 108 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.164591
-  0: The maximum resident set size (KB)                   = 1002368
+  0: The total amount of wall time                        = 352.024288
+  0: The maximum resident set size (KB)                   = 1000068
 
 Test 108 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/rap_control_dyn64_phy32_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/rap_control_dyn64_phy32_debug
 Checking test 109 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 362.537859
-  0: The maximum resident set size (KB)                   = 1029508
+  0: The total amount of wall time                        = 360.024786
+  0: The maximum resident set size (KB)                   = 1035076
 
 Test 109 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_atm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_atm
 Checking test 110 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 316.656003
-  0: The maximum resident set size (KB)                   = 1198840
+  0: The total amount of wall time                        = 326.024783
+  0: The maximum resident set size (KB)                   = 1179256
 
 Test 110 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_atm_thompson_gfdlsf
 Checking test 111 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 370.162645
-  0: The maximum resident set size (KB)                   = 1553048
+  0: The total amount of wall time                        = 379.604414
+  0: The maximum resident set size (KB)                   = 1570728
 
 Test 111 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_atm_ocn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_atm_ocn
 Checking test 112 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3686,14 +3686,14 @@ Checking test 112 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 486.196370
-  0: The maximum resident set size (KB)                   = 1263504
+  0: The total amount of wall time                        = 481.820165
+  0: The maximum resident set size (KB)                   = 1268880
 
 Test 112 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_atm_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_atm_wav
 Checking test 113 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3702,14 +3702,14 @@ Checking test 113 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 891.690532
-  0: The maximum resident set size (KB)                   = 1305496
+  0: The total amount of wall time                        = 892.542304
+  0: The maximum resident set size (KB)                   = 1218672
 
 Test 113 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_atm_ocn_wav
 Checking test 114 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3720,14 +3720,14 @@ Checking test 114 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 998.202052
-  0: The maximum resident set size (KB)                   = 1304752
+  0: The total amount of wall time                        = 994.393687
+  0: The maximum resident set size (KB)                   = 1317936
 
 Test 114 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_docn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_docn
 Checking test 115 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3735,14 +3735,14 @@ Checking test 115 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 462.426889
-  0: The maximum resident set size (KB)                   = 1289652
+  0: The total amount of wall time                        = 461.337382
+  0: The maximum resident set size (KB)                   = 1253120
 
 Test 115 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_docn_oisst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_docn_oisst
 Checking test 116 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3750,131 +3750,131 @@ Checking test 116 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 458.486119
-  0: The maximum resident set size (KB)                   = 1277156
+  0: The total amount of wall time                        = 465.522595
+  0: The maximum resident set size (KB)                   = 1275508
 
 Test 116 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/hafs_regional_datm_cdeps
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/hafs_regional_datm_cdeps
 Checking test 117 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1244.505698
-  0: The maximum resident set size (KB)                   = 972676
+  0: The total amount of wall time                        = 1306.934742
+  0: The maximum resident set size (KB)                   = 977792
 
 Test 117 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_control_cfsr
 Checking test 118 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 211.142135
- 0: The maximum resident set size (KB)                   = 973240
+ 0: The total amount of wall time                        = 214.063744
+ 0: The maximum resident set size (KB)                   = 964452
 
 Test 118 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_restart_cfsr
 Checking test 119 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 131.766790
- 0: The maximum resident set size (KB)                   = 936344
+ 0: The total amount of wall time                        = 129.967907
+ 0: The maximum resident set size (KB)                   = 926516
 
 Test 119 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_control_gefs
 Checking test 120 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 222.859058
- 0: The maximum resident set size (KB)                   = 851264
+ 0: The total amount of wall time                        = 206.238790
+ 0: The maximum resident set size (KB)                   = 852292
 
 Test 120 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_iau_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_iau_gefs
 Checking test 121 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 209.727339
- 0: The maximum resident set size (KB)                   = 851888
+ 0: The total amount of wall time                        = 210.291115
+ 0: The maximum resident set size (KB)                   = 856632
 
 Test 121 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_stochy_gefs
 Checking test 122 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 210.711446
- 0: The maximum resident set size (KB)                   = 854708
+ 0: The total amount of wall time                        = 214.417142
+ 0: The maximum resident set size (KB)                   = 859436
 
 Test 122 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_ciceC_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_ciceC_cfsr
 Checking test 123 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 212.599137
- 0: The maximum resident set size (KB)                   = 970348
+ 0: The total amount of wall time                        = 216.029408
+ 0: The maximum resident set size (KB)                   = 961692
 
 Test 123 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_bulk_cfsr
 Checking test 124 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 213.449543
- 0: The maximum resident set size (KB)                   = 966576
+ 0: The total amount of wall time                        = 214.787899
+ 0: The maximum resident set size (KB)                   = 982028
 
 Test 124 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_bulk_gefs
 Checking test 125 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 205.795466
- 0: The maximum resident set size (KB)                   = 858600
+ 0: The total amount of wall time                        = 205.852775
+ 0: The maximum resident set size (KB)                   = 853052
 
 Test 125 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_mx025_cfsr
 Checking test 126 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3883,14 +3883,14 @@ Checking test 126 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 593.050706
-  0: The maximum resident set size (KB)                   = 763600
+  0: The total amount of wall time                        = 576.928817
+  0: The maximum resident set size (KB)                   = 767556
 
 Test 126 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_mx025_gefs
 Checking test 127 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3899,64 +3899,64 @@ Checking test 127 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 575.024003
-  0: The maximum resident set size (KB)                   = 728456
+  0: The total amount of wall time                        = 584.979817
+  0: The maximum resident set size (KB)                   = 740748
 
 Test 127 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_multiple_files_cfsr
 Checking test 128 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.352553
- 0: The maximum resident set size (KB)                   = 974896
+ 0: The total amount of wall time                        = 213.433130
+ 0: The maximum resident set size (KB)                   = 972292
 
 Test 128 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_3072x1536_cfsr
 Checking test 129 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 315.110129
- 0: The maximum resident set size (KB)                   = 2249732
+ 0: The total amount of wall time                        = 316.501611
+ 0: The maximum resident set size (KB)                   = 2257440
 
 Test 129 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_gfs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_gfs
 Checking test 130 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 300.616012
- 0: The maximum resident set size (KB)                   = 2268684
+ 0: The total amount of wall time                        = 297.763087
+ 0: The maximum resident set size (KB)                   = 2190364
 
 Test 130 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_debug_cfsr
 Checking test 131 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 588.627753
- 0: The maximum resident set size (KB)                   = 933124
+ 0: The total amount of wall time                        = 580.234314
+ 0: The maximum resident set size (KB)                   = 926752
 
 Test 131 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_lnd_gswp3
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_lnd_gswp3
 Checking test 132 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -3965,14 +3965,14 @@ Checking test 132 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 9.823420
-  0: The maximum resident set size (KB)                   = 239136
+  0: The total amount of wall time                        = 10.636538
+  0: The maximum resident set size (KB)                   = 251296
 
 Test 132 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/datm_cdeps_lnd_gswp3_rst
 Checking test 133 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -3981,33 +3981,33 @@ Checking test 133 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 33.974218
-  0: The maximum resident set size (KB)                   = 243580
+  0: The total amount of wall time                        = 25.743079
+  0: The maximum resident set size (KB)                   = 246856
 
 Test 133 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_p8_atmlnd_sbs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_p8_atmlnd_sbs
 Checking test 134 control_p8_atmlnd_sbs results ....
- Comparing sfcf000.tile1.nc ............ALT CHECK......OK
- Comparing sfcf000.tile2.nc ............ALT CHECK......OK
- Comparing sfcf000.tile3.nc ............ALT CHECK......OK
- Comparing sfcf000.tile4.nc ............ALT CHECK......OK
- Comparing sfcf000.tile5.nc ............ALT CHECK......OK
- Comparing sfcf000.tile6.nc ............ALT CHECK......OK
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf000.tile1.nc .........OK
  Comparing atmf000.tile2.nc .........OK
  Comparing atmf000.tile3.nc .........OK
@@ -4073,14 +4073,14 @@ Checking test 134 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 282.365620
-  0: The maximum resident set size (KB)                   = 1586248
+  0: The total amount of wall time                        = 279.592866
+  0: The maximum resident set size (KB)                   = 1584280
 
 Test 134 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/control_atmwav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/control_atmwav
 Checking test 135 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4124,14 +4124,14 @@ Checking test 135 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 115.805489
-  0: The maximum resident set size (KB)                   = 603176
+  0: The total amount of wall time                        = 115.518282
+  0: The maximum resident set size (KB)                   = 597216
 
 Test 135 control_atmwav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/atmaero_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/atmaero_control_p8
 Checking test 136 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4175,14 +4175,14 @@ Checking test 136 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 301.324633
-  0: The maximum resident set size (KB)                   = 1645588
+  0: The total amount of wall time                        = 308.498014
+  0: The maximum resident set size (KB)                   = 1632924
 
 Test 136 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/atmaero_control_p8_rad
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/atmaero_control_p8_rad
 Checking test 137 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4226,14 +4226,14 @@ Checking test 137 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 373.256247
-  0: The maximum resident set size (KB)                   = 1656836
+  0: The total amount of wall time                        = 373.211074
+  0: The maximum resident set size (KB)                   = 1666748
 
 Test 137 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/atmaero_control_p8_rad_micro
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/atmaero_control_p8_rad_micro
 Checking test 138 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4277,21 +4277,21 @@ Checking test 138 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 378.234217
-  0: The maximum resident set size (KB)                   = 1660456
+  0: The total amount of wall time                        = 381.821701
+  0: The maximum resident set size (KB)                   = 1663156
 
 Test 138 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_21981/regional_atmaq
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_170790/regional_atmaq
 Checking test 139 regional_atmaq results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf003.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf003.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4300,12 +4300,12 @@ Checking test 139 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 873.880398
-  0: The maximum resident set size (KB)                   = 1435832
+  0: The total amount of wall time                        = 968.362652
+  0: The maximum resident set size (KB)                   = 1319380
 
 Test 139 regional_atmaq PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 25 22:29:23 GMT 2023
-Elapsed time: 02h:27m:26s. Have a nice day!
+Fri Jan 27 01:34:17 GMT 2023
+Elapsed time: 02h:26m:58s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,37 +1,37 @@
-Wed Jan 25 18:17:00 CST 2023
+Thu Jan 26 15:42:15 CST 2023
 Start Regression test
 
-Compile 001 elapsed time 757 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 771 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 660 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 267 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 265 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 595 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 598 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 574 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 570 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 570 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 540 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 245 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 150 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 527 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 563 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 168 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 158 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 618 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 755 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 605 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 192 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 022 elapsed time 153 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 023 elapsed time 84 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 560 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 025 elapsed time 583 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 593 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 538 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 200 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 736 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 742 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 638 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 248 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 220 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 615 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 649 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 579 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 576 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 577 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 527 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 250 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 208 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 534 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 545 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 199 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 1211 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 1211 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 1137 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 237 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 022 elapsed time 145 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 023 elapsed time 58 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 1023 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 025 elapsed time 997 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 929 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 847 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 161 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8_mixedmode
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_p8_mixedmode
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -96,33 +96,33 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 306.220384
-  0: The maximum resident set size (KB)                   = 3138456
+  0: The total amount of wall time                        = 310.485362
+  0: The maximum resident set size (KB)                   = 3141136
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_gfsv17
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_gfsv17
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_gfsv17
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -167,33 +167,33 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 225.256865
-  0: The maximum resident set size (KB)                   = 1735680
+  0: The total amount of wall time                        = 222.597503
+  0: The maximum resident set size (KB)                   = 1731516
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -239,21 +239,21 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.319358
-  0: The maximum resident set size (KB)                   = 3178828
+  0: The total amount of wall time                        = 345.680208
+  0: The maximum resident set size (KB)                   = 3177100
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -299,21 +299,21 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 216.890235
-  0: The maximum resident set size (KB)                   = 3045080
+  0: The total amount of wall time                        = 215.025455
+  0: The maximum resident set size (KB)                   = 3056440
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_2threads_p8
 Checking test 005 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -359,21 +359,21 @@ Checking test 005 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 405.448774
-  0: The maximum resident set size (KB)                   = 3512616
+  0: The total amount of wall time                        = 409.756491
+  0: The maximum resident set size (KB)                   = 3513192
 
 Test 005 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_esmfthreads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_esmfthreads_p8
 Checking test 006 cpld_esmfthreads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -419,21 +419,21 @@ Checking test 006 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 406.139138
-  0: The maximum resident set size (KB)                   = 3510896
+  0: The total amount of wall time                        = 413.726233
+  0: The maximum resident set size (KB)                   = 3511148
 
 Test 006 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -479,21 +479,21 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 344.240875
-  0: The maximum resident set size (KB)                   = 3168236
+  0: The total amount of wall time                        = 346.072738
+  0: The maximum resident set size (KB)                   = 3171232
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -539,33 +539,33 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 279.543363
-  0: The maximum resident set size (KB)                   = 3026824
+  0: The total amount of wall time                        = 288.824672
+  0: The maximum resident set size (KB)                   = 3033620
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_ciceC_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_ciceC_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -611,21 +611,21 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 343.659093
-  0: The maximum resident set size (KB)                   = 3177376
+  0: The total amount of wall time                        = 347.518593
+  0: The maximum resident set size (KB)                   = 3177352
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -671,21 +671,21 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 648.353743
-  0: The maximum resident set size (KB)                   = 3253908
+  0: The total amount of wall time                        = 813.176918
+  0: The maximum resident set size (KB)                   = 3252128
 
 Test 010 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -731,17 +731,17 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 501.272508
-  0: The maximum resident set size (KB)                   = 3158116
+  0: The total amount of wall time                        = 471.504744
+  0: The maximum resident set size (KB)                   = 3161400
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_bmark_p8
 Checking test 012 cpld_bmark_p8 results ....
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing GFSFLX.GrbF06 .........OK
  Comparing GFSPRS.GrbF06 .........OK
  Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
@@ -786,17 +786,17 @@ Checking test 012 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 852.807476
-   0: The maximum resident set size (KB)                   = 4036784
+   0: The total amount of wall time                        = 914.545473
+   0: The maximum resident set size (KB)                   = 4038768
 
 Test 012 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_restart_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_restart_bmark_p8
 Checking test 013 cpld_restart_bmark_p8 results ....
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing GFSFLX.GrbF06 .........OK
  Comparing GFSPRS.GrbF06 .........OK
  Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
@@ -841,33 +841,33 @@ Checking test 013 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 804.645870
-   0: The maximum resident set size (KB)                   = 3972888
+   0: The total amount of wall time                        = 542.691017
+   0: The maximum resident set size (KB)                   = 3979132
 
 Test 013 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_noaero_p8
 Checking test 014 cpld_control_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -912,33 +912,33 @@ Checking test 014 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 253.078388
-  0: The maximum resident set size (KB)                   = 1722060
+  0: The total amount of wall time                        = 256.919847
+  0: The maximum resident set size (KB)                   = 1720656
 
 Test 014 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c96_noaero_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_nowave_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_nowave_noaero_p8
 Checking test 015 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -981,21 +981,21 @@ Checking test 015 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 256.669038
-  0: The maximum resident set size (KB)                   = 1771600
+  0: The total amount of wall time                        = 261.886722
+  0: The maximum resident set size (KB)                   = 1768572
 
 Test 015 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_debug_p8
 Checking test 016 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1041,21 +1041,21 @@ Checking test 016 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 681.258282
-  0: The maximum resident set size (KB)                   = 3245140
+  0: The total amount of wall time                        = 668.368748
+  0: The maximum resident set size (KB)                   = 3245948
 
 Test 016 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_debug_noaero_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_debug_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_debug_noaero_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_debug_noaero_p8
 Checking test 017 cpld_debug_noaero_p8 results ....
- Comparing sfcf003.tile1.nc ............ALT CHECK......OK
- Comparing sfcf003.tile2.nc ............ALT CHECK......OK
- Comparing sfcf003.tile3.nc ............ALT CHECK......OK
- Comparing sfcf003.tile4.nc ............ALT CHECK......OK
- Comparing sfcf003.tile5.nc ............ALT CHECK......OK
- Comparing sfcf003.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
  Comparing atmf003.tile1.nc .........OK
  Comparing atmf003.tile2.nc .........OK
  Comparing atmf003.tile3.nc .........OK
@@ -1100,33 +1100,33 @@ Checking test 017 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 419.875263
-  0: The maximum resident set size (KB)                   = 1746924
+  0: The total amount of wall time                        = 419.059455
+  0: The maximum resident set size (KB)                   = 1743908
 
 Test 017 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_noaero_p8_agrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_noaero_p8_agrid
 Checking test 018 cpld_control_noaero_p8_agrid results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1169,21 +1169,21 @@ Checking test 018 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 264.902755
-  0: The maximum resident set size (KB)                   = 1761888
+  0: The total amount of wall time                        = 266.896048
+  0: The maximum resident set size (KB)                   = 1758972
 
 Test 018 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_control_c48
 Checking test 019 cpld_control_c48 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1226,21 +1226,21 @@ Checking test 019 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 497.442725
- 0: The maximum resident set size (KB)                   = 2799100
+ 0: The total amount of wall time                        = 497.276692
+ 0: The maximum resident set size (KB)                   = 2804592
 
 Test 019 cpld_control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_warmstart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_warmstart_c48
 Checking test 020 cpld_warmstart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1283,21 +1283,21 @@ Checking test 020 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 134.836161
- 0: The maximum resident set size (KB)                   = 2807852
+ 0: The total amount of wall time                        = 137.031119
+ 0: The maximum resident set size (KB)                   = 2805616
 
 Test 020 cpld_warmstart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/cpld_restart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/cpld_restart_c48
 Checking test 021 cpld_restart_c48 results ....
- Comparing sfcf006.tile1.nc ............ALT CHECK......OK
- Comparing sfcf006.tile2.nc ............ALT CHECK......OK
- Comparing sfcf006.tile3.nc ............ALT CHECK......OK
- Comparing sfcf006.tile4.nc ............ALT CHECK......OK
- Comparing sfcf006.tile5.nc ............ALT CHECK......OK
- Comparing sfcf006.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
  Comparing atmf006.tile1.nc .........OK
  Comparing atmf006.tile2.nc .........OK
  Comparing atmf006.tile3.nc .........OK
@@ -1340,14 +1340,14 @@ Checking test 021 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 73.797644
- 0: The maximum resident set size (KB)                   = 2232748
+ 0: The total amount of wall time                        = 73.020106
+ 0: The maximum resident set size (KB)                   = 2243724
 
 Test 021 cpld_restart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1374,28 +1374,28 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.024589
-  0: The maximum resident set size (KB)                   = 630416
+  0: The total amount of wall time                        = 130.127537
+  0: The maximum resident set size (KB)                   = 632648
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_CubedSphereGrid_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_CubedSphereGrid_parallel
 Checking test 023 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 126.284217
-  0: The maximum resident set size (KB)                   = 629700
+  0: The total amount of wall time                        = 127.545738
+  0: The maximum resident set size (KB)                   = 632380
 
 Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_latlon
 Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1406,14 +1406,14 @@ Checking test 024 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 132.499298
-  0: The maximum resident set size (KB)                   = 631004
+  0: The total amount of wall time                        = 132.748446
+  0: The maximum resident set size (KB)                   = 631332
 
 Test 024 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_wrtGauss_netcdf_parallel
 Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1424,14 +1424,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.343165
-  0: The maximum resident set size (KB)                   = 633128
+  0: The total amount of wall time                        = 135.493225
+  0: The maximum resident set size (KB)                   = 633144
 
 Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_c48
 Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1470,14 +1470,14 @@ Checking test 026 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 344.969074
-0: The maximum resident set size (KB)                   = 802180
+0: The total amount of wall time                        = 345.816767
+0: The maximum resident set size (KB)                   = 815516
 
 Test 026 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_c192
 Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 027 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 530.913913
-  0: The maximum resident set size (KB)                   = 759904
+  0: The total amount of wall time                        = 523.265914
+  0: The maximum resident set size (KB)                   = 760988
 
 Test 027 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_c384
 Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1506,14 +1506,14 @@ Checking test 028 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 600.839217
-  0: The maximum resident set size (KB)                   = 1171636
+  0: The total amount of wall time                        = 584.955530
+  0: The maximum resident set size (KB)                   = 1172196
 
 Test 028 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_c384gdas
 Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1556,14 +1556,14 @@ Checking test 029 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 519.478286
-  0: The maximum resident set size (KB)                   = 1313472
+  0: The total amount of wall time                        = 516.630518
+  0: The maximum resident set size (KB)                   = 1310300
 
 Test 029 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_stochy
 Checking test 030 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1574,28 +1574,28 @@ Checking test 030 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 90.058659
-  0: The maximum resident set size (KB)                   = 636592
+  0: The total amount of wall time                        = 87.210611
+  0: The maximum resident set size (KB)                   = 635072
 
 Test 030 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_stochy_restart
 Checking test 031 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.358470
-  0: The maximum resident set size (KB)                   = 483216
+  0: The total amount of wall time                        = 46.281099
+  0: The maximum resident set size (KB)                   = 481980
 
 Test 031 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_lndp
 Checking test 032 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1606,14 +1606,14 @@ Checking test 032 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 79.791091
-  0: The maximum resident set size (KB)                   = 630352
+  0: The total amount of wall time                        = 80.459591
+  0: The maximum resident set size (KB)                   = 632292
 
 Test 032 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_iovr4
 Checking test 033 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1628,14 +1628,14 @@ Checking test 033 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.050383
-  0: The maximum resident set size (KB)                   = 628864
+  0: The total amount of wall time                        = 134.126741
+  0: The maximum resident set size (KB)                   = 631668
 
 Test 033 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_iovr5
 Checking test 034 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1650,14 +1650,14 @@ Checking test 034 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.401043
-  0: The maximum resident set size (KB)                   = 629380
+  0: The total amount of wall time                        = 133.483614
+  0: The maximum resident set size (KB)                   = 630336
 
 Test 034 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_p8
 Checking test 035 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1704,14 +1704,14 @@ Checking test 035 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.302292
-  0: The maximum resident set size (KB)                   = 1598968
+  0: The total amount of wall time                        = 166.454656
+  0: The maximum resident set size (KB)                   = 1607660
 
 Test 035 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_p8_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_p8_lndp
 Checking test 036 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1730,14 +1730,14 @@ Checking test 036 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 312.725411
-  0: The maximum resident set size (KB)                   = 1602044
+  0: The total amount of wall time                        = 311.450532
+  0: The maximum resident set size (KB)                   = 1601212
 
 Test 036 control_p8_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_restart_p8
 Checking test 037 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1776,14 +1776,14 @@ Checking test 037 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.577887
-  0: The maximum resident set size (KB)                   = 864400
+  0: The total amount of wall time                        = 87.600942
+  0: The maximum resident set size (KB)                   = 862852
 
 Test 037 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_decomp_p8
 Checking test 038 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1826,14 +1826,14 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.213935
-  0: The maximum resident set size (KB)                   = 1586704
+  0: The total amount of wall time                        = 173.809240
+  0: The maximum resident set size (KB)                   = 1591024
 
 Test 038 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_2threads_p8
 Checking test 039 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1876,14 +1876,14 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 181.106856
-  0: The maximum resident set size (KB)                   = 1681552
+  0: The total amount of wall time                        = 179.624840
+  0: The maximum resident set size (KB)                   = 1689432
 
 Test 039 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_p8_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_p8_rrtmgp
 Checking test 040 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1930,14 +1930,14 @@ Checking test 040 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.365780
-  0: The maximum resident set size (KB)                   = 1729736
+  0: The total amount of wall time                        = 200.442345
+  0: The maximum resident set size (KB)                   = 1732040
 
 Test 040 control_p8_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/merra2_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/merra2_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/merra2_thompson
 Checking test 041 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1984,14 +1984,14 @@ Checking test 041 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 194.285450
-  0: The maximum resident set size (KB)                   = 1606392
+  0: The total amount of wall time                        = 192.071061
+  0: The maximum resident set size (KB)                   = 1606908
 
 Test 041 merra2_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_control
 Checking test 042 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2002,28 +2002,28 @@ Checking test 042 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 297.915959
-  0: The maximum resident set size (KB)                   = 864752
+  0: The total amount of wall time                        = 294.372647
+  0: The maximum resident set size (KB)                   = 866208
 
 Test 042 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_restart
 Checking test 043 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 150.991680
-  0: The maximum resident set size (KB)                   = 860836
+  0: The total amount of wall time                        = 148.226753
+  0: The maximum resident set size (KB)                   = 861072
 
 Test 043 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_decomp
 Checking test 044 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2034,14 +2034,14 @@ Checking test 044 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 313.167333
-  0: The maximum resident set size (KB)                   = 855760
+  0: The total amount of wall time                        = 312.196876
+  0: The maximum resident set size (KB)                   = 853332
 
 Test 044 regional_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_2threads
 Checking test 045 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2052,14 +2052,14 @@ Checking test 045 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 210.087094
-  0: The maximum resident set size (KB)                   = 841620
+  0: The total amount of wall time                        = 211.622578
+  0: The maximum resident set size (KB)                   = 835460
 
 Test 045 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_noquilt
 Checking test 046 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2067,28 +2067,28 @@ Checking test 046 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 320.457824
-  0: The maximum resident set size (KB)                   = 857364
+  0: The total amount of wall time                        = 320.156424
+  0: The maximum resident set size (KB)                   = 860660
 
 Test 046 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_netcdf_parallel
 Checking test 047 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 291.807788
-  0: The maximum resident set size (KB)                   = 853268
+  0: The total amount of wall time                        = 291.293403
+  0: The maximum resident set size (KB)                   = 862256
 
 Test 047 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_2dwrtdecomp
 Checking test 048 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 048 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 296.657541
-  0: The maximum resident set size (KB)                   = 866352
+  0: The total amount of wall time                        = 294.004350
+  0: The maximum resident set size (KB)                   = 863316
 
 Test 048 regional_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/fv3_regional_wofs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_wofs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_wofs
 Checking test 049 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2117,14 +2117,14 @@ Checking test 049 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 373.420823
-  0: The maximum resident set size (KB)                   = 620044
+  0: The total amount of wall time                        = 373.982015
+  0: The maximum resident set size (KB)                   = 619756
 
 Test 049 regional_wofs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_control
 Checking test 050 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2171,14 +2171,14 @@ Checking test 050 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 457.601394
-  0: The maximum resident set size (KB)                   = 1058324
+  0: The total amount of wall time                        = 458.254237
+  0: The maximum resident set size (KB)                   = 1058456
 
 Test 050 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_rrtmgp
 Checking test 051 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2225,14 +2225,14 @@ Checking test 051 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 493.139653
-  0: The maximum resident set size (KB)                   = 1222996
+  0: The total amount of wall time                        = 486.611497
+  0: The maximum resident set size (KB)                   = 1216300
 
 Test 051 rap_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_spp_sppt_shum_skeb
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_spp_sppt_shum_skeb
 Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2243,14 +2243,14 @@ Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 329.913113
-  0: The maximum resident set size (KB)                   = 1177016
+  0: The total amount of wall time                        = 325.481339
+  0: The maximum resident set size (KB)                   = 1185516
 
 Test 052 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_decomp
 Checking test 053 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2297,14 +2297,14 @@ Checking test 053 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 482.289608
-  0: The maximum resident set size (KB)                   = 1001996
+  0: The total amount of wall time                        = 511.485616
+  0: The maximum resident set size (KB)                   = 1003076
 
 Test 053 rap_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_2threads
 Checking test 054 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2351,14 +2351,14 @@ Checking test 054 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 483.063195
-  0: The maximum resident set size (KB)                   = 1126036
+  0: The total amount of wall time                        = 509.752535
+  0: The maximum resident set size (KB)                   = 1130316
 
 Test 054 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_restart
 Checking test 055 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2397,14 +2397,14 @@ Checking test 055 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.893762
-  0: The maximum resident set size (KB)                   = 968488
+  0: The total amount of wall time                        = 259.819504
+  0: The maximum resident set size (KB)                   = 962268
 
 Test 055 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_sfcdiff
 Checking test 056 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2451,14 +2451,14 @@ Checking test 056 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 454.172990
-  0: The maximum resident set size (KB)                   = 1059236
+  0: The total amount of wall time                        = 449.785073
+  0: The maximum resident set size (KB)                   = 1062832
 
 Test 056 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_sfcdiff_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_sfcdiff_decomp
 Checking test 057 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2505,14 +2505,14 @@ Checking test 057 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 478.438233
-  0: The maximum resident set size (KB)                   = 1007388
+  0: The total amount of wall time                        = 476.024462
+  0: The maximum resident set size (KB)                   = 1008924
 
 Test 057 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_sfcdiff_restart
 Checking test 058 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2551,14 +2551,14 @@ Checking test 058 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 343.030590
-  0: The maximum resident set size (KB)                   = 986104
+  0: The total amount of wall time                        = 341.166341
+  0: The maximum resident set size (KB)                   = 989940
 
 Test 058 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control
 Checking test 059 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2605,14 +2605,14 @@ Checking test 059 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 437.500797
-  0: The maximum resident set size (KB)                   = 1054884
+  0: The total amount of wall time                        = 436.017409
+  0: The maximum resident set size (KB)                   = 1058584
 
 Test 059 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_decomp
 Checking test 060 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2659,14 +2659,14 @@ Checking test 060 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.394867
-  0: The maximum resident set size (KB)                   = 1002904
+  0: The total amount of wall time                        = 486.227658
+  0: The maximum resident set size (KB)                   = 1009020
 
 Test 060 hrrr_control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_2threads
 Checking test 061 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2713,14 +2713,14 @@ Checking test 061 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 452.585506
-  0: The maximum resident set size (KB)                   = 1132768
+  0: The total amount of wall time                        = 448.897582
+  0: The maximum resident set size (KB)                   = 1130112
 
 Test 061 hrrr_control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_restart
 Checking test 062 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2759,14 +2759,14 @@ Checking test 062 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 329.774910
-  0: The maximum resident set size (KB)                   = 983736
+  0: The total amount of wall time                        = 330.812382
+  0: The maximum resident set size (KB)                   = 976616
 
 Test 062 hrrr_control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_v1beta
 Checking test 063 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2813,14 +2813,14 @@ Checking test 063 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 592.712161
-  0: The maximum resident set size (KB)                   = 1058600
+  0: The total amount of wall time                        = 445.345468
+  0: The maximum resident set size (KB)                   = 1054244
 
 Test 063 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_v1nssl
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_v1nssl
 Checking test 064 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2835,14 +2835,14 @@ Checking test 064 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 528.343760
-  0: The maximum resident set size (KB)                   = 692904
+  0: The total amount of wall time                        = 528.122448
+  0: The maximum resident set size (KB)                   = 694236
 
 Test 064 rrfs_v1nssl PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_v1nssl_nohailnoccn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_v1nssl_nohailnoccn
 Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2857,14 +2857,14 @@ Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 518.150012
-  0: The maximum resident set size (KB)                   = 756360
+  0: The total amount of wall time                        = 515.633476
+  0: The maximum resident set size (KB)                   = 757832
 
 Test 065 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_conus13km_hrrr_warm
 Checking test 066 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2873,14 +2873,14 @@ Checking test 066 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 122.426881
-  0: The maximum resident set size (KB)                   = 932332
+  0: The total amount of wall time                        = 121.796400
+  0: The maximum resident set size (KB)                   = 928412
 
 Test 066 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_smoke_conus13km_hrrr_warm
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2889,14 +2889,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 138.588920
-  0: The maximum resident set size (KB)                   = 958316
+  0: The total amount of wall time                        = 138.159684
+  0: The maximum resident set size (KB)                   = 959896
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_conus13km_radar_tten_warm
 Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2905,14 +2905,14 @@ Checking test 068 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 122.173107
-  0: The maximum resident set size (KB)                   = 937316
+  0: The total amount of wall time                        = 124.745228
+  0: The maximum resident set size (KB)                   = 932312
 
 Test 068 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_conus13km_hrrr_warm_2threads
 Checking test 069 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2921,14 +2921,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 86.875918
-  0: The maximum resident set size (KB)                   = 875104
+  0: The total amount of wall time                        = 83.315805
+  0: The maximum resident set size (KB)                   = 836404
 
 Test 069 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 070 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2937,108 +2937,108 @@ Checking test 070 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 87.471767
-  0: The maximum resident set size (KB)                   = 884728
+  0: The total amount of wall time                        = 90.836798
+  0: The maximum resident set size (KB)                   = 883824
 
 Test 070 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_csawmg
 Checking test 071 control_csawmg results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 343.367544
-  0: The maximum resident set size (KB)                   = 729220
+  0: The total amount of wall time                        = 345.238654
+  0: The maximum resident set size (KB)                   = 728208
 
 Test 071 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_csawmgt
 Checking test 072 control_csawmgt results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 343.787047
-  0: The maximum resident set size (KB)                   = 729488
+  0: The total amount of wall time                        = 339.898285
+  0: The maximum resident set size (KB)                   = 729268
 
 Test 072 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_ras
 Checking test 073 control_ras results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 188.044931
-  0: The maximum resident set size (KB)                   = 717340
+  0: The total amount of wall time                        = 184.174427
+  0: The maximum resident set size (KB)                   = 708872
 
 Test 073 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_wam
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_wam
 Checking test 074 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 111.736448
-  0: The maximum resident set size (KB)                   = 641800
+  0: The total amount of wall time                        = 112.351951
+  0: The maximum resident set size (KB)                   = 643736
 
 Test 074 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_conus13km_hrrr_warm_debug
 Checking test 075 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 746.746190
-  0: The maximum resident set size (KB)                   = 948908
+  0: The total amount of wall time                        = 724.006607
+  0: The maximum resident set size (KB)                   = 948824
 
 Test 075 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_conus13km_radar_tten_warm_debug
 Checking test 076 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 767.896542
-  0: The maximum resident set size (KB)                   = 962108
+  0: The total amount of wall time                        = 744.935876
+  0: The maximum resident set size (KB)                   = 956852
 
 Test 076 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_CubedSphereGrid_debug
 Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3065,348 +3065,348 @@ Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.326240
-  0: The maximum resident set size (KB)                   = 792892
+  0: The total amount of wall time                        = 177.926403
+  0: The maximum resident set size (KB)                   = 793052
 
 Test 077 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_wrtGauss_netcdf_parallel_debug
 Checking test 078 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.477039
-  0: The maximum resident set size (KB)                   = 795204
+  0: The total amount of wall time                        = 161.621179
+  0: The maximum resident set size (KB)                   = 792368
 
 Test 078 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_stochy_debug
 Checking test 079 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 182.370330
-  0: The maximum resident set size (KB)                   = 805644
+  0: The total amount of wall time                        = 184.104515
+  0: The maximum resident set size (KB)                   = 805924
 
 Test 079 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_lndp_debug
 Checking test 080 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.311554
-  0: The maximum resident set size (KB)                   = 795416
+  0: The total amount of wall time                        = 166.964100
+  0: The maximum resident set size (KB)                   = 796652
 
 Test 080 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_csawmg_debug
 Checking test 081 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 245.427731
-  0: The maximum resident set size (KB)                   = 853728
+  0: The total amount of wall time                        = 243.124505
+  0: The maximum resident set size (KB)                   = 846668
 
 Test 081 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_csawmgt_debug
 Checking test 082 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.293656
-  0: The maximum resident set size (KB)                   = 850076
+  0: The total amount of wall time                        = 238.509706
+  0: The maximum resident set size (KB)                   = 846624
 
 Test 082 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_ras_debug
 Checking test 083 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.646780
-  0: The maximum resident set size (KB)                   = 802548
+  0: The total amount of wall time                        = 166.051542
+  0: The maximum resident set size (KB)                   = 806916
 
 Test 083 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_diag_debug
 Checking test 084 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.438928
-  0: The maximum resident set size (KB)                   = 848116
+  0: The total amount of wall time                        = 168.276377
+  0: The maximum resident set size (KB)                   = 855872
 
 Test 084 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_debug_p8
 Checking test 085 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.589747
-  0: The maximum resident set size (KB)                   = 1620644
+  0: The total amount of wall time                        = 180.161574
+  0: The maximum resident set size (KB)                   = 1618992
 
 Test 085 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_debug
 Checking test 086 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 982.235030
-  0: The maximum resident set size (KB)                   = 879184
+  0: The total amount of wall time                        = 989.294633
+  0: The maximum resident set size (KB)                   = 881108
 
 Test 086 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_control_debug
 Checking test 087 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.121949
-  0: The maximum resident set size (KB)                   = 1175792
+  0: The total amount of wall time                        = 288.615682
+  0: The maximum resident set size (KB)                   = 1174412
 
 Test 087 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_debug
 Checking test 088 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.310430
-  0: The maximum resident set size (KB)                   = 1173908
+  0: The total amount of wall time                        = 285.454661
+  0: The maximum resident set size (KB)                   = 1170612
 
 Test 088 hrrr_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_unified_drag_suite_debug
 Checking test 089 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.849953
-  0: The maximum resident set size (KB)                   = 1186584
+  0: The total amount of wall time                        = 307.437672
+  0: The maximum resident set size (KB)                   = 1180388
 
 Test 089 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_diag_debug
 Checking test 090 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 300.659804
-  0: The maximum resident set size (KB)                   = 1254108
+  0: The total amount of wall time                        = 297.957604
+  0: The maximum resident set size (KB)                   = 1263020
 
 Test 090 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_cires_ugwp_debug
 Checking test 091 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.321233
-  0: The maximum resident set size (KB)                   = 1173480
+  0: The total amount of wall time                        = 285.507500
+  0: The maximum resident set size (KB)                   = 1173892
 
 Test 091 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_unified_ugwp_debug
 Checking test 092 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.385179
-  0: The maximum resident set size (KB)                   = 1180704
+  0: The total amount of wall time                        = 295.187905
+  0: The maximum resident set size (KB)                   = 1181904
 
 Test 092 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_lndp_debug
 Checking test 093 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.990953
-  0: The maximum resident set size (KB)                   = 1175692
+  0: The total amount of wall time                        = 284.749104
+  0: The maximum resident set size (KB)                   = 1172064
 
 Test 093 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_flake_debug
 Checking test 094 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.936404
-  0: The maximum resident set size (KB)                   = 1173124
+  0: The total amount of wall time                        = 289.944699
+  0: The maximum resident set size (KB)                   = 1171364
 
 Test 094 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_progcld_thompson_debug
 Checking test 095 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.535987
-  0: The maximum resident set size (KB)                   = 1173612
+  0: The total amount of wall time                        = 287.872149
+  0: The maximum resident set size (KB)                   = 1173492
 
 Test 095 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_noah_debug
 Checking test 096 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.582699
-  0: The maximum resident set size (KB)                   = 1178068
+  0: The total amount of wall time                        = 289.293568
+  0: The maximum resident set size (KB)                   = 1173664
 
 Test 096 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_rrtmgp_debug
 Checking test 097 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 479.134561
-  0: The maximum resident set size (KB)                   = 1302212
+  0: The total amount of wall time                        = 495.670434
+  0: The maximum resident set size (KB)                   = 1305308
 
 Test 097 rap_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_sfcdiff_debug
 Checking test 098 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.083554
-  0: The maximum resident set size (KB)                   = 1175276
+  0: The total amount of wall time                        = 295.273942
+  0: The maximum resident set size (KB)                   = 1174472
 
 Test 098 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 099 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 467.284589
-  0: The maximum resident set size (KB)                   = 1173940
+  0: The total amount of wall time                        = 490.192771
+  0: The maximum resident set size (KB)                   = 1172040
 
 Test 099 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rrfs_v1beta_debug
 Checking test 100 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.519965
-  0: The maximum resident set size (KB)                   = 1167144
+  0: The total amount of wall time                        = 297.314205
+  0: The maximum resident set size (KB)                   = 1167668
 
 Test 100 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_wam_debug
 Checking test 101 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 298.048130
-  0: The maximum resident set size (KB)                   = 522948
+  0: The total amount of wall time                        = 295.469984
+  0: The maximum resident set size (KB)                   = 523980
 
 Test 101 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3417,14 +3417,14 @@ Checking test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 313.155855
-  0: The maximum resident set size (KB)                   = 1085292
+  0: The total amount of wall time                        = 324.816436
+  0: The maximum resident set size (KB)                   = 1078880
 
 Test 102 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_control_dyn32_phy32
 Checking test 103 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3471,14 +3471,14 @@ Checking test 103 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 371.206086
-  0: The maximum resident set size (KB)                   = 1002608
+  0: The total amount of wall time                        = 374.452037
+  0: The maximum resident set size (KB)                   = 1004252
 
 Test 103 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_dyn32_phy32
 Checking test 104 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3525,14 +3525,14 @@ Checking test 104 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.564398
-  0: The maximum resident set size (KB)                   = 963800
+  0: The total amount of wall time                        = 200.080478
+  0: The maximum resident set size (KB)                   = 951488
 
 Test 104 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_2threads_dyn32_phy32
 Checking test 105 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3579,14 +3579,14 @@ Checking test 105 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 389.218399
-  0: The maximum resident set size (KB)                   = 1026028
+  0: The total amount of wall time                        = 396.867417
+  0: The maximum resident set size (KB)                   = 1020412
 
 Test 105 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_2threads_dyn32_phy32
 Checking test 106 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3633,14 +3633,14 @@ Checking test 106 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 218.401770
-  0: The maximum resident set size (KB)                   = 1010240
+  0: The total amount of wall time                        = 216.395158
+  0: The maximum resident set size (KB)                   = 1011260
 
 Test 106 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_decomp_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_decomp_dyn32_phy32
 Checking test 107 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3687,14 +3687,14 @@ Checking test 107 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 214.189940
-  0: The maximum resident set size (KB)                   = 896260
+  0: The total amount of wall time                        = 219.009131
+  0: The maximum resident set size (KB)                   = 896124
 
 Test 107 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_restart_dyn32_phy32
 Checking test 108 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3733,14 +3733,14 @@ Checking test 108 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 286.311887
-  0: The maximum resident set size (KB)                   = 956436
+  0: The total amount of wall time                        = 291.854220
+  0: The maximum resident set size (KB)                   = 941960
 
 Test 108 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_restart_dyn32_phy32
 Checking test 109 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3779,21 +3779,21 @@ Checking test 109 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 99.215315
-  0: The maximum resident set size (KB)                   = 861092
+  0: The total amount of wall time                        = 113.069023
+  0: The maximum resident set size (KB)                   = 851836
 
 Test 109 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_dyn64_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_control_dyn64_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_control_dyn64_phy32
 Checking test 110 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3833,81 +3833,81 @@ Checking test 110 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 243.231511
-  0: The maximum resident set size (KB)                   = 970620
+  0: The total amount of wall time                        = 254.998058
+  0: The maximum resident set size (KB)                   = 964056
 
 Test 110 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_control_debug_dyn32_phy32
 Checking test 111 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.621556
-  0: The maximum resident set size (KB)                   = 1053940
+  0: The total amount of wall time                        = 298.200230
+  0: The maximum resident set size (KB)                   = 1061888
 
 Test 111 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hrrr_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hrrr_control_debug_dyn32_phy32
 Checking test 112 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.611227
-  0: The maximum resident set size (KB)                   = 1059552
+  0: The total amount of wall time                        = 292.714015
+  0: The maximum resident set size (KB)                   = 1062808
 
 Test 112 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/rap_control_dyn64_phy32_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/rap_control_dyn64_phy32_debug
 Checking test 113 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.655908
-  0: The maximum resident set size (KB)                   = 1101924
+  0: The total amount of wall time                        = 295.827583
+  0: The maximum resident set size (KB)                   = 1111188
 
 Test 113 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_atm
 Checking test 114 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 258.975496
-  0: The maximum resident set size (KB)                   = 1027564
+  0: The total amount of wall time                        = 266.548543
+  0: The maximum resident set size (KB)                   = 1019560
 
 Test 114 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_atm_thompson_gfdlsf
 Checking test 115 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 394.102490
-  0: The maximum resident set size (KB)                   = 1391828
+  0: The total amount of wall time                        = 432.154024
+  0: The maximum resident set size (KB)                   = 1397416
 
 Test 115 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_atm_ocn
 Checking test 116 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3916,14 +3916,14 @@ Checking test 116 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.341185
-  0: The maximum resident set size (KB)                   = 1212984
+  0: The total amount of wall time                        = 389.574761
+  0: The maximum resident set size (KB)                   = 1207568
 
 Test 116 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_atm_wav
 Checking test 117 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3932,14 +3932,14 @@ Checking test 117 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 719.053074
-  0: The maximum resident set size (KB)                   = 1238580
+  0: The total amount of wall time                        = 733.719945
+  0: The maximum resident set size (KB)                   = 1237012
 
 Test 117 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_atm_ocn_wav
 Checking test 118 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3950,28 +3950,28 @@ Checking test 118 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 812.373089
-  0: The maximum resident set size (KB)                   = 1253624
+  0: The total amount of wall time                        = 841.055473
+  0: The maximum resident set size (KB)                   = 1249184
 
 Test 118 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_1nest_atm
 Checking test 119 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 361.509998
-  0: The maximum resident set size (KB)                   = 505476
+  0: The total amount of wall time                        = 375.989419
+  0: The maximum resident set size (KB)                   = 505272
 
 Test 119 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_telescopic_2nests_atm
 Checking test 120 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3980,28 +3980,28 @@ Checking test 120 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 411.976590
-  0: The maximum resident set size (KB)                   = 503300
+  0: The total amount of wall time                        = 432.125322
+  0: The maximum resident set size (KB)                   = 507408
 
 Test 120 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_global_1nest_atm
 Checking test 121 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 172.610466
-  0: The maximum resident set size (KB)                   = 351608
+  0: The total amount of wall time                        = 189.510791
+  0: The maximum resident set size (KB)                   = 349996
 
 Test 121 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_global_multiple_4nests_atm
 Checking test 122 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4019,14 +4019,14 @@ Checking test 122 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 472.663484
-  0: The maximum resident set size (KB)                   = 420996
+  0: The total amount of wall time                        = 492.880796
+  0: The maximum resident set size (KB)                   = 424036
 
 Test 122 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_specified_moving_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_specified_moving_1nest_atm
 Checking test 123 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4035,28 +4035,28 @@ Checking test 123 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 234.607610
-  0: The maximum resident set size (KB)                   = 514948
+  0: The total amount of wall time                        = 238.873592
+  0: The maximum resident set size (KB)                   = 520744
 
 Test 123 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_storm_following_1nest_atm
 Checking test 124 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 213.749744
-  0: The maximum resident set size (KB)                   = 521016
+  0: The total amount of wall time                        = 227.700964
+  0: The maximum resident set size (KB)                   = 517676
 
 Test 124 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 125 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4065,28 +4065,28 @@ Checking test 125 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 286.124248
-  0: The maximum resident set size (KB)                   = 551760
+  0: The total amount of wall time                        = 301.546573
+  0: The maximum resident set size (KB)                   = 551264
 
 Test 125 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_global_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_global_storm_following_1nest_atm
 Checking test 126 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 69.319982
-  0: The maximum resident set size (KB)                   = 364392
+  0: The total amount of wall time                        = 83.442087
+  0: The maximum resident set size (KB)                   = 364480
 
 Test 126 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 127 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4097,14 +4097,14 @@ Checking test 127 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 580.612279
-  0: The maximum resident set size (KB)                   = 647656
+  0: The total amount of wall time                        = 578.848922
+  0: The maximum resident set size (KB)                   = 648752
 
 Test 127 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_docn
 Checking test 128 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4112,14 +4112,14 @@ Checking test 128 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 344.468930
-  0: The maximum resident set size (KB)                   = 1215468
+  0: The total amount of wall time                        = 353.246660
+  0: The maximum resident set size (KB)                   = 1214892
 
 Test 128 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_docn_oisst
 Checking test 129 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4127,131 +4127,131 @@ Checking test 129 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 344.785543
-  0: The maximum resident set size (KB)                   = 1197520
+  0: The total amount of wall time                        = 345.920552
+  0: The maximum resident set size (KB)                   = 1197872
 
 Test 129 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/hafs_regional_datm_cdeps
 Checking test 130 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 935.153801
-  0: The maximum resident set size (KB)                   = 1040520
+  0: The total amount of wall time                        = 929.573742
+  0: The maximum resident set size (KB)                   = 1041116
 
 Test 130 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_control_cfsr
 Checking test 131 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 164.630970
- 0: The maximum resident set size (KB)                   = 1070292
+ 0: The total amount of wall time                        = 150.139007
+ 0: The maximum resident set size (KB)                   = 1071344
 
 Test 131 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_restart_cfsr
 Checking test 132 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 93.397571
- 0: The maximum resident set size (KB)                   = 1016920
+ 0: The total amount of wall time                        = 90.002671
+ 0: The maximum resident set size (KB)                   = 1022244
 
 Test 132 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_control_gefs
 Checking test 133 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.323936
- 0: The maximum resident set size (KB)                   = 949808
+ 0: The total amount of wall time                        = 142.387064
+ 0: The maximum resident set size (KB)                   = 965856
 
 Test 133 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_iau_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_iau_gefs
 Checking test 134 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.764733
- 0: The maximum resident set size (KB)                   = 965388
+ 0: The total amount of wall time                        = 144.935405
+ 0: The maximum resident set size (KB)                   = 971048
 
 Test 134 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_stochy_gefs
 Checking test 135 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.941469
- 0: The maximum resident set size (KB)                   = 971940
+ 0: The total amount of wall time                        = 147.500913
+ 0: The maximum resident set size (KB)                   = 972596
 
 Test 135 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_ciceC_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_ciceC_cfsr
 Checking test 136 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.210393
- 0: The maximum resident set size (KB)                   = 1068116
+ 0: The total amount of wall time                        = 147.763378
+ 0: The maximum resident set size (KB)                   = 1066380
 
 Test 136 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_bulk_cfsr
 Checking test 137 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.973120
- 0: The maximum resident set size (KB)                   = 1053192
+ 0: The total amount of wall time                        = 149.014373
+ 0: The maximum resident set size (KB)                   = 1079304
 
 Test 137 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_bulk_gefs
 Checking test 138 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.017447
- 0: The maximum resident set size (KB)                   = 958124
+ 0: The total amount of wall time                        = 145.802738
+ 0: The maximum resident set size (KB)                   = 971624
 
 Test 138 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_mx025_cfsr
 Checking test 139 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4260,14 +4260,14 @@ Checking test 139 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 522.484426
-  0: The maximum resident set size (KB)                   = 877268
+  0: The total amount of wall time                        = 456.512062
+  0: The maximum resident set size (KB)                   = 883304
 
 Test 139 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_mx025_gefs
 Checking test 140 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4276,64 +4276,64 @@ Checking test 140 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 528.265409
-  0: The maximum resident set size (KB)                   = 935792
+  0: The total amount of wall time                        = 432.476975
+  0: The maximum resident set size (KB)                   = 926716
 
 Test 140 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_multiple_files_cfsr
 Checking test 141 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 169.412731
- 0: The maximum resident set size (KB)                   = 1073588
+ 0: The total amount of wall time                        = 144.624085
+ 0: The maximum resident set size (KB)                   = 1060888
 
 Test 141 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_3072x1536_cfsr
 Checking test 142 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 253.780173
- 0: The maximum resident set size (KB)                   = 2364136
+ 0: The total amount of wall time                        = 197.419061
+ 0: The maximum resident set size (KB)                   = 2369324
 
 Test 142 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_gfs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_gfs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_gfs
 Checking test 143 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 208.619101
- 0: The maximum resident set size (KB)                   = 2298572
+ 0: The total amount of wall time                        = 197.906435
+ 0: The maximum resident set size (KB)                   = 2361676
 
 Test 143 datm_cdeps_gfs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_debug_cfsr
 Checking test 144 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 483.438974
- 0: The maximum resident set size (KB)                   = 987868
+ 0: The total amount of wall time                        = 456.218203
+ 0: The maximum resident set size (KB)                   = 992332
 
 Test 144 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_lnd_gswp3
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_lnd_gswp3
 Checking test 145 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4342,14 +4342,14 @@ Checking test 145 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 7.930198
-  0: The maximum resident set size (KB)                   = 260836
+  0: The total amount of wall time                        = 6.458603
+  0: The maximum resident set size (KB)                   = 267588
 
 Test 145 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/datm_cdeps_lnd_gswp3_rst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/datm_cdeps_lnd_gswp3_rst
 Checking test 146 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4358,33 +4358,33 @@ Checking test 146 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 15.701765
-  0: The maximum resident set size (KB)                   = 251244
+  0: The total amount of wall time                        = 12.203824
+  0: The maximum resident set size (KB)                   = 252872
 
 Test 146 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_p8_atmlnd_sbs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_p8_atmlnd_sbs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_p8_atmlnd_sbs
 Checking test 147 control_p8_atmlnd_sbs results ....
- Comparing sfcf000.tile1.nc ............ALT CHECK......OK
- Comparing sfcf000.tile2.nc ............ALT CHECK......OK
- Comparing sfcf000.tile3.nc ............ALT CHECK......OK
- Comparing sfcf000.tile4.nc ............ALT CHECK......OK
- Comparing sfcf000.tile5.nc ............ALT CHECK......OK
- Comparing sfcf000.tile6.nc ............ALT CHECK......OK
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf000.tile1.nc .........OK
  Comparing atmf000.tile2.nc .........OK
  Comparing atmf000.tile3.nc .........OK
@@ -4450,14 +4450,14 @@ Checking test 147 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 202.924581
-  0: The maximum resident set size (KB)                   = 1611356
+  0: The total amount of wall time                        = 201.710107
+  0: The maximum resident set size (KB)                   = 1607580
 
 Test 147 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/control_atmwav
 Checking test 148 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4501,14 +4501,14 @@ Checking test 148 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 89.740602
-  0: The maximum resident set size (KB)                   = 662096
+  0: The total amount of wall time                        = 85.443945
+  0: The maximum resident set size (KB)                   = 660556
 
 Test 148 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/atmaero_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/atmaero_control_p8
 Checking test 149 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4552,14 +4552,14 @@ Checking test 149 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 480.238614
-  0: The maximum resident set size (KB)                   = 2974352
+  0: The total amount of wall time                        = 227.627030
+  0: The maximum resident set size (KB)                   = 2979088
 
 Test 149 atmaero_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/atmaero_control_p8_rad
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/atmaero_control_p8_rad
 Checking test 150 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4603,14 +4603,14 @@ Checking test 150 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 469.165079
-  0: The maximum resident set size (KB)                   = 3051340
+  0: The total amount of wall time                        = 280.978996
+  0: The maximum resident set size (KB)                   = 3045840
 
 Test 150 atmaero_control_p8_rad PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/atmaero_control_p8_rad_micro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/atmaero_control_p8_rad_micro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/atmaero_control_p8_rad_micro
 Checking test 151 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4654,21 +4654,21 @@ Checking test 151 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 472.729828
-  0: The maximum resident set size (KB)                   = 3051208
+  0: The total amount of wall time                        = 283.133887
+  0: The maximum resident set size (KB)                   = 3047236
 
 Test 151 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_atmaq
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_atmaq
 Checking test 152 regional_atmaq results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf003.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf003.nc ............ALT CHECK......OK
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing atmf006.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4677,19 +4677,19 @@ Checking test 152 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 588.786705
-  0: The maximum resident set size (KB)                   = 1556304
+  0: The total amount of wall time                        = 586.464122
+  0: The maximum resident set size (KB)                   = 1561828
 
 Test 152 regional_atmaq PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230120/INTEL/regional_atmaq_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_198454/regional_atmaq_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_410033/regional_atmaq_debug
 Checking test 153 regional_atmaq_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -4698,12 +4698,12 @@ Checking test 153 regional_atmaq_debug results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1303.014343
-  0: The maximum resident set size (KB)                   = 1515232
+  0: The total amount of wall time                        = 1306.566499
+  0: The maximum resident set size (KB)                   = 1517824
 
 Test 153 regional_atmaq_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 25 19:38:16 CST 2023
-Elapsed time: 01h:21m:16s. Have a nice day!
+Thu Jan 26 17:03:05 CST 2023
+Elapsed time: 01h:20m:51s. Have a nice day!

--- a/tests/RegressionTests_wcoss2.intel.log
+++ b/tests/RegressionTests_wcoss2.intel.log
@@ -1,30 +1,30 @@
-Wed Jan 18 16:23:07 UTC 2023
+Sat Jan 28 19:58:13 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 596 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 612 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1236 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 698 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 1151 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 1007 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 496 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 488 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 1136 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 529 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 672 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 665 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1126 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 715 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 642 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 654 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 919 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 625 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 667 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 624 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 252 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 648 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1757 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1508 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 1002 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 528 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 500 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 958 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 479 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1543 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 238 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 356 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 472 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 991 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 449 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 882 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 1049 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 876 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 706 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 932 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 703 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_p8_mixedmode
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -89,14 +89,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 344.696431
-The maximum resident set size (KB)                   = 2950864
+The total amount of wall time                        = 341.555423
+The maximum resident set size (KB)                   = 2949428
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_p8
 Checking test 002 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -161,14 +161,14 @@ Checking test 002 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 393.248012
-The maximum resident set size (KB)                   = 2978988
+The total amount of wall time                        = 395.284130
+The maximum resident set size (KB)                   = 2975184
 
 Test 002 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_restart_p8
 Checking test 003 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -221,14 +221,14 @@ Checking test 003 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 234.445444
-The maximum resident set size (KB)                   = 2867336
+The total amount of wall time                        = 230.520459
+The maximum resident set size (KB)                   = 2869088
 
 Test 003 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_2threads_p8
 Checking test 004 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -281,14 +281,14 @@ Checking test 004 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 380.064727
-The maximum resident set size (KB)                   = 3283856
+The total amount of wall time                        = 382.094153
+The maximum resident set size (KB)                   = 3282692
 
 Test 004 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_esmfthreads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_esmfthreads_p8
 Checking test 005 cpld_esmfthreads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -341,14 +341,14 @@ Checking test 005 cpld_esmfthreads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 380.779634
-The maximum resident set size (KB)                   = 3280044
+The total amount of wall time                        = 383.238285
+The maximum resident set size (KB)                   = 3280628
 
 Test 005 cpld_esmfthreads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_decomp_p8
 Checking test 006 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -401,14 +401,14 @@ Checking test 006 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 385.496830
-The maximum resident set size (KB)                   = 2974228
+The total amount of wall time                        = 397.309944
+The maximum resident set size (KB)                   = 2976400
 
 Test 006 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_mpi_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_mpi_p8
 Checking test 007 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -461,14 +461,14 @@ Checking test 007 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 327.394479
-The maximum resident set size (KB)                   = 2909628
+The total amount of wall time                        = 330.875087
+The maximum resident set size (KB)                   = 2904568
 
 Test 007 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_ciceC_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_ciceC_p8
 Checking test 008 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -533,14 +533,14 @@ Checking test 008 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 397.110668
-The maximum resident set size (KB)                   = 2977968
+The total amount of wall time                        = 400.819097
+The maximum resident set size (KB)                   = 2978552
 
 Test 008 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_bmark_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_bmark_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_bmark_p8
 Checking test 009 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -588,14 +588,14 @@ Checking test 009 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 938.220673
-The maximum resident set size (KB)                   = 3912928
+The total amount of wall time                        = 923.688431
+The maximum resident set size (KB)                   = 3914236
 
 Test 009 cpld_bmark_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_bmark_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_restart_bmark_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_bmark_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_restart_bmark_p8
 Checking test 010 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -643,14 +643,14 @@ Checking test 010 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 646.821111
-The maximum resident set size (KB)                   = 3885200
+The total amount of wall time                        = 640.437384
+The maximum resident set size (KB)                   = 3886324
 
 Test 010 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_noaero_p8
 Checking test 011 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -714,14 +714,14 @@ Checking test 011 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 286.051842
-The maximum resident set size (KB)                   = 1577112
+The total amount of wall time                        = 286.793358
+The maximum resident set size (KB)                   = 1576060
 
 Test 011 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_nowave_noaero_p8
 Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -783,14 +783,14 @@ Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 301.998551
-The maximum resident set size (KB)                   = 1626504
+The total amount of wall time                        = 301.101470
+The maximum resident set size (KB)                   = 1633272
 
 Test 012 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_noaero_p8_agrid
 Checking test 013 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -852,14 +852,14 @@ Checking test 013 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 314.131031
-The maximum resident set size (KB)                   = 1627608
+The total amount of wall time                        = 304.344862
+The maximum resident set size (KB)                   = 1628136
 
 Test 013 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_control_c48
 Checking test 014 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -909,14 +909,14 @@ Checking test 014 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 436.401572
-The maximum resident set size (KB)                   = 2633144
+The total amount of wall time                        = 438.869278
+The maximum resident set size (KB)                   = 2630148
 
 Test 014 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_warmstart_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_warmstart_c48
 Checking test 015 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -966,14 +966,14 @@ Checking test 015 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 127.794426
-The maximum resident set size (KB)                   = 2654828
+The total amount of wall time                        = 122.313411
+The maximum resident set size (KB)                   = 2653528
 
 Test 015 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/cpld_restart_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/cpld_restart_c48
 Checking test 016 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1023,14 +1023,14 @@ Checking test 016 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 70.648962
-The maximum resident set size (KB)                   = 2060796
+The total amount of wall time                        = 73.194946
+The maximum resident set size (KB)                   = 2060052
 
 Test 016 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_CubedSphereGrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_CubedSphereGrid
 Checking test 017 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1057,14 +1057,14 @@ Checking test 017 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 128.843911
-The maximum resident set size (KB)                   = 511748
+The total amount of wall time                        = 129.651607
+The maximum resident set size (KB)                   = 515504
 
 Test 017 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_latlon
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_latlon
 Checking test 018 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1075,14 +1075,14 @@ Checking test 018 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 130.792474
-The maximum resident set size (KB)                   = 514352
+The total amount of wall time                        = 132.198285
+The maximum resident set size (KB)                   = 519732
 
 Test 018 control_latlon PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_wrtGauss_netcdf_parallel
 Checking test 019 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1093,14 +1093,14 @@ Checking test 019 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.606150
-The maximum resident set size (KB)                   = 519612
+The total amount of wall time                        = 138.523965
+The maximum resident set size (KB)                   = 513844
 
 Test 019 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_c48
 Checking test 020 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1139,14 +1139,14 @@ Checking test 020 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 326.414743
-The maximum resident set size (KB)                   = 666044
+The total amount of wall time                        = 329.529557
+The maximum resident set size (KB)                   = 665420
 
 Test 020 control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_c192
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_c192
 Checking test 021 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1157,14 +1157,14 @@ Checking test 021 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 529.723118
-The maximum resident set size (KB)                   = 614488
+The total amount of wall time                        = 529.925272
+The maximum resident set size (KB)                   = 615348
 
 Test 021 control_c192 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_c384
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_c384
 Checking test 022 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1175,14 +1175,14 @@ Checking test 022 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 572.715290
-The maximum resident set size (KB)                   = 889080
+The total amount of wall time                        = 576.294642
+The maximum resident set size (KB)                   = 889556
 
 Test 022 control_c384 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_c384gdas
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_c384gdas
 Checking test 023 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1225,14 +1225,14 @@ Checking test 023 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 503.041555
-The maximum resident set size (KB)                   = 1017544
+The total amount of wall time                        = 499.841942
+The maximum resident set size (KB)                   = 1017088
 
 Test 023 control_c384gdas PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_stochy
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_stochy
 Checking test 024 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1243,28 +1243,28 @@ Checking test 024 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 90.029537
-The maximum resident set size (KB)                   = 522452
+The total amount of wall time                        = 89.981724
+The maximum resident set size (KB)                   = 522932
 
 Test 024 control_stochy PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_stochy_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_stochy_restart
 Checking test 025 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 46.852913
-The maximum resident set size (KB)                   = 287732
+The total amount of wall time                        = 46.136867
+The maximum resident set size (KB)                   = 287884
 
 Test 025 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_lndp
 Checking test 026 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1275,14 +1275,14 @@ Checking test 026 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 81.457983
-The maximum resident set size (KB)                   = 517160
+The total amount of wall time                        = 82.045155
+The maximum resident set size (KB)                   = 518096
 
 Test 026 control_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_iovr4
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_iovr4
 Checking test 027 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1297,14 +1297,14 @@ Checking test 027 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 134.241788
-The maximum resident set size (KB)                   = 517664
+The total amount of wall time                        = 134.557772
+The maximum resident set size (KB)                   = 516152
 
 Test 027 control_iovr4 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_iovr5
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_iovr5
 Checking test 028 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1319,14 +1319,14 @@ Checking test 028 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.874465
-The maximum resident set size (KB)                   = 518376
+The total amount of wall time                        = 138.213353
+The maximum resident set size (KB)                   = 515648
 
 Test 028 control_iovr5 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_p8
 Checking test 029 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1373,14 +1373,14 @@ Checking test 029 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.655685
-The maximum resident set size (KB)                   = 1490148
+The total amount of wall time                        = 180.700818
+The maximum resident set size (KB)                   = 1486132
 
 Test 029 control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_p8_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_p8_lndp
 Checking test 030 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1399,14 +1399,14 @@ Checking test 030 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 322.294514
-The maximum resident set size (KB)                   = 1488396
+The total amount of wall time                        = 325.982884
+The maximum resident set size (KB)                   = 1491360
 
 Test 030 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_restart_p8
 Checking test 031 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1445,14 +1445,14 @@ Checking test 031 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.395396
-The maximum resident set size (KB)                   = 654000
+The total amount of wall time                        = 97.013148
+The maximum resident set size (KB)                   = 648968
 
 Test 031 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_decomp_p8
 Checking test 032 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1495,14 +1495,14 @@ Checking test 032 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 182.570271
-The maximum resident set size (KB)                   = 1478120
+The total amount of wall time                        = 183.903544
+The maximum resident set size (KB)                   = 1478656
 
 Test 032 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_2threads_p8
 Checking test 033 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1545,14 +1545,14 @@ Checking test 033 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 160.785600
-The maximum resident set size (KB)                   = 1564412
+The total amount of wall time                        = 166.343201
+The maximum resident set size (KB)                   = 1569068
 
 Test 033 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_p8_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_p8_rrtmgp
 Checking test 034 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1599,14 +1599,14 @@ Checking test 034 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 258.486120
-The maximum resident set size (KB)                   = 1607140
+The total amount of wall time                        = 265.974965
+The maximum resident set size (KB)                   = 1607640
 
 Test 034 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/merra2_thompson
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/merra2_thompson
 Checking test 035 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1653,14 +1653,14 @@ Checking test 035 merra2_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 205.918242
-The maximum resident set size (KB)                   = 1496588
+The total amount of wall time                        = 208.425050
+The maximum resident set size (KB)                   = 1499212
 
 Test 035 merra2_thompson PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_control
 Checking test 036 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1671,28 +1671,28 @@ Checking test 036 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 292.275403
-The maximum resident set size (KB)                   = 651300
+The total amount of wall time                        = 292.347193
+The maximum resident set size (KB)                   = 654340
 
 Test 036 regional_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_restart
 Checking test 037 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 157.325660
-The maximum resident set size (KB)                   = 649956
+The total amount of wall time                        = 156.845651
+The maximum resident set size (KB)                   = 650860
 
 Test 037 regional_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_decomp
 Checking test 038 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1703,14 +1703,14 @@ Checking test 038 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 307.752312
-The maximum resident set size (KB)                   = 652492
+The total amount of wall time                        = 311.408700
+The maximum resident set size (KB)                   = 652600
 
 Test 038 regional_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_2threads
 Checking test 039 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1721,14 +1721,14 @@ Checking test 039 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 180.030020
-The maximum resident set size (KB)                   = 691104
+The total amount of wall time                        = 177.316130
+The maximum resident set size (KB)                   = 689000
 
 Test 039 regional_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_noquilt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1736,28 +1736,28 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 316.467903
-The maximum resident set size (KB)                   = 645624
+The total amount of wall time                        = 315.993291
+The maximum resident set size (KB)                   = 645664
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_netcdf_parallel
 Checking test 041 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-The total amount of wall time                        = 287.254432
-The maximum resident set size (KB)                   = 646544
+The total amount of wall time                        = 286.559948
+The maximum resident set size (KB)                   = 647116
 
 Test 041 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_2dwrtdecomp
 Checking test 042 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 042 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 293.007842
-The maximum resident set size (KB)                   = 651576
+The total amount of wall time                        = 295.253662
+The maximum resident set size (KB)                   = 651668
 
 Test 042 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/fv3_regional_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_wofs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/fv3_regional_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_wofs
 Checking test 043 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1786,14 +1786,14 @@ Checking test 043 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 361.226027
-The maximum resident set size (KB)                   = 334640
+The total amount of wall time                        = 360.425169
+The maximum resident set size (KB)                   = 332936
 
 Test 043 regional_wofs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_control
 Checking test 044 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1840,14 +1840,14 @@ Checking test 044 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 429.649577
-The maximum resident set size (KB)                   = 896472
+The total amount of wall time                        = 418.810609
+The maximum resident set size (KB)                   = 894552
 
 Test 044 rap_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_rrtmgp
 Checking test 045 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1894,14 +1894,14 @@ Checking test 045 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 514.589828
-The maximum resident set size (KB)                   = 1011600
+The total amount of wall time                        = 496.766642
+The maximum resident set size (KB)                   = 1010580
 
 Test 045 rap_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1912,14 +1912,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 299.620023
-The maximum resident set size (KB)                   = 983160
+The total amount of wall time                        = 287.564947
+The maximum resident set size (KB)                   = 988436
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_decomp
 Checking test 047 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1966,14 +1966,14 @@ Checking test 047 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 450.204262
-The maximum resident set size (KB)                   = 893376
+The total amount of wall time                        = 433.740366
+The maximum resident set size (KB)                   = 892580
 
 Test 047 rap_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2020,14 +2020,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 414.021775
-The maximum resident set size (KB)                   = 962976
+The total amount of wall time                        = 391.427547
+The maximum resident set size (KB)                   = 967340
 
 Test 048 rap_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2066,14 +2066,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 212.997414
-The maximum resident set size (KB)                   = 638676
+The total amount of wall time                        = 220.664333
+The maximum resident set size (KB)                   = 638540
 
 Test 049 rap_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_sfcdiff
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2120,14 +2120,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 427.687658
-The maximum resident set size (KB)                   = 894496
+The total amount of wall time                        = 414.694478
+The maximum resident set size (KB)                   = 897444
 
 Test 050 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_sfcdiff_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_sfcdiff_decomp
 Checking test 051 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2174,14 +2174,14 @@ Checking test 051 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 443.260691
-The maximum resident set size (KB)                   = 894468
+The total amount of wall time                        = 434.954115
+The maximum resident set size (KB)                   = 894040
 
 Test 051 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_sfcdiff_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_sfcdiff_restart
 Checking test 052 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2220,14 +2220,14 @@ Checking test 052 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 311.267367
-The maximum resident set size (KB)                   = 637016
+The total amount of wall time                        = 325.477731
+The maximum resident set size (KB)                   = 642124
 
 Test 052 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control
 Checking test 053 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2274,14 +2274,14 @@ Checking test 053 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 409.458834
-The maximum resident set size (KB)                   = 894392
+The total amount of wall time                        = 400.528757
+The maximum resident set size (KB)                   = 894372
 
 Test 053 hrrr_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_decomp
 Checking test 054 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2328,14 +2328,14 @@ Checking test 054 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 435.012934
-The maximum resident set size (KB)                   = 892184
+The total amount of wall time                        = 414.841933
+The maximum resident set size (KB)                   = 890892
 
 Test 054 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_2threads
 Checking test 055 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2382,14 +2382,14 @@ Checking test 055 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 391.120743
-The maximum resident set size (KB)                   = 957460
+The total amount of wall time                        = 371.032892
+The maximum resident set size (KB)                   = 954284
 
 Test 055 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_restart
 Checking test 056 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2428,14 +2428,14 @@ Checking test 056 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 297.974052
-The maximum resident set size (KB)                   = 635456
+The total amount of wall time                        = 303.651212
+The maximum resident set size (KB)                   = 638824
 
 Test 056 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_v1beta
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_v1beta
 Checking test 057 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2482,14 +2482,14 @@ Checking test 057 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 425.175384
-The maximum resident set size (KB)                   = 885908
+The total amount of wall time                        = 411.793769
+The maximum resident set size (KB)                   = 885280
 
 Test 057 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_v1nssl
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_v1nssl
 Checking test 058 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2504,14 +2504,14 @@ Checking test 058 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 485.848941
-The maximum resident set size (KB)                   = 577776
+The total amount of wall time                        = 474.645478
+The maximum resident set size (KB)                   = 579896
 
 Test 058 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_v1nssl_nohailnoccn
 Checking test 059 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2526,14 +2526,14 @@ Checking test 059 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 472.908214
-The maximum resident set size (KB)                   = 568840
+The total amount of wall time                        = 464.835635
+The maximum resident set size (KB)                   = 568652
 
 Test 059 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_conus13km_hrrr_warm
 Checking test 060 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2542,14 +2542,14 @@ Checking test 060 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 125.377838
-The maximum resident set size (KB)                   = 763448
+The total amount of wall time                        = 115.098436
+The maximum resident set size (KB)                   = 767356
 
 Test 060 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_smoke_conus13km_hrrr_warm
 Checking test 061 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2558,14 +2558,14 @@ Checking test 061 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 135.610916
-The maximum resident set size (KB)                   = 776356
+The total amount of wall time                        = 128.375110
+The maximum resident set size (KB)                   = 777776
 
 Test 061 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_conus13km_radar_tten_warm
 Checking test 062 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2574,14 +2574,14 @@ Checking test 062 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 123.118306
-The maximum resident set size (KB)                   = 767740
+The total amount of wall time                        = 116.540074
+The maximum resident set size (KB)                   = 771736
 
 Test 062 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_conus13km_hrrr_warm_2threads
 Checking test 063 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2590,14 +2590,14 @@ Checking test 063 rrfs_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 91.676309
-The maximum resident set size (KB)                   = 764160
+The total amount of wall time                        = 85.213512
+The maximum resident set size (KB)                   = 764156
 
 Test 063 rrfs_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_conus13km_radar_tten_warm_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_conus13km_radar_tten_warm_2threads
 Checking test 064 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2606,14 +2606,14 @@ Checking test 064 rrfs_conus13km_radar_tten_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 103.591484
-The maximum resident set size (KB)                   = 764100
+The total amount of wall time                        = 86.113930
+The maximum resident set size (KB)                   = 765808
 
 Test 064 rrfs_conus13km_radar_tten_warm_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_csawmg
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_csawmg
 Checking test 065 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2624,14 +2624,14 @@ Checking test 065 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 354.805407
-The maximum resident set size (KB)                   = 586928
+The total amount of wall time                        = 346.857503
+The maximum resident set size (KB)                   = 587800
 
 Test 065 control_csawmg PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_csawmgt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_csawmgt
 Checking test 066 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2642,14 +2642,14 @@ Checking test 066 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 360.839496
-The maximum resident set size (KB)                   = 583208
+The total amount of wall time                        = 341.501303
+The maximum resident set size (KB)                   = 586048
 
 Test 066 control_csawmgt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_ras
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_ras
 Checking test 067 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2660,54 +2660,54 @@ Checking test 067 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 181.542602
-The maximum resident set size (KB)                   = 548956
+The total amount of wall time                        = 179.978871
+The maximum resident set size (KB)                   = 549916
 
 Test 067 control_ras PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_wam
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_wam
 Checking test 068 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 117.075836
-The maximum resident set size (KB)                   = 289124
+The total amount of wall time                        = 117.916504
+The maximum resident set size (KB)                   = 263928
 
 Test 068 control_wam PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_conus13km_hrrr_warm_debug
 Checking test 069 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 778.361771
-The maximum resident set size (KB)                   = 793904
+The total amount of wall time                        = 785.436816
+The maximum resident set size (KB)                   = 796928
 
 Test 069 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_conus13km_radar_tten_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_conus13km_radar_tten_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_conus13km_radar_tten_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_conus13km_radar_tten_warm_debug
 Checking test 070 rrfs_conus13km_radar_tten_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 781.955712
-The maximum resident set size (KB)                   = 789948
+The total amount of wall time                        = 780.368178
+The maximum resident set size (KB)                   = 790248
 
 Test 070 rrfs_conus13km_radar_tten_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_CubedSphereGrid_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_CubedSphereGrid_debug
 Checking test 071 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2734,348 +2734,348 @@ Checking test 071 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 167.693317
-The maximum resident set size (KB)                   = 679908
+The total amount of wall time                        = 169.239145
+The maximum resident set size (KB)                   = 675840
 
 Test 071 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_wrtGauss_netcdf_parallel_debug
 Checking test 072 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.654548
-The maximum resident set size (KB)                   = 680864
+The total amount of wall time                        = 158.190214
+The maximum resident set size (KB)                   = 678112
 
 Test 072 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_stochy_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_stochy_debug
 Checking test 073 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.656911
-The maximum resident set size (KB)                   = 686116
+The total amount of wall time                        = 178.632435
+The maximum resident set size (KB)                   = 685876
 
 Test 073 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_lndp_debug
 Checking test 074 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.749023
-The maximum resident set size (KB)                   = 686280
+The total amount of wall time                        = 159.886967
+The maximum resident set size (KB)                   = 682604
 
 Test 074 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_csawmg_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_csawmg_debug
 Checking test 075 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 265.029150
-The maximum resident set size (KB)                   = 723252
+The total amount of wall time                        = 255.528461
+The maximum resident set size (KB)                   = 720516
 
 Test 075 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_csawmgt_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_csawmgt_debug
 Checking test 076 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 260.098222
-The maximum resident set size (KB)                   = 722592
+The total amount of wall time                        = 252.920618
+The maximum resident set size (KB)                   = 720704
 
 Test 076 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_ras_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_ras_debug
 Checking test 077 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.957966
-The maximum resident set size (KB)                   = 692852
+The total amount of wall time                        = 163.054187
+The maximum resident set size (KB)                   = 695800
 
 Test 077 control_ras_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_diag_debug
 Checking test 078 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.763662
-The maximum resident set size (KB)                   = 743584
+The total amount of wall time                        = 164.109193
+The maximum resident set size (KB)                   = 740548
 
 Test 078 control_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_debug_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_debug_p8
 Checking test 079 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 188.721231
-The maximum resident set size (KB)                   = 1505808
+The total amount of wall time                        = 187.322556
+The maximum resident set size (KB)                   = 1500928
 
 Test 079 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1042.211497
-The maximum resident set size (KB)                   = 677652
+The total amount of wall time                        = 1043.936481
+The maximum resident set size (KB)                   = 672820
 
 Test 080 regional_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.406045
-The maximum resident set size (KB)                   = 1057460
+The total amount of wall time                        = 297.873571
+The maximum resident set size (KB)                   = 1058596
 
 Test 081 rap_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_debug
 Checking test 082 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.619124
-The maximum resident set size (KB)                   = 1053628
+The total amount of wall time                        = 292.950978
+The maximum resident set size (KB)                   = 1056396
 
 Test 082 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_unified_drag_suite_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.792590
-The maximum resident set size (KB)                   = 1057064
+The total amount of wall time                        = 303.725375
+The maximum resident set size (KB)                   = 1058584
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.527805
-The maximum resident set size (KB)                   = 1138764
+The total amount of wall time                        = 309.048333
+The maximum resident set size (KB)                   = 1141332
 
 Test 084 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.184879
-The maximum resident set size (KB)                   = 1059716
+The total amount of wall time                        = 306.321575
+The maximum resident set size (KB)                   = 1053368
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_unified_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.224810
-The maximum resident set size (KB)                   = 1057008
+The total amount of wall time                        = 303.692078
+The maximum resident set size (KB)                   = 1059592
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_lndp_debug
 Checking test 087 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.688919
-The maximum resident set size (KB)                   = 1062256
+The total amount of wall time                        = 301.343391
+The maximum resident set size (KB)                   = 1061420
 
 Test 087 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_flake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_flake_debug
 Checking test 088 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.106476
-The maximum resident set size (KB)                   = 1057788
+The total amount of wall time                        = 298.220122
+The maximum resident set size (KB)                   = 1056388
 
 Test 088 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_progcld_thompson_debug
 Checking test 089 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.791118
-The maximum resident set size (KB)                   = 1058416
+The total amount of wall time                        = 297.597031
+The maximum resident set size (KB)                   = 1055932
 
 Test 089 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_noah_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_noah_debug
 Checking test 090 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.009998
-The maximum resident set size (KB)                   = 1057220
+The total amount of wall time                        = 292.464156
+The maximum resident set size (KB)                   = 1058332
 
 Test 090 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_rrtmgp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_rrtmgp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_rrtmgp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_rrtmgp_debug
 Checking test 091 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 500.894604
-The maximum resident set size (KB)                   = 1173540
+The total amount of wall time                        = 499.865306
+The maximum resident set size (KB)                   = 1173244
 
 Test 091 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_sfcdiff_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_sfcdiff_debug
 Checking test 092 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.994028
-The maximum resident set size (KB)                   = 1058432
+The total amount of wall time                        = 300.600488
+The maximum resident set size (KB)                   = 1062480
 
 Test 092 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 093 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 486.097221
-The maximum resident set size (KB)                   = 1057580
+The total amount of wall time                        = 487.939533
+The maximum resident set size (KB)                   = 1053384
 
 Test 093 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rrfs_v1beta_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.136918
-The maximum resident set size (KB)                   = 1052776
+The total amount of wall time                        = 292.741667
+The maximum resident set size (KB)                   = 1053564
 
 Test 094 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_wam_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 297.173378
-The maximum resident set size (KB)                   = 299184
+The total amount of wall time                        = 296.305771
+The maximum resident set size (KB)                   = 298852
 
 Test 095 control_wam_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 096 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3086,14 +3086,14 @@ Checking test 096 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 271.731157
-The maximum resident set size (KB)                   = 887484
+The total amount of wall time                        = 269.594277
+The maximum resident set size (KB)                   = 889112
 
 Test 096 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_control_dyn32_phy32
 Checking test 097 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3140,14 +3140,14 @@ Checking test 097 rap_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 346.025562
-The maximum resident set size (KB)                   = 775308
+The total amount of wall time                        = 342.816999
+The maximum resident set size (KB)                   = 775096
 
 Test 097 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_dyn32_phy32
 Checking test 098 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3194,14 +3194,14 @@ Checking test 098 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 183.381437
-The maximum resident set size (KB)                   = 775816
+The total amount of wall time                        = 181.735678
+The maximum resident set size (KB)                   = 773484
 
 Test 098 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_2threads_dyn32_phy32
 Checking test 099 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3248,14 +3248,14 @@ Checking test 099 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 324.613582
-The maximum resident set size (KB)                   = 831204
+The total amount of wall time                        = 322.635727
+The maximum resident set size (KB)                   = 827492
 
 Test 099 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_2threads_dyn32_phy32
 Checking test 100 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3302,14 +3302,14 @@ Checking test 100 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 173.323674
-The maximum resident set size (KB)                   = 826848
+The total amount of wall time                        = 171.218471
+The maximum resident set size (KB)                   = 829124
 
 Test 100 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_decomp_dyn32_phy32
 Checking test 101 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3356,14 +3356,14 @@ Checking test 101 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 189.847333
-The maximum resident set size (KB)                   = 773656
+The total amount of wall time                        = 188.088905
+The maximum resident set size (KB)                   = 771416
 
 Test 101 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_restart_dyn32_phy32
 Checking test 102 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3402,14 +3402,14 @@ Checking test 102 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 260.421324
-The maximum resident set size (KB)                   = 610248
+The total amount of wall time                        = 253.782914
+The maximum resident set size (KB)                   = 612052
 
 Test 102 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_restart_dyn32_phy32
 Checking test 103 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3448,14 +3448,14 @@ Checking test 103 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 92.530552
-The maximum resident set size (KB)                   = 608576
+The total amount of wall time                        = 101.883297
+The maximum resident set size (KB)                   = 607840
 
 Test 103 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_control_dyn64_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_control_dyn64_phy32
 Checking test 104 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3502,81 +3502,81 @@ Checking test 104 rap_control_dyn64_phy32 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 231.516370
-The maximum resident set size (KB)                   = 797212
+The total amount of wall time                        = 231.419111
+The maximum resident set size (KB)                   = 798988
 
 Test 104 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_control_debug_dyn32_phy32
 Checking test 105 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.159884
-The maximum resident set size (KB)                   = 945732
+The total amount of wall time                        = 289.260350
+The maximum resident set size (KB)                   = 942640
 
 Test 105 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hrrr_control_debug_dyn32_phy32
 Checking test 106 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 286.542805
-The maximum resident set size (KB)                   = 941388
+The total amount of wall time                        = 289.082408
+The maximum resident set size (KB)                   = 943804
 
 Test 106 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/rap_control_dyn64_phy32_debug
 Checking test 107 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.247622
-The maximum resident set size (KB)                   = 960784
+The total amount of wall time                        = 295.353194
+The maximum resident set size (KB)                   = 957072
 
 Test 107 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_atm
 Checking test 108 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 262.716831
-The maximum resident set size (KB)                   = 800372
+The total amount of wall time                        = 255.308744
+The maximum resident set size (KB)                   = 803204
 
 Test 108 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_atm_thompson_gfdlsf
 Checking test 109 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 324.837417
-The maximum resident set size (KB)                   = 1163604
+The total amount of wall time                        = 321.069526
+The maximum resident set size (KB)                   = 1166152
 
 Test 109 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_atm_ocn
 Checking test 110 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3585,14 +3585,14 @@ Checking test 110 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 383.388709
-The maximum resident set size (KB)                   = 836712
+The total amount of wall time                        = 380.155328
+The maximum resident set size (KB)                   = 837380
 
 Test 110 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_atm_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_atm_wav
 Checking test 111 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3601,14 +3601,14 @@ Checking test 111 hafs_regional_atm_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 701.331072
-The maximum resident set size (KB)                   = 869248
+The total amount of wall time                        = 701.103851
+The maximum resident set size (KB)                   = 868980
 
 Test 111 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_atm_ocn_wav
 Checking test 112 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3619,28 +3619,28 @@ Checking test 112 hafs_regional_atm_ocn_wav results ....
  Comparing 20190829.060000.restart.ww3 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 894.539341
-The maximum resident set size (KB)                   = 900844
+The total amount of wall time                        = 894.372173
+The maximum resident set size (KB)                   = 900528
 
 Test 112 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_1nest_atm
 Checking test 113 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 328.731208
-The maximum resident set size (KB)                   = 474724
+The total amount of wall time                        = 324.044527
+The maximum resident set size (KB)                   = 387120
 
 Test 113 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_telescopic_2nests_atm
 Checking test 114 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3649,28 +3649,28 @@ Checking test 114 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 401.857927
-The maximum resident set size (KB)                   = 415020
+The total amount of wall time                        = 397.156418
+The maximum resident set size (KB)                   = 402452
 
 Test 114 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_global_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_global_1nest_atm
 Checking test 115 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 164.945173
-The maximum resident set size (KB)                   = 294724
+The total amount of wall time                        = 164.947616
+The maximum resident set size (KB)                   = 274088
 
 Test 115 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_global_multiple_4nests_atm
 Checking test 116 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3688,14 +3688,14 @@ Checking test 116 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 489.960043
-The maximum resident set size (KB)                   = 340492
+The total amount of wall time                        = 488.410938
+The maximum resident set size (KB)                   = 340156
 
 Test 116 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_specified_moving_1nest_atm
 Checking test 117 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3704,28 +3704,28 @@ Checking test 117 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 212.256077
-The maximum resident set size (KB)                   = 399128
+The total amount of wall time                        = 211.601719
+The maximum resident set size (KB)                   = 400420
 
 Test 117 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_storm_following_1nest_atm
 Checking test 118 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 200.527761
-The maximum resident set size (KB)                   = 400228
+The total amount of wall time                        = 199.437409
+The maximum resident set size (KB)                   = 402144
 
 Test 118 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 119 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3734,28 +3734,28 @@ Checking test 119 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 242.132681
-The maximum resident set size (KB)                   = 453656
+The total amount of wall time                        = 241.298559
+The maximum resident set size (KB)                   = 445980
 
 Test 119 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_global_storm_following_1nest_atm
 Checking test 120 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 79.208114
-The maximum resident set size (KB)                   = 288088
+The total amount of wall time                        = 80.034896
+The maximum resident set size (KB)                   = 284272
 
 Test 120 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 121 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3766,14 +3766,14 @@ Checking test 121 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 522.020564
-The maximum resident set size (KB)                   = 517236
+The total amount of wall time                        = 519.593729
+The maximum resident set size (KB)                   = 518660
 
 Test 121 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/control_p8_atmlnd_sbs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/control_p8_atmlnd_sbs
 Checking test 122 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3858,14 +3858,14 @@ Checking test 122 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 238.153172
-The maximum resident set size (KB)                   = 1542656
+The total amount of wall time                        = 235.440731
+The maximum resident set size (KB)                   = 1548780
 
 Test 122 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/atmaero_control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/atmaero_control_p8
 Checking test 123 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3909,14 +3909,14 @@ Checking test 123 atmaero_control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 247.277895
-The maximum resident set size (KB)                   = 2819020
+The total amount of wall time                        = 255.888045
+The maximum resident set size (KB)                   = 2814104
 
 Test 123 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/atmaero_control_p8_rad
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/atmaero_control_p8_rad
 Checking test 124 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3960,14 +3960,14 @@ Checking test 124 atmaero_control_p8_rad results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 281.991556
-The maximum resident set size (KB)                   = 2880744
+The total amount of wall time                        = 285.452877
+The maximum resident set size (KB)                   = 2881156
 
 Test 124 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/atmaero_control_p8_rad_micro
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/atmaero_control_p8_rad_micro
 Checking test 125 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4011,14 +4011,14 @@ Checking test 125 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 289.976621
-The maximum resident set size (KB)                   = 2884800
+The total amount of wall time                        = 287.090878
+The maximum resident set size (KB)                   = 2885352
 
 Test 125 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_atmaq
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_atmaq
 Checking test 126 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4034,14 +4034,14 @@ Checking test 126 regional_atmaq results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 695.154704
-The maximum resident set size (KB)                   = 1386128
+The total amount of wall time                        = 664.890967
+The maximum resident set size (KB)                   = 1384872
 
 Test 126 regional_atmaq PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230118/INTEL/regional_atmaq_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_181657/regional_atmaq_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230126/INTEL/regional_atmaq_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_97376/regional_atmaq_debug
 Checking test 127 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4055,12 +4055,12 @@ Checking test 127 regional_atmaq_debug results ....
  Comparing RESTART/phy_data.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
 
-The total amount of wall time                        = 1421.116807
-The maximum resident set size (KB)                   = 1417724
+The total amount of wall time                        = 1420.410748
+The maximum resident set size (KB)                   = 1425776
 
 Test 127 regional_atmaq_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 18 17:28:27 UTC 2023
-Elapsed time: 01h:05m:21s. Have a nice day!
+Sat Jan 28 21:09:00 UTC 2023
+Elapsed time: 01h:11m:02s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -445,7 +445,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20230120
+BL_DATE=20230126
 
 RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 


### PR DESCRIPTION
## Description
This is an emergency bug fix for cloud effective radius for convective clouds in ccpp-physics (Issuehttps://github.com/ufs-community/ccpp-physics/issues/36).

### Input data additions/changes
- [x] No changes are expected to input data.
- [ ] There will be new input data. <!-- Add "input data change" Label -->
- [ ] Input data will be updated. <!-- Add "New Input Data Req'd" Label -->

### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test. <!-- Add "No Baseline Change" Label -->
- [x] Changes are expected to the following tests: <!-- Add "Baseline Change" Label -->
<!-- Please insert what RT's change and why you expect them to change -->
All cpld and control_p8 related PRs failed as expected.
[RegressionTests_hera.intel.log](https://github.com/ufs-community/ufs-weather-model/files/10510611/RegressionTests_hera.intel.log)

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [x] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [ ] none

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [x] Link PR's from all sub-components involved
- [x] Confirm reviews completed in sub-component PR's
- [x] Add all appropriate labels to this PR.
- [x] Run full RT suite on either Hera/Cheyenne with both Intel/GNU compilers
- [x] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

Dependencies:
 - Depends on ufs-community/ccpp-physics/pull/35
 - Depends on NOAA-EMC/fv3atm/pull/621

Issue:
 - ufs-community/ccpp-physics/issues/36

## Testing Day Checklist:
- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - Intel
    - [x] Hera
    - [x] Orion
    - [x] Jet
    - [x] Gaea
    - [x] Cheyenne
  - GNU
    - [x] Hera
    - [x] Cheyenne
- WCOSS2
  - [x] Dogwood/Cactus
  - [x] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
