### PR TITLE
utilize custom restart names for WW3

### DIFF
--- a/tests/fv3_conf/cpld_control_run.IN
+++ b/tests/fv3_conf/cpld_control_run.IN
@@ -130,7 +130,8 @@ else
 
      # WAVE restart file
      if [[ $CPLWAV == .true. ]]; then
-       cp ../${DEP_RUN}${SUFFIX}/${RESTART_FILE_PREFIX}.restart.ww3 ./restart.ww3
+       RFILE=ufs.cpld.ww3.r.${RESTART_FILE_SUFFIX_SECS}
+       cp ../${DEP_RUN}${SUFFIX}/${RFILE} .
      fi
 
   else

--- a/tests/parm/nems.configure.cpld.IN
+++ b/tests/parm/nems.configure.cpld.IN
@@ -74,6 +74,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.cpld_esmfthreads.IN
+++ b/tests/parm/nems.configure.cpld_esmfthreads.IN
@@ -74,6 +74,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.cpld_noaero.IN
+++ b/tests/parm/nems.configure.cpld_noaero.IN
@@ -67,6 +67,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.cpld_noaero_outwav.IN
+++ b/tests/parm/nems.configure.cpld_noaero_outwav.IN
@@ -61,6 +61,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.hafs_atm_ocn_wav.IN
+++ b/tests/parm/nems.configure.hafs_atm_ocn_wav.IN
@@ -86,6 +86,7 @@ WAV_attributes::
   merge_import = .true.
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # Run Sequence #

--- a/tests/parm/nems.configure.hafs_atm_wav.IN
+++ b/tests/parm/nems.configure.hafs_atm_wav.IN
@@ -55,6 +55,7 @@ WAV_attributes::
   merge_import = .true.
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # Run Sequence #

--- a/tests/tests/hafs_regional_atm_ocn_wav
+++ b/tests/tests/hafs_regional_atm_ocn_wav
@@ -14,7 +14,7 @@ export LIST_FILES="atmf006.nc \
                    archs.2019_241_06.a \
                    out_grd.ww3 \
                    out_pnt.ww3 \
-                   20190829.060000.restart.ww3 \
+                   ufs.hafs.ww3.r.2019-08-29-21600 \
                    ufs.hafs.cpl.r.2019-08-29-21600.nc"
 
 export_fv3

--- a/tests/tests/hafs_regional_atm_wav
+++ b/tests/tests/hafs_regional_atm_wav
@@ -12,7 +12,7 @@ export LIST_FILES="atmf006.nc \
                    sfcf006.nc \
                    out_grd.ww3 \
                    out_pnt.ww3 \
-                   20190829.060000.restart.ww3 \
+                   ufs.hafs.ww3.r.2019-08-29-21600 \
                    ufs.hafs.cpl.r.2019-08-29-21600.nc"
 
 export_fv3


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
Utilizes configuration variable ``user_sets_restname`` in nems.configure to trigger a custom restart file name in WW3. Restarts will be produced with name ``ufs.APP.ww3.r.YYYY-MM-DD-SSSSS`` where ``APP`` is either ``cpld`` or ``hafs``. 

If a file of the expected name is not present at restart, WW3 will abort with error

```
 EXTCDE MSG=required initial/restart file ufs.cpld.ww3.r.2021-03-22-64800 does not exist
```

On a restart run, the following will be written to stdout

```
WW3: reading initial/restart file ufs.cpld.ww3.r.2021-03-22-64800
```

### Top of commit queue on: TBD
<!-- Please have sub-component Code Managers ready for merging sub-component PR's on the date above and the day after the date above -->

### Input data additions/changes
- [x] No changes are expected to input data.
- [ ] There will be new input data. <!-- Add "input data change" Label -->
- [ ] Input data will be updated. <!-- Add "New Input Data Req'd" Label -->

### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test. <!-- Add "No Baseline Change" Label -->
- [x] Changes are expected to the following tests: <!-- Add "Baseline Change" Label -->
<!-- Please insert what RT's change and why you expect them to change -->

The ``hafs_regional_atm_ocn_wav`` and ``hafs_regional_atm_wav`` will fail because the name of the restart file changes. Manual comparison against the existing baseline file shows they are B4B. **All other tests pass.**

During testing, the hera.intel log was not produced but the ``rt_`` logs were catted manually. The ``cpld_control_p8`` test timed-out for GNU.

[intel.log](https://github.com/ufs-community/ufs-weather-model/files/11102262/intel.log)
[RegressionTests_cheyenne.gnu.log](https://github.com/ufs-community/ufs-weather-model/files/11102263/RegressionTests_cheyenne.gnu.log)

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [x] none

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [ ] Link PR's from all sub-components involved
- [ ] Confirm reviews completed in sub-component PR's
- [ ] Add all appropriate labels to this PR.
- [ ] Run full RT suite on either Hera/Cheyenne with both Intel/GNU compilers
- [ ] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on NOAA-EMC/fv3atm/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes NOAA-EMC/fv3atm/issues/<issue_number>
-->

- fixes #1590 

## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - Intel
    - [ ] Hera
    - [ ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
  - GNU
    - [ ] Hera
    - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
