### PR TITLE
Enable usage of shared pio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(FMS)
 endif()
 
 if(CMEPS)
-  find_package(PIO 2.5.3 REQUIRED COMPONENTS C Fortran STATIC)
+  find_package(PIO 2.5.3 REQUIRED COMPONENTS C Fortran)
 endif()
 
 find_package(bacio 2.4.0 REQUIRED)


### PR DESCRIPTION
## Description
Currently, `CMakeLists.txt` requires static builds of `parallelio` (see [these lines](https://github.com/ufs-community/ufs-weather-model/blob/94cc62ac76ac259fce6cd1041dc280f603e29723/CMakeLists.txt#L139-L141)). A relaxation of this requirement (i.e.: to allow shared or static versions of `parallelio`) could be facilitated by updating `CMakeModules` to its develop branch, where `FindPIO.cmake` can automatically accommodate both static or shared builds. 

Apart from updating `CMakeModules` to develop, the `STATIC` requirement would need to be removed from `CMakeLists.txt`.

This change is in anticipation of transition from hpc-stack to spack-stack, where `parallelio` is currently being built as a shared library (see [NOAA-EMC/spack-stack PR #454](https://github.com/NOAA-EMC/spack-stack/pull/454), [issue #478](https://github.com/NOAA-EMC/spack-stack/issues/478)).

RT `cpld_contrl_p8` passed on Orion (Intel) and Hera (Intel & GNU) (logs in comments). I will report further RT results as they complete.

### Anticipated changes to regression tests:
- [ x] No changes are expected to any regression test. <!-- Add "No Baseline Change" Label -->
- [ ] Changes are expected to the following tests: <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [x ] CMakeModules

## Commit Queue Checklist:

- [ ] Link PR's from all sub-components involved
- [ ] Confirm reviews completed in sub-component PR's
- [ ] Add all appropriate labels to this PR.
- [ ] Run full RT suite on either Hera/Cheyenne with both Intel/GNU compilers
- [ ] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
Addresses #1512 

## Testing Day Checklist:
- [x ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - Intel
    - [x ] Hera
    - [ x] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
  - GNU
    - [ x] Hera
    - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
