### PR TITLE
update CMEPS to allow bilinear ATM<->WAV mapping for global coupled application; utilize custom restart names for WW3 (was #1684) 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,10 +16,8 @@
   branch = develop
 [submodule "CMEPS"]
   path = CMEPS-interface/CMEPS
-  #url = https://github.com/NOAA-EMC/CMEPS
-  #branch = emc/develop
-  url = https://github.com/DeniseWorthen/CMEPS
-  branch = feature/add_unstr
+  url = https://github.com/NOAA-EMC/CMEPS
+  branch = emc/develop
 [submodule "HYCOM"]
   path = HYCOM-interface/HYCOM
   url = https://github.com/NOAA-EMC/HYCOM-src

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,8 +16,10 @@
   branch = develop
 [submodule "CMEPS"]
   path = CMEPS-interface/CMEPS
-  url = https://github.com/NOAA-EMC/CMEPS
-  branch = emc/develop
+  #url = https://github.com/NOAA-EMC/CMEPS
+  #branch = emc/develop
+  url = https://github.com/DeniseWorthen/CMEPS
+  branch = feature/add_unstr
 [submodule "HYCOM"]
   path = HYCOM-interface/HYCOM
   url = https://github.com/NOAA-EMC/HYCOM-src

--- a/tests/RegressionTests_acorn.intel.log
+++ b/tests/RegressionTests_acorn.intel.log
@@ -1,40 +1,40 @@
-Thu Mar 30 16:30:11 UTC 2023
+Mon Apr  3 14:11:37 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 540 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1145 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 506 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 478 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 477 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 1118 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1149 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 469 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 929 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 963 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 602 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 1496 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1013 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 841 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 1247 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 582 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 335 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 476 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 238 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 021 elapsed time 699 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 728 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 832 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 024 elapsed time 828 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 113 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 1010 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 621 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 733 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 775 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 733 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 031 elapsed time 679 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 545 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1030 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 515 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 483 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 489 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 641 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1279 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 986 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1653 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 1084 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 1700 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 645 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 965 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 439 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 499 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 339 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 307 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 485 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 810 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 021 elapsed time 733 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 658 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 345 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 024 elapsed time 317 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 202 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 518 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 881 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 634 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 445 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 206 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 031 elapsed time 690 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_p8_mixedmode
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -99,14 +99,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 334.857481
-The maximum resident set size (KB)                   = 2952384
+The total amount of wall time                        = 334.997418
+The maximum resident set size (KB)                   = 2950216
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_gfsv17
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_gfsv17
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_gfsv17
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -170,14 +170,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 258.062343
-The maximum resident set size (KB)                   = 1584204
+The total amount of wall time                        = 258.245295
+The maximum resident set size (KB)                   = 1572760
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -242,14 +242,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.249156
-The maximum resident set size (KB)                   = 2981544
+The total amount of wall time                        = 389.078866
+The maximum resident set size (KB)                   = 2979724
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -302,14 +302,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 229.759665
-The maximum resident set size (KB)                   = 2869976
+The total amount of wall time                        = 230.014852
+The maximum resident set size (KB)                   = 2872528
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -374,14 +374,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 388.544897
-The maximum resident set size (KB)                   = 2992456
+The total amount of wall time                        = 389.988750
+The maximum resident set size (KB)                   = 2991564
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_restart_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -434,14 +434,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 233.164657
-The maximum resident set size (KB)                   = 2883540
+The total amount of wall time                        = 233.661648
+The maximum resident set size (KB)                   = 2881836
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -494,14 +494,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 366.410096
-The maximum resident set size (KB)                   = 3282632
+The total amount of wall time                        = 367.455681
+The maximum resident set size (KB)                   = 3286572
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -554,14 +554,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 380.683828
-The maximum resident set size (KB)                   = 2976980
+The total amount of wall time                        = 381.271551
+The maximum resident set size (KB)                   = 2976824
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_mpi_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -614,14 +614,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 320.058680
-The maximum resident set size (KB)                   = 2905624
+The total amount of wall time                        = 317.288158
+The maximum resident set size (KB)                   = 2909716
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_ciceC_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -686,14 +686,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 388.822031
-The maximum resident set size (KB)                   = 2977196
+The total amount of wall time                        = 386.900317
+The maximum resident set size (KB)                   = 2981428
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_noaero_p8
 Checking test 011 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -757,14 +757,14 @@ Checking test 011 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 285.247233
-The maximum resident set size (KB)                   = 1572740
+The total amount of wall time                        = 285.504284
+The maximum resident set size (KB)                   = 1570096
 
 Test 011 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_nowave_noaero_p8
 Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -826,14 +826,14 @@ Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 301.398946
-The maximum resident set size (KB)                   = 1629412
+The total amount of wall time                        = 302.585115
+The maximum resident set size (KB)                   = 1627832
 
 Test 012 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_noaero_p8_agrid
 Checking test 013 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -895,14 +895,14 @@ Checking test 013 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 307.206615
-The maximum resident set size (KB)                   = 1625656
+The total amount of wall time                        = 308.722129
+The maximum resident set size (KB)                   = 1619428
 
 Test 013 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_c48
 Checking test 014 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -952,14 +952,14 @@ Checking test 014 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 436.771122
-The maximum resident set size (KB)                   = 2637152
+The total amount of wall time                        = 436.419764
+The maximum resident set size (KB)                   = 2636152
 
 Test 014 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_warmstart_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_warmstart_c48
 Checking test 015 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 015 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 124.640036
-The maximum resident set size (KB)                   = 2649036
+The total amount of wall time                        = 124.706287
+The maximum resident set size (KB)                   = 2650428
 
 Test 015 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_restart_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_restart_c48
 Checking test 016 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1066,14 +1066,14 @@ Checking test 016 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 68.635311
-The maximum resident set size (KB)                   = 2072348
+The total amount of wall time                        = 68.763579
+The maximum resident set size (KB)                   = 2067608
 
 Test 016 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/cpld_control_p8_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/cpld_control_p8_faster
 Checking test 017 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1138,14 +1138,14 @@ Checking test 017 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 379.236270
-The maximum resident set size (KB)                   = 2978508
+The total amount of wall time                        = 380.296637
+The maximum resident set size (KB)                   = 2980856
 
 Test 017 cpld_control_p8_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_CubedSphereGrid
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1172,14 +1172,14 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 129.718674
-The maximum resident set size (KB)                   = 514168
+The total amount of wall time                        = 128.962422
+The maximum resident set size (KB)                   = 510792
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_latlon
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_latlon
 Checking test 019 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1190,14 +1190,14 @@ Checking test 019 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.115280
-The maximum resident set size (KB)                   = 512288
+The total amount of wall time                        = 132.852461
+The maximum resident set size (KB)                   = 512444
 
 Test 019 control_latlon PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_wrtGauss_netcdf_parallel
 Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1208,14 +1208,14 @@ Checking test 020 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.235533
-The maximum resident set size (KB)                   = 512584
+The total amount of wall time                        = 135.060205
+The maximum resident set size (KB)                   = 514108
 
 Test 020 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_c48
 Checking test 021 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1254,14 +1254,14 @@ Checking test 021 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 327.875740
-The maximum resident set size (KB)                   = 672264
+The total amount of wall time                        = 329.615353
+The maximum resident set size (KB)                   = 671968
 
 Test 021 control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_c192
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1272,14 +1272,14 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 532.415732
-The maximum resident set size (KB)                   = 611696
+The total amount of wall time                        = 529.666174
+The maximum resident set size (KB)                   = 612996
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_c384
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1290,14 +1290,14 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 564.604373
-The maximum resident set size (KB)                   = 923992
+The total amount of wall time                        = 570.789389
+The maximum resident set size (KB)                   = 920112
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_c384gdas
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1340,14 +1340,14 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 499.403760
-The maximum resident set size (KB)                   = 1058068
+The total amount of wall time                        = 498.555712
+The maximum resident set size (KB)                   = 1052744
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_stochy
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1358,28 +1358,28 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 89.816807
-The maximum resident set size (KB)                   = 519784
+The total amount of wall time                        = 88.996307
+The maximum resident set size (KB)                   = 516676
 
 Test 025 control_stochy PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_stochy_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_stochy_restart
 Checking test 026 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 48.770607
-The maximum resident set size (KB)                   = 286736
+The total amount of wall time                        = 48.852568
+The maximum resident set size (KB)                   = 285428
 
 Test 026 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_lndp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_lndp
 Checking test 027 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1390,14 +1390,14 @@ Checking test 027 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 82.773124
-The maximum resident set size (KB)                   = 517012
+The total amount of wall time                        = 83.286444
+The maximum resident set size (KB)                   = 515108
 
 Test 027 control_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_iovr4
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_iovr4
 Checking test 028 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1412,14 +1412,14 @@ Checking test 028 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.773244
-The maximum resident set size (KB)                   = 512544
+The total amount of wall time                        = 135.136668
+The maximum resident set size (KB)                   = 516700
 
 Test 028 control_iovr4 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_iovr5
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_iovr5
 Checking test 029 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1434,14 +1434,14 @@ Checking test 029 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.194817
-The maximum resident set size (KB)                   = 512060
+The total amount of wall time                        = 135.587184
+The maximum resident set size (KB)                   = 512248
 
 Test 029 control_iovr5 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_p8
 Checking test 030 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1488,14 +1488,14 @@ Checking test 030 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.375833
-The maximum resident set size (KB)                   = 1482300
+The total amount of wall time                        = 179.324120
+The maximum resident set size (KB)                   = 1488188
 
 Test 030 control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_restart_p8
 Checking test 031 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1534,14 +1534,14 @@ Checking test 031 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.768035
-The maximum resident set size (KB)                   = 654308
+The total amount of wall time                        = 99.231967
+The maximum resident set size (KB)                   = 653208
 
 Test 031 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_qr_p8
 Checking test 032 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1588,14 +1588,14 @@ Checking test 032 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 177.107372
-The maximum resident set size (KB)                   = 1491568
+The total amount of wall time                        = 177.184892
+The maximum resident set size (KB)                   = 1496100
 
 Test 032 control_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_restart_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_restart_qr_p8
 Checking test 033 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1634,14 +1634,14 @@ Checking test 033 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 100.602764
-The maximum resident set size (KB)                   = 668548
+The total amount of wall time                        = 99.459581
+The maximum resident set size (KB)                   = 665780
 
 Test 033 control_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1684,14 +1684,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 181.969260
-The maximum resident set size (KB)                   = 1477968
+The total amount of wall time                        = 181.698247
+The maximum resident set size (KB)                   = 1479696
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1734,14 +1734,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 155.737008
-The maximum resident set size (KB)                   = 1568284
+The total amount of wall time                        = 157.061251
+The maximum resident set size (KB)                   = 1570732
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_p8_lndp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_p8_lndp
 Checking test 036 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1760,14 +1760,14 @@ Checking test 036 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 321.949084
-The maximum resident set size (KB)                   = 1483716
+The total amount of wall time                        = 323.117434
+The maximum resident set size (KB)                   = 1480048
 
 Test 036 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_p8_rrtmgp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_p8_rrtmgp
 Checking test 037 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1814,14 +1814,14 @@ Checking test 037 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 233.873279
-The maximum resident set size (KB)                   = 1541776
+The total amount of wall time                        = 234.440864
+The maximum resident set size (KB)                   = 1546200
 
 Test 037 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_p8_mynn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_p8_mynn
 Checking test 038 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1868,14 +1868,14 @@ Checking test 038 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.545186
-The maximum resident set size (KB)                   = 1483216
+The total amount of wall time                        = 180.856866
+The maximum resident set size (KB)                   = 1484984
 
 Test 038 control_p8_mynn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/merra2_thompson
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/merra2_thompson
 Checking test 039 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1922,14 +1922,14 @@ Checking test 039 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 203.479908
-The maximum resident set size (KB)                   = 1491796
+The total amount of wall time                        = 203.857891
+The maximum resident set size (KB)                   = 1491196
 
 Test 039 merra2_thompson PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_control
 Checking test 040 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1940,28 +1940,28 @@ Checking test 040 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 291.701614
-The maximum resident set size (KB)                   = 649812
+The total amount of wall time                        = 287.056637
+The maximum resident set size (KB)                   = 655392
 
 Test 040 regional_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_restart
 Checking test 041 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 156.262318
-The maximum resident set size (KB)                   = 651436
+The total amount of wall time                        = 155.769247
+The maximum resident set size (KB)                   = 649256
 
 Test 041 regional_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_control_qr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_control_qr
 Checking test 042 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1972,28 +1972,28 @@ Checking test 042 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 287.441524
-The maximum resident set size (KB)                   = 649844
+The total amount of wall time                        = 288.589544
+The maximum resident set size (KB)                   = 655480
 
 Test 042 regional_control_qr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_restart_qr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_restart_qr
 Checking test 043 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 156.995151
-The maximum resident set size (KB)                   = 651132
+The total amount of wall time                        = 155.717368
+The maximum resident set size (KB)                   = 650632
 
 Test 043 regional_restart_qr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_decomp
 Checking test 044 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2004,14 +2004,14 @@ Checking test 044 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 301.601919
-The maximum resident set size (KB)                   = 649708
+The total amount of wall time                        = 303.580505
+The maximum resident set size (KB)                   = 651052
 
 Test 044 regional_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_2threads
 Checking test 045 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2022,14 +2022,14 @@ Checking test 045 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 176.114563
-The maximum resident set size (KB)                   = 696060
+The total amount of wall time                        = 176.883901
+The maximum resident set size (KB)                   = 695036
 
 Test 045 regional_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_noquilt
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_noquilt
 Checking test 046 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 046 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 313.537090
-The maximum resident set size (KB)                   = 643064
+The total amount of wall time                        = 313.813434
+The maximum resident set size (KB)                   = 644268
 
 Test 046 regional_noquilt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_2dwrtdecomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_2dwrtdecomp
 Checking test 047 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2055,14 +2055,14 @@ Checking test 047 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 287.503661
-The maximum resident set size (KB)                   = 648784
+The total amount of wall time                        = 287.184737
+The maximum resident set size (KB)                   = 649956
 
 Test 047 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_wofs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/fv3_regional_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_wofs
 Checking test 048 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2073,14 +2073,14 @@ Checking test 048 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 361.643572
-The maximum resident set size (KB)                   = 340428
+The total amount of wall time                        = 363.612919
+The maximum resident set size (KB)                   = 338876
 
 Test 048 regional_wofs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_ifi_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_ifi_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_ifi_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_ifi_control
 Checking test 049 regional_ifi_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2091,14 +2091,14 @@ Checking test 049 regional_ifi_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 324.581266
-The maximum resident set size (KB)                   = 653448
+The total amount of wall time                        = 322.114132
+The maximum resident set size (KB)                   = 649716
 
 Test 049 regional_ifi_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_ifi_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_ifi_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_ifi_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_ifi_decomp
 Checking test 050 regional_ifi_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2109,14 +2109,14 @@ Checking test 050 regional_ifi_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 338.858598
-The maximum resident set size (KB)                   = 649716
+The total amount of wall time                        = 337.344053
+The maximum resident set size (KB)                   = 653288
 
 Test 050 regional_ifi_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_ifi_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_ifi_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_ifi_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_ifi_2threads
 Checking test 051 regional_ifi_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2127,14 +2127,14 @@ Checking test 051 regional_ifi_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 197.820279
-The maximum resident set size (KB)                   = 694896
+The total amount of wall time                        = 201.223607
+The maximum resident set size (KB)                   = 696512
 
 Test 051 regional_ifi_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_control
 Checking test 052 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2181,14 +2181,14 @@ Checking test 052 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 419.534701
-The maximum resident set size (KB)                   = 892140
+The total amount of wall time                        = 420.578529
+The maximum resident set size (KB)                   = 891920
 
 Test 052 rap_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_spp_sppt_shum_skeb
 Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2199,14 +2199,14 @@ Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 243.950318
-The maximum resident set size (KB)                   = 989036
+The total amount of wall time                        = 242.079317
+The maximum resident set size (KB)                   = 987840
 
 Test 053 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_decomp
 Checking test 054 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2253,14 +2253,14 @@ Checking test 054 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 433.139718
-The maximum resident set size (KB)                   = 892296
+The total amount of wall time                        = 432.433369
+The maximum resident set size (KB)                   = 891144
 
 Test 054 rap_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_2threads
 Checking test 055 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2307,14 +2307,14 @@ Checking test 055 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 387.732275
-The maximum resident set size (KB)                   = 963116
+The total amount of wall time                        = 387.696421
+The maximum resident set size (KB)                   = 962844
 
 Test 055 rap_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_restart
 Checking test 056 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2353,14 +2353,14 @@ Checking test 056 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 211.713198
-The maximum resident set size (KB)                   = 644548
+The total amount of wall time                        = 212.608949
+The maximum resident set size (KB)                   = 644708
 
 Test 056 rap_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_sfcdiff
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_sfcdiff
 Checking test 057 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2407,14 +2407,14 @@ Checking test 057 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 422.674965
-The maximum resident set size (KB)                   = 888728
+The total amount of wall time                        = 421.322643
+The maximum resident set size (KB)                   = 891792
 
 Test 057 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_sfcdiff_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_sfcdiff_decomp
 Checking test 058 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2461,14 +2461,14 @@ Checking test 058 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 441.195515
-The maximum resident set size (KB)                   = 892408
+The total amount of wall time                        = 439.239442
+The maximum resident set size (KB)                   = 893800
 
 Test 058 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_sfcdiff_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_sfcdiff_restart
 Checking test 059 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2507,14 +2507,14 @@ Checking test 059 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 309.631487
-The maximum resident set size (KB)                   = 644836
+The total amount of wall time                        = 310.691963
+The maximum resident set size (KB)                   = 638500
 
 Test 059 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control
 Checking test 060 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2561,14 +2561,14 @@ Checking test 060 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 409.065281
-The maximum resident set size (KB)                   = 891756
+The total amount of wall time                        = 406.087817
+The maximum resident set size (KB)                   = 885856
 
 Test 060 hrrr_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_decomp
 Checking test 061 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2615,14 +2615,14 @@ Checking test 061 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 420.455554
-The maximum resident set size (KB)                   = 887380
+The total amount of wall time                        = 420.283746
+The maximum resident set size (KB)                   = 888804
 
 Test 061 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_2threads
 Checking test 062 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2669,14 +2669,14 @@ Checking test 062 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 375.112474
-The maximum resident set size (KB)                   = 959364
+The total amount of wall time                        = 372.711939
+The maximum resident set size (KB)                   = 961928
 
 Test 062 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_restart
 Checking test 063 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2715,14 +2715,14 @@ Checking test 063 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 298.225091
-The maximum resident set size (KB)                   = 638820
+The total amount of wall time                        = 297.979299
+The maximum resident set size (KB)                   = 638300
 
 Test 063 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_v1beta
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_v1beta
 Checking test 064 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2769,14 +2769,14 @@ Checking test 064 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 419.801716
-The maximum resident set size (KB)                   = 889088
+The total amount of wall time                        = 417.492995
+The maximum resident set size (KB)                   = 885352
 
 Test 064 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_v1nssl
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_v1nssl
 Checking test 065 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2791,14 +2791,14 @@ Checking test 065 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 484.341531
-The maximum resident set size (KB)                   = 572312
+The total amount of wall time                        = 483.886093
+The maximum resident set size (KB)                   = 573224
 
 Test 065 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_v1nssl_nohailnoccn
 Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2813,14 +2813,14 @@ Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 473.307993
-The maximum resident set size (KB)                   = 567132
+The total amount of wall time                        = 471.577785
+The maximum resident set size (KB)                   = 567096
 
 Test 066 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_smoke_conus13km_hrrr_warm
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2829,14 +2829,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 145.538792
-The maximum resident set size (KB)                   = 799084
+The total amount of wall time                        = 146.687543
+The maximum resident set size (KB)                   = 799496
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 068 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2845,14 +2845,14 @@ Checking test 068 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 101.833884
-The maximum resident set size (KB)                   = 806260
+The total amount of wall time                        = 102.202141
+The maximum resident set size (KB)                   = 798424
 
 Test 068 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_conus13km_hrrr_warm
 Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2861,14 +2861,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 131.879348
-The maximum resident set size (KB)                   = 778944
+The total amount of wall time                        = 132.770658
+The maximum resident set size (KB)                   = 775176
 
 Test 069 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 070 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2877,26 +2877,26 @@ Checking test 070 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 146.667978
-The maximum resident set size (KB)                   = 801536
+The total amount of wall time                        = 145.709856
+The maximum resident set size (KB)                   = 802656
 
 Test 070 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 071 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 67.151335
-The maximum resident set size (KB)                   = 758948
+The total amount of wall time                        = 67.361418
+The maximum resident set size (KB)                   = 756312
 
 Test 071 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_csawmg
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_csawmg
 Checking test 072 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2907,14 +2907,14 @@ Checking test 072 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 349.327691
-The maximum resident set size (KB)                   = 581916
+The total amount of wall time                        = 348.031304
+The maximum resident set size (KB)                   = 581556
 
 Test 072 control_csawmg PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_csawmgt
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_csawmgt
 Checking test 073 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2925,14 +2925,14 @@ Checking test 073 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 345.535243
-The maximum resident set size (KB)                   = 581696
+The total amount of wall time                        = 344.405784
+The maximum resident set size (KB)                   = 582556
 
 Test 073 control_csawmgt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_ras
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_ras
 Checking test 074 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2943,26 +2943,26 @@ Checking test 074 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 181.898879
-The maximum resident set size (KB)                   = 550952
+The total amount of wall time                        = 183.828599
+The maximum resident set size (KB)                   = 547252
 
 Test 074 control_ras PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_wam
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_wam
 Checking test 075 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 117.433340
-The maximum resident set size (KB)                   = 272084
+The total amount of wall time                        = 117.698833
+The maximum resident set size (KB)                   = 269300
 
 Test 075 control_wam PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_p8_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_p8_faster
 Checking test 076 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3009,14 +3009,14 @@ Checking test 076 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.139197
-The maximum resident set size (KB)                   = 1491308
+The total amount of wall time                        = 173.616392
+The maximum resident set size (KB)                   = 1488000
 
 Test 076 control_p8_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_control_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_control_faster
 Checking test 077 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3027,56 +3027,56 @@ Checking test 077 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 282.502072
-The maximum resident set size (KB)                   = 655072
+The total amount of wall time                        = 280.485488
+The maximum resident set size (KB)                   = 655124
 
 Test 077 regional_control_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 078 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 903.690717
-The maximum resident set size (KB)                   = 827732
+The total amount of wall time                        = 903.232871
+The maximum resident set size (KB)                   = 831628
 
 Test 078 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 522.587870
-The maximum resident set size (KB)                   = 830464
+The total amount of wall time                        = 522.874540
+The maximum resident set size (KB)                   = 828024
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_conus13km_hrrr_warm_debug
 Checking test 080 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 810.582302
-The maximum resident set size (KB)                   = 807728
+The total amount of wall time                        = 818.307147
+The maximum resident set size (KB)                   = 807100
 
 Test 080 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_CubedSphereGrid_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_CubedSphereGrid_debug
 Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3103,334 +3103,334 @@ Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 167.983080
-The maximum resident set size (KB)                   = 675100
+The total amount of wall time                        = 168.596532
+The maximum resident set size (KB)                   = 673536
 
 Test 081 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_wrtGauss_netcdf_parallel_debug
 Checking test 082 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.652080
-The maximum resident set size (KB)                   = 676204
+The total amount of wall time                        = 160.618247
+The maximum resident set size (KB)                   = 678448
 
 Test 082 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_stochy_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_stochy_debug
 Checking test 083 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.810189
-The maximum resident set size (KB)                   = 682952
+The total amount of wall time                        = 181.205984
+The maximum resident set size (KB)                   = 682964
 
 Test 083 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_lndp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_lndp_debug
 Checking test 084 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.221115
-The maximum resident set size (KB)                   = 681732
+The total amount of wall time                        = 162.341363
+The maximum resident set size (KB)                   = 689048
 
 Test 084 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_csawmg_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_csawmg_debug
 Checking test 085 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 258.281925
-The maximum resident set size (KB)                   = 715676
+The total amount of wall time                        = 255.664539
+The maximum resident set size (KB)                   = 721168
 
 Test 085 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_csawmgt_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_csawmgt_debug
 Checking test 086 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 252.015563
-The maximum resident set size (KB)                   = 721076
+The total amount of wall time                        = 251.549383
+The maximum resident set size (KB)                   = 715532
 
 Test 086 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_ras_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_ras_debug
 Checking test 087 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 164.495631
-The maximum resident set size (KB)                   = 691140
+The total amount of wall time                        = 164.686125
+The maximum resident set size (KB)                   = 694092
 
 Test 087 control_ras_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_diag_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_diag_debug
 Checking test 088 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.878992
-The maximum resident set size (KB)                   = 736456
+The total amount of wall time                        = 164.545711
+The maximum resident set size (KB)                   = 736108
 
 Test 088 control_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_debug_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_debug_p8
 Checking test 089 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 188.684206
-The maximum resident set size (KB)                   = 1505888
+The total amount of wall time                        = 186.658517
+The maximum resident set size (KB)                   = 1507916
 
 Test 089 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1047.789039
-The maximum resident set size (KB)                   = 676624
+The total amount of wall time                        = 1046.512043
+The maximum resident set size (KB)                   = 673452
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_control_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.696075
-The maximum resident set size (KB)                   = 1052244
+The total amount of wall time                        = 301.186876
+The maximum resident set size (KB)                   = 1055180
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_debug
 Checking test 092 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.912413
-The maximum resident set size (KB)                   = 1051052
+The total amount of wall time                        = 295.342367
+The maximum resident set size (KB)                   = 1049208
 
 Test 092 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_unified_drag_suite_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_unified_drag_suite_debug
 Checking test 093 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.508010
-The maximum resident set size (KB)                   = 1052844
+The total amount of wall time                        = 302.219715
+The maximum resident set size (KB)                   = 1056348
 
 Test 093 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_diag_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_diag_debug
 Checking test 094 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 311.457665
-The maximum resident set size (KB)                   = 1135108
+The total amount of wall time                        = 312.844662
+The maximum resident set size (KB)                   = 1133696
 
 Test 094 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_cires_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_cires_ugwp_debug
 Checking test 095 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.743414
-The maximum resident set size (KB)                   = 1055128
+The total amount of wall time                        = 307.100092
+The maximum resident set size (KB)                   = 1054048
 
 Test 095 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_unified_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_unified_ugwp_debug
 Checking test 096 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.449126
-The maximum resident set size (KB)                   = 1051844
+The total amount of wall time                        = 307.888280
+The maximum resident set size (KB)                   = 1050988
 
 Test 096 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_lndp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_lndp_debug
 Checking test 097 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.159254
-The maximum resident set size (KB)                   = 1057508
+The total amount of wall time                        = 304.209918
+The maximum resident set size (KB)                   = 1054704
 
 Test 097 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_flake_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_flake_debug
 Checking test 098 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.878588
-The maximum resident set size (KB)                   = 1053860
+The total amount of wall time                        = 302.186605
+The maximum resident set size (KB)                   = 1053208
 
 Test 098 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_progcld_thompson_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_progcld_thompson_debug
 Checking test 099 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.804469
-The maximum resident set size (KB)                   = 1053596
+The total amount of wall time                        = 300.169247
+The maximum resident set size (KB)                   = 1054584
 
 Test 099 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_noah_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_noah_debug
 Checking test 100 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.609439
-The maximum resident set size (KB)                   = 1053060
+The total amount of wall time                        = 294.032419
+The maximum resident set size (KB)                   = 1046904
 
 Test 100 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_sfcdiff_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_sfcdiff_debug
 Checking test 101 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.315556
-The maximum resident set size (KB)                   = 1051752
+The total amount of wall time                        = 300.278755
+The maximum resident set size (KB)                   = 1053168
 
 Test 101 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 102 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 493.995276
-The maximum resident set size (KB)                   = 1050132
+The total amount of wall time                        = 491.391589
+The maximum resident set size (KB)                   = 1049776
 
 Test 102 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rrfs_v1beta_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rrfs_v1beta_debug
 Checking test 103 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.124586
-The maximum resident set size (KB)                   = 1049868
+The total amount of wall time                        = 296.683001
+The maximum resident set size (KB)                   = 1048976
 
 Test 103 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_wam_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_wam_debug
 Checking test 104 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 298.097363
-The maximum resident set size (KB)                   = 304904
+The total amount of wall time                        = 298.807926
+The maximum resident set size (KB)                   = 303200
 
 Test 104 control_wam_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 105 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3441,14 +3441,14 @@ Checking test 105 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 232.224031
-The maximum resident set size (KB)                   = 882808
+The total amount of wall time                        = 232.360262
+The maximum resident set size (KB)                   = 880264
 
 Test 105 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_control_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_control_dyn32_phy32
 Checking test 106 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3495,14 +3495,14 @@ Checking test 106 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 353.961662
-The maximum resident set size (KB)                   = 772604
+The total amount of wall time                        = 351.001868
+The maximum resident set size (KB)                   = 774028
 
 Test 106 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_dyn32_phy32
 Checking test 107 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3549,14 +3549,14 @@ Checking test 107 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 188.130422
-The maximum resident set size (KB)                   = 774048
+The total amount of wall time                        = 187.008818
+The maximum resident set size (KB)                   = 772376
 
 Test 107 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_2threads_dyn32_phy32
 Checking test 108 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3603,14 +3603,14 @@ Checking test 108 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 329.056666
-The maximum resident set size (KB)                   = 826620
+The total amount of wall time                        = 328.302978
+The maximum resident set size (KB)                   = 832724
 
 Test 108 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_2threads_dyn32_phy32
 Checking test 109 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3657,14 +3657,14 @@ Checking test 109 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 171.911724
-The maximum resident set size (KB)                   = 824100
+The total amount of wall time                        = 172.632144
+The maximum resident set size (KB)                   = 829508
 
 Test 109 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_decomp_dyn32_phy32
 Checking test 110 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3711,14 +3711,14 @@ Checking test 110 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 195.245801
-The maximum resident set size (KB)                   = 771424
+The total amount of wall time                        = 194.853356
+The maximum resident set size (KB)                   = 775596
 
 Test 110 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_restart_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_restart_dyn32_phy32
 Checking test 111 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3757,14 +3757,14 @@ Checking test 111 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 257.930125
-The maximum resident set size (KB)                   = 609160
+The total amount of wall time                        = 259.042549
+The maximum resident set size (KB)                   = 609204
 
 Test 111 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_restart_dyn32_phy32
 Checking test 112 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3803,14 +3803,14 @@ Checking test 112 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 97.732233
-The maximum resident set size (KB)                   = 606080
+The total amount of wall time                        = 97.129661
+The maximum resident set size (KB)                   = 605132
 
 Test 112 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_control_dyn64_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_control_dyn64_phy32
 Checking test 113 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3857,81 +3857,81 @@ Checking test 113 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 235.527532
-The maximum resident set size (KB)                   = 791880
+The total amount of wall time                        = 235.209072
+The maximum resident set size (KB)                   = 796052
 
 Test 113 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_control_debug_dyn32_phy32
 Checking test 114 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.363014
-The maximum resident set size (KB)                   = 939400
+The total amount of wall time                        = 291.463545
+The maximum resident set size (KB)                   = 937788
 
 Test 114 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hrrr_control_debug_dyn32_phy32
 Checking test 115 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 286.727205
-The maximum resident set size (KB)                   = 938124
+The total amount of wall time                        = 286.695883
+The maximum resident set size (KB)                   = 935264
 
 Test 115 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/rap_control_dyn64_phy32_debug
 Checking test 116 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.459968
-The maximum resident set size (KB)                   = 956232
+The total amount of wall time                        = 293.483945
+The maximum resident set size (KB)                   = 953660
 
 Test 116 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_atm
 Checking test 117 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 269.003587
-The maximum resident set size (KB)                   = 824032
+The total amount of wall time                        = 268.748425
+The maximum resident set size (KB)                   = 825160
 
 Test 117 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_atm_thompson_gfdlsf
 Checking test 118 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 322.096090
-The maximum resident set size (KB)                   = 1179168
+The total amount of wall time                        = 312.883691
+The maximum resident set size (KB)                   = 1182976
 
 Test 118 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_atm_ocn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_atm_ocn
 Checking test 119 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3940,30 +3940,30 @@ Checking test 119 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 387.476404
-The maximum resident set size (KB)                   = 858152
+The total amount of wall time                        = 385.940568
+The maximum resident set size (KB)                   = 859996
 
 Test 119 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_atm_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_atm_wav
 Checking test 120 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 700.922067
-The maximum resident set size (KB)                   = 887356
+The total amount of wall time                        = 699.782499
+The maximum resident set size (KB)                   = 887380
 
 Test 120 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_atm_ocn_wav
 Checking test 121 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3971,31 +3971,31 @@ Checking test 121 hafs_regional_atm_ocn_wav results ....
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 892.759235
-The maximum resident set size (KB)                   = 914132
+The total amount of wall time                        = 889.920464
+The maximum resident set size (KB)                   = 913632
 
 Test 121 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_1nest_atm
 Checking test 122 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 332.415715
-The maximum resident set size (KB)                   = 398012
+The total amount of wall time                        = 333.526583
+The maximum resident set size (KB)                   = 396720
 
 Test 122 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_telescopic_2nests_atm
 Checking test 123 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4004,28 +4004,28 @@ Checking test 123 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 401.733899
-The maximum resident set size (KB)                   = 400768
+The total amount of wall time                        = 403.276298
+The maximum resident set size (KB)                   = 399816
 
 Test 123 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_global_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_global_1nest_atm
 Checking test 124 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 171.487002
-The maximum resident set size (KB)                   = 264904
+The total amount of wall time                        = 172.660778
+The maximum resident set size (KB)                   = 261148
 
 Test 124 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_global_multiple_4nests_atm
 Checking test 125 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4043,14 +4043,14 @@ Checking test 125 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 489.492375
-The maximum resident set size (KB)                   = 345964
+The total amount of wall time                        = 492.792493
+The maximum resident set size (KB)                   = 349868
 
 Test 125 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_specified_moving_1nest_atm
 Checking test 126 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4059,28 +4059,28 @@ Checking test 126 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 219.004698
-The maximum resident set size (KB)                   = 406380
+The total amount of wall time                        = 220.036329
+The maximum resident set size (KB)                   = 406284
 
 Test 126 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_storm_following_1nest_atm
 Checking test 127 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 206.342762
-The maximum resident set size (KB)                   = 406512
+The total amount of wall time                        = 207.760698
+The maximum resident set size (KB)                   = 406096
 
 Test 127 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 128 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4089,42 +4089,42 @@ Checking test 128 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 253.636364
-The maximum resident set size (KB)                   = 469476
+The total amount of wall time                        = 253.817068
+The maximum resident set size (KB)                   = 470024
 
 Test 128 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_global_storm_following_1nest_atm
 Checking test 129 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 84.728648
-The maximum resident set size (KB)                   = 279308
+The total amount of wall time                        = 84.990266
+The maximum resident set size (KB)                   = 289216
 
 Test 129 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 818.983545
-The maximum resident set size (KB)                   = 491820
+The total amount of wall time                        = 811.267023
+The maximum resident set size (KB)                   = 492308
 
 Test 130 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4135,14 +4135,14 @@ Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 504.989922
-The maximum resident set size (KB)                   = 523564
+The total amount of wall time                        = 503.573804
+The maximum resident set size (KB)                   = 525288
 
 Test 131 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_docn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_docn
 Checking test 132 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4150,14 +4150,14 @@ Checking test 132 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 369.718174
-The maximum resident set size (KB)                   = 861192
+The total amount of wall time                        = 369.241742
+The maximum resident set size (KB)                   = 861560
 
 Test 132 hafs_regional_docn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_docn_oisst
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_docn_oisst
 Checking test 133 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4165,131 +4165,131 @@ Checking test 133 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 370.763100
-The maximum resident set size (KB)                   = 845428
+The total amount of wall time                        = 370.277897
+The maximum resident set size (KB)                   = 848344
 
 Test 133 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/hafs_regional_datm_cdeps
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/hafs_regional_datm_cdeps
 Checking test 134 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 949.757393
-The maximum resident set size (KB)                   = 836876
+The total amount of wall time                        = 949.494035
+The maximum resident set size (KB)                   = 834528
 
 Test 134 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_control_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_control_cfsr
 Checking test 135 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.707284
-The maximum resident set size (KB)                   = 733604
+The total amount of wall time                        = 141.365727
+The maximum resident set size (KB)                   = 731840
 
 Test 135 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_restart_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_restart_cfsr
 Checking test 136 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 85.266054
-The maximum resident set size (KB)                   = 728032
+The total amount of wall time                        = 86.002576
+The maximum resident set size (KB)                   = 727596
 
 Test 136 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_control_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_control_gefs
 Checking test 137 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 135.333275
-The maximum resident set size (KB)                   = 616460
+The total amount of wall time                        = 134.203688
+The maximum resident set size (KB)                   = 615624
 
 Test 137 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_iau_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_iau_gefs
 Checking test 138 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 137.693984
-The maximum resident set size (KB)                   = 611220
+The total amount of wall time                        = 136.835545
+The maximum resident set size (KB)                   = 613016
 
 Test 138 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_stochy_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_stochy_gefs
 Checking test 139 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 137.769532
-The maximum resident set size (KB)                   = 613904
+The total amount of wall time                        = 137.269149
+The maximum resident set size (KB)                   = 613536
 
 Test 139 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_ciceC_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_ciceC_cfsr
 Checking test 140 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.635913
-The maximum resident set size (KB)                   = 733080
+The total amount of wall time                        = 141.316413
+The maximum resident set size (KB)                   = 736464
 
 Test 140 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_bulk_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_bulk_cfsr
 Checking test 141 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.186974
-The maximum resident set size (KB)                   = 736804
+The total amount of wall time                        = 142.315535
+The maximum resident set size (KB)                   = 732172
 
 Test 141 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_bulk_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_bulk_gefs
 Checking test 142 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 132.698576
-The maximum resident set size (KB)                   = 619548
+The total amount of wall time                        = 134.832154
+The maximum resident set size (KB)                   = 616888
 
 Test 142 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_mx025_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_mx025_cfsr
 Checking test 143 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4298,14 +4298,14 @@ Checking test 143 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 429.131284
-The maximum resident set size (KB)                   = 568972
+The total amount of wall time                        = 429.467478
+The maximum resident set size (KB)                   = 568020
 
 Test 143 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_mx025_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_mx025_gefs
 Checking test 144 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4314,64 +4314,64 @@ Checking test 144 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 427.039953
-The maximum resident set size (KB)                   = 549480
+The total amount of wall time                        = 430.605490
+The maximum resident set size (KB)                   = 547484
 
 Test 144 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_multiple_files_cfsr
 Checking test 145 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.543146
-The maximum resident set size (KB)                   = 734884
+The total amount of wall time                        = 141.358313
+The maximum resident set size (KB)                   = 734340
 
 Test 145 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_3072x1536_cfsr
 Checking test 146 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 257.926521
-The maximum resident set size (KB)                   = 1980852
+The total amount of wall time                        = 256.775533
+The maximum resident set size (KB)                   = 1980356
 
 Test 146 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_gfs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_gfs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_gfs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_gfs
 Checking test 147 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 257.140875
-The maximum resident set size (KB)                   = 1981628
+The total amount of wall time                        = 256.459404
+The maximum resident set size (KB)                   = 1980680
 
 Test 147 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_control_cfsr_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_control_cfsr_faster
 Checking test 148 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.406446
-The maximum resident set size (KB)                   = 733792
+The total amount of wall time                        = 141.093547
+The maximum resident set size (KB)                   = 732832
 
 Test 148 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_lnd_gswp3
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_lnd_gswp3
 Checking test 149 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4380,14 +4380,14 @@ Checking test 149 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 21.990838
-The maximum resident set size (KB)                   = 228060
+The total amount of wall time                        = 22.059304
+The maximum resident set size (KB)                   = 226840
 
 Test 149 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/datm_cdeps_lnd_gswp3_rst
 Checking test 150 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4396,14 +4396,14 @@ Checking test 150 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 27.547151
-The maximum resident set size (KB)                   = 229488
+The total amount of wall time                        = 27.270256
+The maximum resident set size (KB)                   = 232468
 
 Test 150 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_p8_atmlnd_sbs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_p8_atmlnd_sbs
 Checking test 151 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4488,14 +4488,14 @@ Checking test 151 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 234.562679
-The maximum resident set size (KB)                   = 1545116
+The total amount of wall time                        = 234.336783
+The maximum resident set size (KB)                   = 1540108
 
 Test 151 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_atmwav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/control_atmwav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_atmwav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/control_atmwav
 Checking test 152 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4539,14 +4539,14 @@ Checking test 152 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 91.647649
-The maximum resident set size (KB)                   = 537712
+The total amount of wall time                        = 91.504838
+The maximum resident set size (KB)                   = 539624
 
 Test 152 control_atmwav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/atmaero_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/atmaero_control_p8
 Checking test 153 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4590,14 +4590,14 @@ Checking test 153 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 246.842657
-The maximum resident set size (KB)                   = 2811184
+The total amount of wall time                        = 245.163053
+The maximum resident set size (KB)                   = 2813832
 
 Test 153 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/atmaero_control_p8_rad
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/atmaero_control_p8_rad
 Checking test 154 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4641,14 +4641,14 @@ Checking test 154 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 283.414227
-The maximum resident set size (KB)                   = 2876660
+The total amount of wall time                        = 281.936632
+The maximum resident set size (KB)                   = 2876048
 
 Test 154 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/atmaero_control_p8_rad_micro
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/atmaero_control_p8_rad_micro
 Checking test 155 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4692,14 +4692,14 @@ Checking test 155 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 289.388829
-The maximum resident set size (KB)                   = 2881256
+The total amount of wall time                        = 289.302760
+The maximum resident set size (KB)                   = 2884628
 
 Test 155 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_atmaq
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_atmaq
 Checking test 156 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4715,14 +4715,14 @@ Checking test 156 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 681.530293
-The maximum resident set size (KB)                   = 1259256
+The total amount of wall time                        = 678.700772
+The maximum resident set size (KB)                   = 1260240
 
 Test 156 regional_atmaq PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_atmaq_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_atmaq_debug
 Checking test 157 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4736,14 +4736,14 @@ Checking test 157 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1379.429764
-The maximum resident set size (KB)                   = 1293780
+The total amount of wall time                        = 1357.371598
+The maximum resident set size (KB)                   = 1294444
 
 Test 157 regional_atmaq_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_214821/regional_atmaq_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_135385/regional_atmaq_faster
 Checking test 158 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4759,12 +4759,12 @@ Checking test 158 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 643.440873
-The maximum resident set size (KB)                   = 1256944
+The total amount of wall time                        = 633.025785
+The maximum resident set size (KB)                   = 1257788
 
 Test 158 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 18:06:21 UTC 2023
-Elapsed time: 01h:36m:11s. Have a nice day!
+Mon Apr  3 15:52:38 UTC 2023
+Elapsed time: 01h:41m:02s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,21 +1,21 @@
-Thu Mar 30 11:40:41 MDT 2023
+Sun Apr  2 19:46:04 MDT 2023
 Start Regression test
 
-Compile 001 elapsed time 384 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 399 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 852 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 198 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 377 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1075 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 854 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 851 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 619 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 563 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 359 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 299 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 401 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 857 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 375 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1086 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 855 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 853 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 640 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 568 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 357 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 294 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_c48
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_c48
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_c48
 Checking test 001 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,14 +54,14 @@ Checking test 001 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 818.932811
-0:The maximum resident set size (KB)                   = 679680
+0:The total amount of wall time                        = 821.382548
+0:The maximum resident set size (KB)                   = 679724
 
 Test 001 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_stochy
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_stochy
 Checking test 002 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -72,14 +72,14 @@ Checking test 002 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 177.472515
-0:The maximum resident set size (KB)                   = 443708
+0:The total amount of wall time                        = 177.669428
+0:The maximum resident set size (KB)                   = 443200
 
 Test 002 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_ras
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_ras
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_ras
 Checking test 003 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -90,14 +90,14 @@ Checking test 003 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 294.481336
-0:The maximum resident set size (KB)                   = 452036
+0:The total amount of wall time                        = 293.917961
+0:The maximum resident set size (KB)                   = 452048
 
 Test 003 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_p8
 Checking test 004 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 004 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 310.641262
-0:The maximum resident set size (KB)                   = 1224256
+0:The total amount of wall time                        = 310.597668
+0:The maximum resident set size (KB)                   = 1226276
 
 Test 004 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_control
 Checking test 005 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 005 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 710.740057
-0:The maximum resident set size (KB)                   = 792152
+0:The total amount of wall time                        = 709.949782
+0:The maximum resident set size (KB)                   = 792004
 
 Test 005 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_decomp
 Checking test 006 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -252,14 +252,14 @@ Checking test 006 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 721.136864
-0:The maximum resident set size (KB)                   = 791864
+0:The total amount of wall time                        = 722.076410
+0:The maximum resident set size (KB)                   = 791768
 
 Test 006 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_2threads
 Checking test 007 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -306,14 +306,14 @@ Checking test 007 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 654.142559
-0:The maximum resident set size (KB)                   = 865496
+0:The total amount of wall time                        = 654.455663
+0:The maximum resident set size (KB)                   = 865708
 
 Test 007 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_restart
 Checking test 008 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 355.456006
-0:The maximum resident set size (KB)                   = 539196
+0:The total amount of wall time                        = 355.199421
+0:The maximum resident set size (KB)                   = 540312
 
 Test 008 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_sfcdiff
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_sfcdiff
 Checking test 009 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 714.211449
-0:The maximum resident set size (KB)                   = 792272
+0:The total amount of wall time                        = 710.942566
+0:The maximum resident set size (KB)                   = 792244
 
 Test 009 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_sfcdiff
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_sfcdiff_decomp
 Checking test 010 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -460,14 +460,14 @@ Checking test 010 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 721.946792
-0:The maximum resident set size (KB)                   = 791188
+0:The total amount of wall time                        = 721.850591
+0:The maximum resident set size (KB)                   = 791572
 
 Test 010 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_sfcdiff
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_sfcdiff_restart
 Checking test 011 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 527.290404
-0:The maximum resident set size (KB)                   = 544076
+0:The total amount of wall time                        = 528.358538
+0:The maximum resident set size (KB)                   = 544836
 
 Test 011 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control
 Checking test 012 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 689.408073
-0:The maximum resident set size (KB)                   = 789908
+0:The total amount of wall time                        = 695.328350
+0:The maximum resident set size (KB)                   = 789904
 
 Test 012 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_2threads
 Checking test 013 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -614,14 +614,14 @@ Checking test 013 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 626.108333
-0:The maximum resident set size (KB)                   = 860664
+0:The total amount of wall time                        = 627.235739
+0:The maximum resident set size (KB)                   = 860192
 
 Test 013 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_decomp
 Checking test 014 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -668,14 +668,14 @@ Checking test 014 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 694.020434
-0:The maximum resident set size (KB)                   = 788828
+0:The total amount of wall time                        = 687.659274
+0:The maximum resident set size (KB)                   = 789164
 
 Test 014 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_restart
 Checking test 015 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 509.192789
-0:The maximum resident set size (KB)                   = 540232
+0:The total amount of wall time                        = 512.255889
+0:The maximum resident set size (KB)                   = 540640
 
 Test 015 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_v1beta
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 707.645306
-0:The maximum resident set size (KB)                   = 789128
+0:The total amount of wall time                        = 706.940753
+0:The maximum resident set size (KB)                   = 789160
 
 Test 016 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_smoke_conus13km_hrrr_warm
 Checking test 017 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -784,14 +784,14 @@ Checking test 017 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 231.705240
-0:The maximum resident set size (KB)                   = 636572
+0:The total amount of wall time                        = 230.363787
+0:The maximum resident set size (KB)                   = 636436
 
 Test 017 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 018 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -800,14 +800,14 @@ Checking test 018 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 146.796159
-0:The maximum resident set size (KB)                   = 661076
+0:The total amount of wall time                        = 148.724746
+0:The maximum resident set size (KB)                   = 660668
 
 Test 018 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_conus13km_hrrr_warm
 Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -816,14 +816,14 @@ Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 213.145560
-0:The maximum resident set size (KB)                   = 615148
+0:The total amount of wall time                        = 212.995745
+0:The maximum resident set size (KB)                   = 615860
 
 Test 019 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 020 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -832,234 +832,234 @@ Checking test 020 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 232.542704
-0:The maximum resident set size (KB)                   = 639692
+0:The total amount of wall time                        = 234.453658
+0:The maximum resident set size (KB)                   = 639316
 
 Test 020 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 021 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 110.251654
-0:The maximum resident set size (KB)                   = 596868
+0:The total amount of wall time                        = 110.568057
+0:The maximum resident set size (KB)                   = 596528
 
 Test 021 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_diag_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_diag_debug
 Checking test 022 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 88.735374
-0:The maximum resident set size (KB)                   = 494864
+0:The total amount of wall time                        = 90.103589
+0:The maximum resident set size (KB)                   = 494968
 
 Test 022 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/regional_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/regional_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/regional_debug
 Checking test 023 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 479.520762
-0:The maximum resident set size (KB)                   = 570760
+0:The total amount of wall time                        = 480.342095
+0:The maximum resident set size (KB)                   = 570556
 
 Test 023 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_control_debug
 Checking test 024 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 151.924868
-0:The maximum resident set size (KB)                   = 808552
+0:The total amount of wall time                        = 149.863459
+0:The maximum resident set size (KB)                   = 809304
 
 Test 024 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_debug
 Checking test 025 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.922840
-0:The maximum resident set size (KB)                   = 805400
+0:The total amount of wall time                        = 148.664768
+0:The maximum resident set size (KB)                   = 805496
 
 Test 025 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_diag_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_diag_debug
 Checking test 026 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 158.945983
-0:The maximum resident set size (KB)                   = 891324
+0:The total amount of wall time                        = 158.504441
+0:The maximum resident set size (KB)                   = 891672
 
 Test 026 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 027 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 238.821340
-0:The maximum resident set size (KB)                   = 807276
+0:The total amount of wall time                        = 239.324871
+0:The maximum resident set size (KB)                   = 807360
 
 Test 027 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_progcld_thompson_debug
 Checking test 028 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 150.235395
-0:The maximum resident set size (KB)                   = 808660
+0:The total amount of wall time                        = 150.076881
+0:The maximum resident set size (KB)                   = 809008
 
 Test 028 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_v1beta_debug
 Checking test 029 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 149.530430
-0:The maximum resident set size (KB)                   = 804192
+0:The total amount of wall time                        = 148.748984
+0:The maximum resident set size (KB)                   = 804552
 
 Test 029 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_ras_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_ras_debug
 Checking test 030 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 85.909266
-0:The maximum resident set size (KB)                   = 449252
+0:The total amount of wall time                        = 85.726989
+0:The maximum resident set size (KB)                   = 449164
 
 Test 030 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_stochy_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_stochy_debug
 Checking test 031 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.905845
-0:The maximum resident set size (KB)                   = 441544
+0:The total amount of wall time                        = 93.889590
+0:The maximum resident set size (KB)                   = 441672
 
 Test 031 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_debug_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_debug_p8
 Checking test 032 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 96.512682
-0:The maximum resident set size (KB)                   = 1224120
+0:The total amount of wall time                        = 95.808155
+0:The maximum resident set size (KB)                   = 1224572
 
 Test 032 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 033 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 444.110266
-0:The maximum resident set size (KB)                   = 645028
+0:The total amount of wall time                        = 446.750787
+0:The maximum resident set size (KB)                   = 644708
 
 Test 033 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 034 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 262.640513
-0:The maximum resident set size (KB)                   = 668912
+0:The total amount of wall time                        = 262.334256
+0:The maximum resident set size (KB)                   = 669008
 
 Test 034 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rrfs_conus13km_hrrr_warm_debug
 Checking test 035 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 400.323757
-0:The maximum resident set size (KB)                   = 623496
+0:The total amount of wall time                        = 400.708967
+0:The maximum resident set size (KB)                   = 623644
 
 Test 035 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/control_wam_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 146.150513
-0:The maximum resident set size (KB)                   = 185300
+0:The total amount of wall time                        = 144.827467
+0:The maximum resident set size (KB)                   = 185388
 
 Test 036 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_control_dyn32_phy32
 Checking test 037 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1106,14 +1106,14 @@ Checking test 037 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 704.672868
-0:The maximum resident set size (KB)                   = 673260
+0:The total amount of wall time                        = 702.982134
+0:The maximum resident set size (KB)                   = 672580
 
 Test 037 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_dyn32_phy32
 Checking test 038 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1160,14 +1160,14 @@ Checking test 038 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.745069
-0:The maximum resident set size (KB)                   = 671200
+0:The total amount of wall time                        = 360.976059
+0:The maximum resident set size (KB)                   = 671056
 
 Test 038 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_2threads_dyn32_phy32
 Checking test 039 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1214,14 +1214,14 @@ Checking test 039 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 638.337417
-0:The maximum resident set size (KB)                   = 719960
+0:The total amount of wall time                        = 659.431580
+0:The maximum resident set size (KB)                   = 719260
 
 Test 039 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_2threads_dyn32_phy32
 Checking test 040 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1268,14 +1268,14 @@ Checking test 040 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 318.047926
-0:The maximum resident set size (KB)                   = 717204
+0:The total amount of wall time                        = 320.049603
+0:The maximum resident set size (KB)                   = 717092
 
 Test 040 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_decomp_dyn32_phy32
 Checking test 041 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1322,14 +1322,14 @@ Checking test 041 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.669353
-0:The maximum resident set size (KB)                   = 670384
+0:The total amount of wall time                        = 353.533037
+0:The maximum resident set size (KB)                   = 670452
 
 Test 041 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_restart_dyn32_phy32
 Checking test 042 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1368,14 +1368,14 @@ Checking test 042 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 518.943713
-0:The maximum resident set size (KB)                   = 511336
+0:The total amount of wall time                        = 519.455517
+0:The maximum resident set size (KB)                   = 511656
 
 Test 042 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_restart_dyn32_phy32
 Checking test 043 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1414,14 +1414,14 @@ Checking test 043 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 179.135052
-0:The maximum resident set size (KB)                   = 507484
+0:The total amount of wall time                        = 179.639970
+0:The maximum resident set size (KB)                   = 507544
 
 Test 043 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn64_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_control_dyn64_phy32
 Checking test 044 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1468,56 +1468,56 @@ Checking test 044 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 413.352836
-0:The maximum resident set size (KB)                   = 692720
+0:The total amount of wall time                        = 412.334266
+0:The maximum resident set size (KB)                   = 693888
 
 Test 044 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_control_debug_dyn32_phy32
 Checking test 045 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 149.960472
-0:The maximum resident set size (KB)                   = 691188
+0:The total amount of wall time                        = 149.190540
+0:The maximum resident set size (KB)                   = 690224
 
 Test 045 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/hrrr_control_debug_dyn32_phy32
 Checking test 046 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.279376
-0:The maximum resident set size (KB)                   = 688080
+0:The total amount of wall time                        = 146.525027
+0:The maximum resident set size (KB)                   = 688496
 
 Test 046 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/rap_control_dyn64_phy32_debug
 Checking test 047 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.008488
-0:The maximum resident set size (KB)                   = 710612
+0:The total amount of wall time                        = 153.785256
+0:The maximum resident set size (KB)                   = 711012
 
 Test 047 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/cpld_control_p8
 Checking test 048 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1582,14 +1582,14 @@ Checking test 048 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 498.603226
-0:The maximum resident set size (KB)                   = 3164172
+0:The total amount of wall time                        = 499.171667
+0:The maximum resident set size (KB)                   = 3158748
 
 Test 048 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/cpld_control_nowave_noaero_p8
 Checking test 049 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1651,14 +1651,14 @@ Checking test 049 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 249.743402
-0:The maximum resident set size (KB)                   = 1240204
+0:The total amount of wall time                        = 246.717852
+0:The maximum resident set size (KB)                   = 1240676
 
 Test 049 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/cpld_debug_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/cpld_debug_p8
 Checking test 050 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1711,25 +1711,25 @@ Checking test 050 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 275.756962
-0:The maximum resident set size (KB)                   = 3178504
+0:The total amount of wall time                        = 273.826383
+0:The maximum resident set size (KB)                   = 3177276
 
 Test 050 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_3748/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/GNU/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-gnu/jongkim/FV3_RT/rt_27302/datm_cdeps_control_cfsr
 Checking test 051 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 178.759957
-0:The maximum resident set size (KB)                   = 669460
+0:The total amount of wall time                        = 172.990006
+0:The maximum resident set size (KB)                   = 672380
 
 Test 051 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 12:13:55 MDT 2023
-Elapsed time: 00h:33m:14s. Have a nice day!
+Sun Apr  2 20:23:46 MDT 2023
+Elapsed time: 00h:37m:43s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,42 +1,44 @@
-Thu Mar 30 14:08:45 MDT 2023
+Mon Apr  3 07:55:22 MDT 2023
 Start Regression test
 
-Compile 001 elapsed time 1506 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1525 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1377 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 468 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 409 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1117 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1094 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 1782 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 1075 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 993 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 935 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 800 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1306 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 407 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 277 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 827 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 844 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 275 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 278 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 1129 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 337 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 1574 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 1118 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 425 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 201 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 425 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 105 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 944 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 986 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 907 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 876 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 310 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 033 elapsed time 1031 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Test 008 compile FAIL
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_p8_mixedmode
+Compile 001 elapsed time 1382 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1399 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1361 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 447 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 400 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1071 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1102 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1758 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 1089 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 980 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 925 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 801 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 1303 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 414 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 273 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 841 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 841 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 288 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 281 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 1120 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 347 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 1572 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 1114 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 428 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 201 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 429 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 103 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 948 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 988 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 891 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 871 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 307 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 033 elapsed time 1033 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -101,14 +103,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 320.874772
-0:The maximum resident set size (KB)                   = 2699984
+0:The total amount of wall time                        = 321.018608
+0:The maximum resident set size (KB)                   = 2698364
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_gfsv17
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_gfsv17
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_gfsv17
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -172,33 +174,33 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 282.516362
-0:The maximum resident set size (KB)                   = 1438760
+0:The total amount of wall time                        = 280.756647
+0:The maximum resident set size (KB)                   = 1437628
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -244,21 +246,21 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 322.996332
-0:The maximum resident set size (KB)                   = 2716548
+0:The total amount of wall time                        = 321.783469
+0:The maximum resident set size (KB)                   = 2715024
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -304,33 +306,33 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 187.296031
-0:The maximum resident set size (KB)                   = 2577996
+0:The total amount of wall time                        = 183.899337
+0:The maximum resident set size (KB)                   = 2576596
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
- Comparing sfcf021.tile1.nc ............ALT CHECK......OK
- Comparing sfcf021.tile2.nc ............ALT CHECK......OK
- Comparing sfcf021.tile3.nc ............ALT CHECK......OK
- Comparing sfcf021.tile4.nc ............ALT CHECK......OK
- Comparing sfcf021.tile5.nc ............ALT CHECK......OK
- Comparing sfcf021.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
  Comparing atmf021.tile1.nc .........OK
  Comparing atmf021.tile2.nc .........OK
  Comparing atmf021.tile3.nc .........OK
  Comparing atmf021.tile4.nc .........OK
  Comparing atmf021.tile5.nc .........OK
  Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -376,21 +378,21 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 329.465301
-0:The maximum resident set size (KB)                   = 2721044
+0:The total amount of wall time                        = 324.347370
+0:The maximum resident set size (KB)                   = 2719464
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_restart_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -436,21 +438,21 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 203.808624
-0:The maximum resident set size (KB)                   = 2594696
+0:The total amount of wall time                        = 191.105457
+0:The maximum resident set size (KB)                   = 2593760
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -496,21 +498,21 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 254.427509
-0:The maximum resident set size (KB)                   = 3177776
+0:The total amount of wall time                        = 251.194233
+0:The maximum resident set size (KB)                   = 3177724
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -556,21 +558,21 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 314.092757
-0:The maximum resident set size (KB)                   = 2721724
+0:The total amount of wall time                        = 321.628724
+0:The maximum resident set size (KB)                   = 2720412
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_mpi_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -616,14 +618,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 277.838630
-0:The maximum resident set size (KB)                   = 2681612
+0:The total amount of wall time                        = 275.773539
+0:The maximum resident set size (KB)                   = 2680568
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_ciceC_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_ciceC_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_ciceC_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -688,21 +690,21 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 323.252828
-0:The maximum resident set size (KB)                   = 2716880
+0:The total amount of wall time                        = 320.727504
+0:The maximum resident set size (KB)                   = 2715172
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -748,21 +750,21 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 632.857578
-0:The maximum resident set size (KB)                   = 3351948
+0:The total amount of wall time                        = 626.605472
+0:The maximum resident set size (KB)                   = 3350840
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_restart_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
- Comparing sfcf030.tile1.nc ............ALT CHECK......OK
- Comparing sfcf030.tile2.nc ............ALT CHECK......OK
- Comparing sfcf030.tile3.nc ............ALT CHECK......OK
- Comparing sfcf030.tile4.nc ............ALT CHECK......OK
- Comparing sfcf030.tile5.nc ............ALT CHECK......OK
- Comparing sfcf030.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf030.tile1.nc .........OK
+ Comparing sfcf030.tile2.nc .........OK
+ Comparing sfcf030.tile3.nc .........OK
+ Comparing sfcf030.tile4.nc .........OK
+ Comparing sfcf030.tile5.nc .........OK
+ Comparing sfcf030.tile6.nc .........OK
  Comparing atmf030.tile1.nc .........OK
  Comparing atmf030.tile2.nc .........OK
  Comparing atmf030.tile3.nc .........OK
@@ -808,14 +810,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 392.401011
-0:The maximum resident set size (KB)                   = 3276796
+0:The total amount of wall time                        = 380.835301
+0:The maximum resident set size (KB)                   = 3275932
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -879,14 +881,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 295.533673
-0:The maximum resident set size (KB)                   = 1436912
+0:The total amount of wall time                        = 292.658879
+0:The maximum resident set size (KB)                   = 1436276
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -948,14 +950,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 196.511646
-0:The maximum resident set size (KB)                   = 1453328
+0:The total amount of wall time                        = 193.519543
+0:The maximum resident set size (KB)                   = 1453144
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1008,14 +1010,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 474.086141
-0:The maximum resident set size (KB)                   = 2787784
+0:The total amount of wall time                        = 473.669252
+0:The maximum resident set size (KB)                   = 2786240
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_noaero_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_debug_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_noaero_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1067,14 +1069,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 349.061686
-0:The maximum resident set size (KB)                   = 1461552
+0:The total amount of wall time                        = 348.270260
+0:The maximum resident set size (KB)                   = 1460536
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_noaero_p8_agrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1136,21 +1138,21 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 255.699194
-0:The maximum resident set size (KB)                   = 1456892
+0:The total amount of wall time                        = 253.826707
+0:The maximum resident set size (KB)                   = 1456872
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
- Comparing sfcf024.tile1.nc ............ALT CHECK......OK
- Comparing sfcf024.tile2.nc ............ALT CHECK......OK
- Comparing sfcf024.tile3.nc ............ALT CHECK......OK
- Comparing sfcf024.tile4.nc ............ALT CHECK......OK
- Comparing sfcf024.tile5.nc ............ALT CHECK......OK
- Comparing sfcf024.tile6.nc ............ALT CHECK......OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
  Comparing atmf024.tile1.nc .........OK
  Comparing atmf024.tile2.nc .........OK
  Comparing atmf024.tile3.nc .........OK
@@ -1193,14 +1195,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 606.982728
-0:The maximum resident set size (KB)                   = 2586064
+0:The total amount of wall time                        = 606.540948
+0:The maximum resident set size (KB)                   = 2586656
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_warmstart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1250,14 +1252,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 164.261557
-0:The maximum resident set size (KB)                   = 2601616
+0:The total amount of wall time                        = 163.878597
+0:The maximum resident set size (KB)                   = 2601644
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/cpld_restart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1307,14 +1309,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 84.597038
-0:The maximum resident set size (KB)                   = 2018844
+0:The total amount of wall time                        = 84.981085
+0:The maximum resident set size (KB)                   = 2018956
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_CubedSphereGrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1341,28 +1343,28 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.611586
-0:The maximum resident set size (KB)                   = 454256
+0:The total amount of wall time                        = 143.193448
+0:The maximum resident set size (KB)                   = 454272
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_parallel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_CubedSphereGrid_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_parallel
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_CubedSphereGrid_parallel
 Checking test 022 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 137.084478
-0:The maximum resident set size (KB)                   = 454240
+0:The total amount of wall time                        = 138.360679
+0:The maximum resident set size (KB)                   = 454196
 
 Test 022 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_latlon
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1373,32 +1375,32 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.903803
-0:The maximum resident set size (KB)                   = 454304
+0:The total amount of wall time                        = 146.285185
+0:The maximum resident set size (KB)                   = 454400
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 149.945775
-0:The maximum resident set size (KB)                   = 454408
+0:The total amount of wall time                        = 152.131459
+0:The maximum resident set size (KB)                   = 454592
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1437,14 +1439,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 442.990812
-0:The maximum resident set size (KB)                   = 633528
+0:The total amount of wall time                        = 444.111808
+0:The maximum resident set size (KB)                   = 633524
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_c192
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1455,14 +1457,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 598.721090
-0:The maximum resident set size (KB)                   = 560360
+0:The total amount of wall time                        = 596.775844
+0:The maximum resident set size (KB)                   = 560340
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_c384
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1473,14 +1475,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 588.149210
-0:The maximum resident set size (KB)                   = 899540
+0:The total amount of wall time                        = 590.340444
+0:The maximum resident set size (KB)                   = 899408
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_c384gdas
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1523,14 +1525,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 509.590494
-0:The maximum resident set size (KB)                   = 1026968
+0:The total amount of wall time                        = 516.149382
+0:The maximum resident set size (KB)                   = 1026800
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1541,28 +1543,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 98.223240
-0:The maximum resident set size (KB)                   = 459220
+0:The total amount of wall time                        = 97.811063
+0:The maximum resident set size (KB)                   = 459132
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_stochy_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 52.905909
-0:The maximum resident set size (KB)                   = 226536
+0:The total amount of wall time                        = 52.757201
+0:The maximum resident set size (KB)                   = 226520
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1573,14 +1575,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 91.361108
-0:The maximum resident set size (KB)                   = 458220
+0:The total amount of wall time                        = 89.953334
+0:The maximum resident set size (KB)                   = 458212
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_iovr4
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1595,14 +1597,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.139340
-0:The maximum resident set size (KB)                   = 454232
+0:The total amount of wall time                        = 149.147166
+0:The maximum resident set size (KB)                   = 454780
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_iovr5
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1617,14 +1619,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 149.097879
-0:The maximum resident set size (KB)                   = 454252
+0:The total amount of wall time                        = 148.323931
+0:The maximum resident set size (KB)                   = 454268
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1671,14 +1673,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 176.252630
-0:The maximum resident set size (KB)                   = 1423892
+0:The total amount of wall time                        = 177.196329
+0:The maximum resident set size (KB)                   = 1423876
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1717,14 +1719,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 93.674833
-0:The maximum resident set size (KB)                   = 582884
+0:The total amount of wall time                        = 95.915221
+0:The maximum resident set size (KB)                   = 582856
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_qr_p8
 Checking test 036 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1771,14 +1773,14 @@ Checking test 036 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 182.384199
-0:The maximum resident set size (KB)                   = 1427264
+0:The total amount of wall time                        = 183.290583
+0:The maximum resident set size (KB)                   = 1427252
 
 Test 036 control_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_restart_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_restart_qr_p8
 Checking test 037 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1817,14 +1819,14 @@ Checking test 037 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 98.815129
-0:The maximum resident set size (KB)                   = 596808
+0:The total amount of wall time                        = 98.786564
+0:The maximum resident set size (KB)                   = 596884
 
 Test 037 control_restart_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_decomp_p8
 Checking test 038 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1867,14 +1869,14 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 187.112863
-0:The maximum resident set size (KB)                   = 1418420
+0:The total amount of wall time                        = 186.665266
+0:The maximum resident set size (KB)                   = 1418400
 
 Test 038 control_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_2threads_p8
 Checking test 039 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1917,14 +1919,14 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 166.797801
-0:The maximum resident set size (KB)                   = 1508660
+0:The total amount of wall time                        = 170.215495
+0:The maximum resident set size (KB)                   = 1509068
 
 Test 039 control_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_p8_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_p8_lndp
 Checking test 040 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1943,14 +1945,14 @@ Checking test 040 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 337.275015
-0:The maximum resident set size (KB)                   = 1424940
+0:The total amount of wall time                        = 334.123175
+0:The maximum resident set size (KB)                   = 1424944
 
 Test 040 control_p8_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_p8_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_p8_rrtmgp
 Checking test 041 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1997,14 +1999,14 @@ Checking test 041 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 255.053618
-0:The maximum resident set size (KB)                   = 1480244
+0:The total amount of wall time                        = 245.252211
+0:The maximum resident set size (KB)                   = 1480228
 
 Test 041 control_p8_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_p8_mynn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_p8_mynn
 Checking test 042 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2051,14 +2053,14 @@ Checking test 042 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 187.447201
-0:The maximum resident set size (KB)                   = 1427928
+0:The total amount of wall time                        = 185.220956
+0:The maximum resident set size (KB)                   = 1427892
 
 Test 042 control_p8_mynn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/merra2_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/merra2_thompson
 Checking test 043 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2105,14 +2107,14 @@ Checking test 043 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 206.770023
-0:The maximum resident set size (KB)                   = 1429664
+0:The total amount of wall time                        = 209.021884
+0:The maximum resident set size (KB)                   = 1429712
 
 Test 043 merra2_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_control
 Checking test 044 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2123,28 +2125,28 @@ Checking test 044 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 342.752075
-0:The maximum resident set size (KB)                   = 604832
+0:The total amount of wall time                        = 342.522505
+0:The maximum resident set size (KB)                   = 604760
 
 Test 044 regional_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_restart
 Checking test 045 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 175.711329
-0:The maximum resident set size (KB)                   = 594192
+0:The total amount of wall time                        = 174.575884
+0:The maximum resident set size (KB)                   = 594208
 
 Test 045 regional_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_control_qr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_control_qr
 Checking test 046 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2155,28 +2157,28 @@ Checking test 046 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 329.436049
-0:The maximum resident set size (KB)                   = 604836
+0:The total amount of wall time                        = 349.583600
+0:The maximum resident set size (KB)                   = 604804
 
 Test 046 regional_control_qr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_restart_qr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_restart_qr
 Checking test 047 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 173.629667
-0:The maximum resident set size (KB)                   = 594148
+0:The total amount of wall time                        = 175.192567
+0:The maximum resident set size (KB)                   = 594100
 
 Test 047 regional_restart_qr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_decomp
 Checking test 048 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2187,14 +2189,14 @@ Checking test 048 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 349.749635
-0:The maximum resident set size (KB)                   = 598184
+0:The total amount of wall time                        = 359.757054
+0:The maximum resident set size (KB)                   = 598180
 
 Test 048 regional_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_2threads
 Checking test 049 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2205,14 +2207,14 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 203.247846
-0:The maximum resident set size (KB)                   = 611512
+0:The total amount of wall time                        = 202.951735
+0:The maximum resident set size (KB)                   = 611416
 
 Test 049 regional_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_noquilt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_noquilt
 Checking test 050 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2220,28 +2222,28 @@ Checking test 050 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 365.303939
-0:The maximum resident set size (KB)                   = 599616
+0:The total amount of wall time                        = 364.619542
+0:The maximum resident set size (KB)                   = 599088
 
 Test 050 regional_noquilt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_netcdf_parallel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_netcdf_parallel
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_netcdf_parallel
 Checking test 051 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf006.nc .........OK
+ Comparing phyf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 326.385068
-0:The maximum resident set size (KB)                   = 596692
+0:The total amount of wall time                        = 327.188584
+0:The maximum resident set size (KB)                   = 597264
 
 Test 051 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_2dwrtdecomp
 Checking test 052 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2252,14 +2254,14 @@ Checking test 052 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 340.669174
-0:The maximum resident set size (KB)                   = 604820
+0:The total amount of wall time                        = 341.211799
+0:The maximum resident set size (KB)                   = 604832
 
 Test 052 regional_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_wofs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/fv3_regional_wofs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_wofs
 Checking test 053 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2270,14 +2272,14 @@ Checking test 053 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 426.878328
-0:The maximum resident set size (KB)                   = 275888
+0:The total amount of wall time                        = 435.316594
+0:The maximum resident set size (KB)                   = 275808
 
 Test 053 regional_wofs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_control
 Checking test 054 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2324,14 +2326,14 @@ Checking test 054 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 481.311218
-0:The maximum resident set size (KB)                   = 823460
+0:The total amount of wall time                        = 480.072617
+0:The maximum resident set size (KB)                   = 823544
 
 Test 054 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_spp_sppt_shum_skeb
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_spp_sppt_shum_skeb
 Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2342,14 +2344,14 @@ Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 262.045254
-0:The maximum resident set size (KB)                   = 952328
+0:The total amount of wall time                        = 260.060739
+0:The maximum resident set size (KB)                   = 952032
 
 Test 055 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_decomp
 Checking test 056 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2396,14 +2398,14 @@ Checking test 056 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 512.380863
-0:The maximum resident set size (KB)                   = 822412
+0:The total amount of wall time                        = 496.448497
+0:The maximum resident set size (KB)                   = 822316
 
 Test 056 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_2threads
 Checking test 057 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2450,14 +2452,14 @@ Checking test 057 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 458.743033
-0:The maximum resident set size (KB)                   = 893500
+0:The total amount of wall time                        = 454.844511
+0:The maximum resident set size (KB)                   = 894048
 
 Test 057 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_restart
 Checking test 058 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2496,14 +2498,14 @@ Checking test 058 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 241.882247
-0:The maximum resident set size (KB)                   = 571200
+0:The total amount of wall time                        = 243.492165
+0:The maximum resident set size (KB)                   = 571648
 
 Test 058 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_sfcdiff
 Checking test 059 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2550,14 +2552,14 @@ Checking test 059 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 481.975954
-0:The maximum resident set size (KB)                   = 823372
+0:The total amount of wall time                        = 483.665131
+0:The maximum resident set size (KB)                   = 823668
 
 Test 059 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_sfcdiff_decomp
 Checking test 060 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2604,14 +2606,14 @@ Checking test 060 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 505.330190
-0:The maximum resident set size (KB)                   = 822252
+0:The total amount of wall time                        = 502.713340
+0:The maximum resident set size (KB)                   = 822316
 
 Test 060 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_sfcdiff_restart
 Checking test 061 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2650,14 +2652,14 @@ Checking test 061 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.443574
-0:The maximum resident set size (KB)                   = 570788
+0:The total amount of wall time                        = 354.493648
+0:The maximum resident set size (KB)                   = 570772
 
 Test 061 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control
 Checking test 062 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2704,14 +2706,14 @@ Checking test 062 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 461.637244
-0:The maximum resident set size (KB)                   = 820708
+0:The total amount of wall time                        = 466.559897
+0:The maximum resident set size (KB)                   = 820736
 
 Test 062 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_decomp
 Checking test 063 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2758,14 +2760,14 @@ Checking test 063 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 483.207990
-0:The maximum resident set size (KB)                   = 820652
+0:The total amount of wall time                        = 482.175955
+0:The maximum resident set size (KB)                   = 820708
 
 Test 063 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_2threads
 Checking test 064 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2812,14 +2814,14 @@ Checking test 064 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 438.631980
-0:The maximum resident set size (KB)                   = 888376
+0:The total amount of wall time                        = 441.212743
+0:The maximum resident set size (KB)                   = 888420
 
 Test 064 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_restart
 Checking test 065 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2858,14 +2860,14 @@ Checking test 065 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 342.544075
-0:The maximum resident set size (KB)                   = 566324
+0:The total amount of wall time                        = 341.711004
+0:The maximum resident set size (KB)                   = 566612
 
 Test 065 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_v1beta
 Checking test 066 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2912,14 +2914,14 @@ Checking test 066 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 478.578537
-0:The maximum resident set size (KB)                   = 819332
+0:The total amount of wall time                        = 467.017236
+0:The maximum resident set size (KB)                   = 820060
 
 Test 066 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_v1nssl
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_v1nssl
 Checking test 067 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2934,14 +2936,14 @@ Checking test 067 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 586.365531
-0:The maximum resident set size (KB)                   = 508784
+0:The total amount of wall time                        = 574.350129
+0:The maximum resident set size (KB)                   = 509320
 
 Test 067 rrfs_v1nssl PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_v1nssl_nohailnoccn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_v1nssl_nohailnoccn
 Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2956,14 +2958,14 @@ Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 566.201075
-0:The maximum resident set size (KB)                   = 502500
+0:The total amount of wall time                        = 557.657843
+0:The maximum resident set size (KB)                   = 502612
 
 Test 068 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_smoke_conus13km_hrrr_warm
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2972,14 +2974,14 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 153.276340
-0:The maximum resident set size (KB)                   = 675352
+0:The total amount of wall time                        = 151.611495
+0:The maximum resident set size (KB)                   = 675328
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2988,14 +2990,14 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 94.117393
-0:The maximum resident set size (KB)                   = 693992
+0:The total amount of wall time                        = 92.381950
+0:The maximum resident set size (KB)                   = 694576
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_conus13km_hrrr_warm
 Checking test 071 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3004,14 +3006,14 @@ Checking test 071 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 137.445112
-0:The maximum resident set size (KB)                   = 654084
+0:The total amount of wall time                        = 136.420492
+0:The maximum resident set size (KB)                   = 654108
 
 Test 071 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 072 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3020,26 +3022,26 @@ Checking test 072 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 154.116878
-0:The maximum resident set size (KB)                   = 677936
+0:The total amount of wall time                        = 152.880461
+0:The maximum resident set size (KB)                   = 677976
 
 Test 072 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 073 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 70.683122
-0:The maximum resident set size (KB)                   = 632208
+0:The total amount of wall time                        = 70.747897
+0:The maximum resident set size (KB)                   = 632268
 
 Test 073 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_csawmg
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_csawmg
 Checking test 074 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3050,14 +3052,14 @@ Checking test 074 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 397.852152
-0:The maximum resident set size (KB)                   = 527728
+0:The total amount of wall time                        = 398.188737
+0:The maximum resident set size (KB)                   = 527724
 
 Test 074 control_csawmg PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_csawmgt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_csawmgt
 Checking test 075 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3068,14 +3070,14 @@ Checking test 075 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 394.392928
-0:The maximum resident set size (KB)                   = 528340
+0:The total amount of wall time                        = 394.556936
+0:The maximum resident set size (KB)                   = 528352
 
 Test 075 control_csawmgt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_ras
 Checking test 076 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3086,26 +3088,26 @@ Checking test 076 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 206.650179
-0:The maximum resident set size (KB)                   = 491376
+0:The total amount of wall time                        = 204.961793
+0:The maximum resident set size (KB)                   = 491224
 
 Test 076 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_wam
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_wam
 Checking test 077 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 128.151365
-0:The maximum resident set size (KB)                   = 206584
+0:The total amount of wall time                        = 129.370662
+0:The maximum resident set size (KB)                   = 206484
 
 Test 077 control_wam PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_p8_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_p8_faster
 Checking test 078 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3152,14 +3154,14 @@ Checking test 078 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 172.660276
-0:The maximum resident set size (KB)                   = 1423832
+0:The total amount of wall time                        = 173.987495
+0:The maximum resident set size (KB)                   = 1423824
 
 Test 078 control_p8_faster PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_control_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_control_faster
 Checking test 079 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3170,56 +3172,56 @@ Checking test 079 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 320.645621
-0:The maximum resident set size (KB)                   = 604580
+0:The total amount of wall time                        = 326.610025
+0:The maximum resident set size (KB)                   = 604612
 
 Test 079 regional_control_faster PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 897.167620
-0:The maximum resident set size (KB)                   = 709708
+0:The total amount of wall time                        = 897.724326
+0:The maximum resident set size (KB)                   = 709660
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 515.894294
-0:The maximum resident set size (KB)                   = 729904
+0:The total amount of wall time                        = 518.178929
+0:The maximum resident set size (KB)                   = 729476
 
 Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_conus13km_hrrr_warm_debug
 Checking test 082 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 794.223399
-0:The maximum resident set size (KB)                   = 688340
+0:The total amount of wall time                        = 797.233909
+0:The maximum resident set size (KB)                   = 688296
 
 Test 082 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_CubedSphereGrid_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_CubedSphereGrid_debug
 Checking test 083 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3246,334 +3248,334 @@ Checking test 083 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 175.575745
-0:The maximum resident set size (KB)                   = 622420
+0:The total amount of wall time                        = 176.219711
+0:The maximum resident set size (KB)                   = 623116
 
 Test 083 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_wrtGauss_netcdf_parallel_debug
 Checking test 084 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.776366
-0:The maximum resident set size (KB)                   = 620580
+0:The total amount of wall time                        = 163.232020
+0:The maximum resident set size (KB)                   = 620592
 
 Test 084 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_stochy_debug
 Checking test 085 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 184.208215
-0:The maximum resident set size (KB)                   = 626116
+0:The total amount of wall time                        = 184.751016
+0:The maximum resident set size (KB)                   = 626144
 
 Test 085 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_lndp_debug
 Checking test 086 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 166.571663
-0:The maximum resident set size (KB)                   = 624908
+0:The total amount of wall time                        = 165.481248
+0:The maximum resident set size (KB)                   = 624896
 
 Test 086 control_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_csawmg_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_csawmg_debug
 Checking test 087 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 256.226856
-0:The maximum resident set size (KB)                   = 671332
+0:The total amount of wall time                        = 259.709204
+0:The maximum resident set size (KB)                   = 671428
 
 Test 087 control_csawmg_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_csawmgt_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_csawmgt_debug
 Checking test 088 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 256.858167
-0:The maximum resident set size (KB)                   = 672304
+0:The total amount of wall time                        = 257.286572
+0:The maximum resident set size (KB)                   = 672372
 
 Test 088 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_ras_debug
 Checking test 089 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 169.775245
-0:The maximum resident set size (KB)                   = 635240
+0:The total amount of wall time                        = 172.746553
+0:The maximum resident set size (KB)                   = 635208
 
 Test 089 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_diag_debug
 Checking test 090 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 169.924275
-0:The maximum resident set size (KB)                   = 679892
+0:The total amount of wall time                        = 174.285989
+0:The maximum resident set size (KB)                   = 680288
 
 Test 090 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_debug_p8
 Checking test 091 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 186.502892
-0:The maximum resident set size (KB)                   = 1447324
+0:The total amount of wall time                        = 184.474068
+0:The maximum resident set size (KB)                   = 1447360
 
 Test 091 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_debug
 Checking test 092 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 1041.962871
-0:The maximum resident set size (KB)                   = 630784
+0:The total amount of wall time                        = 1046.393608
+0:The maximum resident set size (KB)                   = 630816
 
 Test 092 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_control_debug
 Checking test 093 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 296.341676
-0:The maximum resident set size (KB)                   = 991636
+0:The total amount of wall time                        = 301.691945
+0:The maximum resident set size (KB)                   = 991820
 
 Test 093 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_debug
 Checking test 094 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.774992
-0:The maximum resident set size (KB)                   = 989164
+0:The total amount of wall time                        = 293.731134
+0:The maximum resident set size (KB)                   = 989104
 
 Test 094 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_unified_drag_suite_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_unified_drag_suite_debug
 Checking test 095 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 296.601471
-0:The maximum resident set size (KB)                   = 991640
+0:The total amount of wall time                        = 300.073565
+0:The maximum resident set size (KB)                   = 991768
 
 Test 095 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_diag_debug
 Checking test 096 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 309.276283
-0:The maximum resident set size (KB)                   = 1074836
+0:The total amount of wall time                        = 309.656294
+0:The maximum resident set size (KB)                   = 1075096
 
 Test 096 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_cires_ugwp_debug
 Checking test 097 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 302.908003
-0:The maximum resident set size (KB)                   = 990864
+0:The total amount of wall time                        = 301.233647
+0:The maximum resident set size (KB)                   = 991112
 
 Test 097 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_unified_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_unified_ugwp_debug
 Checking test 098 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 302.996190
-0:The maximum resident set size (KB)                   = 991768
+0:The total amount of wall time                        = 308.342979
+0:The maximum resident set size (KB)                   = 992592
 
 Test 098 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_lndp_debug
 Checking test 099 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 299.319337
-0:The maximum resident set size (KB)                   = 993464
+0:The total amount of wall time                        = 298.152165
+0:The maximum resident set size (KB)                   = 992548
 
 Test 099 rap_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_flake_debug
 Checking test 100 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 297.925837
-0:The maximum resident set size (KB)                   = 991816
+0:The total amount of wall time                        = 297.616574
+0:The maximum resident set size (KB)                   = 991720
 
 Test 100 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_progcld_thompson_debug
 Checking test 101 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 296.868179
-0:The maximum resident set size (KB)                   = 991828
+0:The total amount of wall time                        = 296.728556
+0:The maximum resident set size (KB)                   = 991692
 
 Test 101 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_noah_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_noah_debug
 Checking test 102 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 290.613834
-0:The maximum resident set size (KB)                   = 989488
+0:The total amount of wall time                        = 289.942507
+0:The maximum resident set size (KB)                   = 989540
 
 Test 102 rap_noah_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_sfcdiff_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_sfcdiff_debug
 Checking test 103 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 296.912919
-0:The maximum resident set size (KB)                   = 991380
+0:The total amount of wall time                        = 296.789694
+0:The maximum resident set size (KB)                   = 991492
 
 Test 103 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 482.678258
-0:The maximum resident set size (KB)                   = 990212
+0:The total amount of wall time                        = 487.237012
+0:The maximum resident set size (KB)                   = 990336
 
 Test 104 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rrfs_v1beta_debug
 Checking test 105 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.308836
-0:The maximum resident set size (KB)                   = 988432
+0:The total amount of wall time                        = 293.577667
+0:The maximum resident set size (KB)                   = 988424
 
 Test 105 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_wam_debug
 Checking test 106 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 307.797056
-0:The maximum resident set size (KB)                   = 240088
+0:The total amount of wall time                        = 296.745280
+0:The maximum resident set size (KB)                   = 240332
 
 Test 106 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3584,14 +3586,14 @@ Checking test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 242.246597
-0:The maximum resident set size (KB)                   = 851168
+0:The total amount of wall time                        = 246.276073
+0:The maximum resident set size (KB)                   = 851052
 
 Test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_control_dyn32_phy32
 Checking test 108 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3638,14 +3640,14 @@ Checking test 108 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 402.192335
-0:The maximum resident set size (KB)                   = 707880
+0:The total amount of wall time                        = 394.618756
+0:The maximum resident set size (KB)                   = 707760
 
 Test 108 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_dyn32_phy32
 Checking test 109 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3692,14 +3694,14 @@ Checking test 109 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 208.936609
-0:The maximum resident set size (KB)                   = 706524
+0:The total amount of wall time                        = 204.666811
+0:The maximum resident set size (KB)                   = 706420
 
 Test 109 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_2threads_dyn32_phy32
 Checking test 110 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3746,14 +3748,14 @@ Checking test 110 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 382.924346
-0:The maximum resident set size (KB)                   = 759440
+0:The total amount of wall time                        = 383.963679
+0:The maximum resident set size (KB)                   = 759496
 
 Test 110 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_2threads_dyn32_phy32
 Checking test 111 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3800,14 +3802,14 @@ Checking test 111 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 196.252523
-0:The maximum resident set size (KB)                   = 752640
+0:The total amount of wall time                        = 198.736870
+0:The maximum resident set size (KB)                   = 756904
 
 Test 111 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_decomp_dyn32_phy32
 Checking test 112 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3854,14 +3856,14 @@ Checking test 112 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 220.385903
-0:The maximum resident set size (KB)                   = 704404
+0:The total amount of wall time                        = 221.546232
+0:The maximum resident set size (KB)                   = 704412
 
 Test 112 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_restart_dyn32_phy32
 Checking test 113 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3900,14 +3902,14 @@ Checking test 113 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 294.042315
-0:The maximum resident set size (KB)                   = 544576
+0:The total amount of wall time                        = 294.097855
+0:The maximum resident set size (KB)                   = 544468
 
 Test 113 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_restart_dyn32_phy32
 Checking test 114 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3946,14 +3948,14 @@ Checking test 114 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 108.834169
-0:The maximum resident set size (KB)                   = 537492
+0:The total amount of wall time                        = 107.580176
+0:The maximum resident set size (KB)                   = 537560
 
 Test 114 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_control_dyn64_phy32
 Checking test 115 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4000,81 +4002,81 @@ Checking test 115 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 272.251136
-0:The maximum resident set size (KB)                   = 730516
+0:The total amount of wall time                        = 272.444827
+0:The maximum resident set size (KB)                   = 730496
 
 Test 115 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_control_debug_dyn32_phy32
 Checking test 116 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.440812
-0:The maximum resident set size (KB)                   = 877808
+0:The total amount of wall time                        = 295.897807
+0:The maximum resident set size (KB)                   = 878144
 
 Test 116 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hrrr_control_debug_dyn32_phy32
 Checking test 117 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.442616
-0:The maximum resident set size (KB)                   = 875864
+0:The total amount of wall time                        = 291.526902
+0:The maximum resident set size (KB)                   = 875956
 
 Test 117 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/rap_control_dyn64_phy32_debug
 Checking test 118 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 296.310465
-0:The maximum resident set size (KB)                   = 894920
+0:The total amount of wall time                        = 299.472788
+0:The maximum resident set size (KB)                   = 895000
 
 Test 118 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_atm
 Checking test 119 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 259.111922
-0:The maximum resident set size (KB)                   = 743084
+0:The total amount of wall time                        = 260.559560
+0:The maximum resident set size (KB)                   = 742252
 
 Test 119 hafs_regional_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_atm_thompson_gfdlsf
 Checking test 120 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 289.408352
-0:The maximum resident set size (KB)                   = 1099856
+0:The total amount of wall time                        = 295.025206
+0:The maximum resident set size (KB)                   = 1100012
 
 Test 120 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_atm_ocn
 Checking test 121 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4083,30 +4085,30 @@ Checking test 121 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 454.748565
-0:The maximum resident set size (KB)                   = 740984
+0:The total amount of wall time                        = 455.192770
+0:The maximum resident set size (KB)                   = 740944
 
 Test 121 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_atm_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_atm_wav
 Checking test 122 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1048.642507
-0:The maximum resident set size (KB)                   = 769952
+0:The total amount of wall time                        = 1063.511316
+0:The maximum resident set size (KB)                   = 768960
 
 Test 122 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_atm_ocn_wav
 Checking test 123 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4114,31 +4116,31 @@ Checking test 123 hafs_regional_atm_ocn_wav results ....
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1155.858452
-0:The maximum resident set size (KB)                   = 792576
+0:The total amount of wall time                        = 1094.683601
+0:The maximum resident set size (KB)                   = 793104
 
 Test 123 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_1nest_atm
 Checking test 124 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 375.791173
-0:The maximum resident set size (KB)                   = 300452
+0:The total amount of wall time                        = 374.587788
+0:The maximum resident set size (KB)                   = 300736
 
 Test 124 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_telescopic_2nests_atm
 Checking test 125 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4147,28 +4149,28 @@ Checking test 125 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 430.392690
-0:The maximum resident set size (KB)                   = 319900
+0:The total amount of wall time                        = 428.124458
+0:The maximum resident set size (KB)                   = 320264
 
 Test 125 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_global_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_global_1nest_atm
 Checking test 126 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 171.544391
-0:The maximum resident set size (KB)                   = 213572
+0:The total amount of wall time                        = 171.932162
+0:The maximum resident set size (KB)                   = 214180
 
 Test 126 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_global_multiple_4nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_global_multiple_4nests_atm
 Checking test 127 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4186,14 +4188,14 @@ Checking test 127 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-0:The total amount of wall time                        = 500.696745
-0:The maximum resident set size (KB)                   = 302608
+0:The total amount of wall time                        = 484.892247
+0:The maximum resident set size (KB)                   = 300240
 
 Test 127 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_specified_moving_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_specified_moving_1nest_atm
 Checking test 128 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4202,28 +4204,28 @@ Checking test 128 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 240.268649
-0:The maximum resident set size (KB)                   = 318204
+0:The total amount of wall time                        = 240.751910
+0:The maximum resident set size (KB)                   = 317936
 
 Test 128 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_storm_following_1nest_atm
 Checking test 129 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 228.172950
-0:The maximum resident set size (KB)                   = 318548
+0:The total amount of wall time                        = 227.430924
+0:The maximum resident set size (KB)                   = 318400
 
 Test 129 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 130 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4232,42 +4234,42 @@ Checking test 130 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 282.453055
-0:The maximum resident set size (KB)                   = 376224
+0:The total amount of wall time                        = 279.903777
+0:The maximum resident set size (KB)                   = 376124
 
 Test 130 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_global_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_global_storm_following_1nest_atm
 Checking test 131 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 68.943271
-0:The maximum resident set size (KB)                   = 233264
+0:The total amount of wall time                        = 67.125011
+0:The maximum resident set size (KB)                   = 233296
 
 Test 131 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-0:The total amount of wall time                        = 822.999725
-0:The maximum resident set size (KB)                   = 409468
+0:The total amount of wall time                        = 826.567695
+0:The maximum resident set size (KB)                   = 409072
 
 Test 132 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 133 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4278,14 +4280,14 @@ Checking test 133 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 704.297067
-0:The maximum resident set size (KB)                   = 427004
+0:The total amount of wall time                        = 716.790689
+0:The maximum resident set size (KB)                   = 426600
 
 Test 133 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_docn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_docn
 Checking test 134 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4293,14 +4295,14 @@ Checking test 134 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 391.952463
-0:The maximum resident set size (KB)                   = 755604
+0:The total amount of wall time                        = 378.353398
+0:The maximum resident set size (KB)                   = 755540
 
 Test 134 hafs_regional_docn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_docn_oisst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_docn_oisst
 Checking test 135 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4308,131 +4310,131 @@ Checking test 135 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 380.146394
-0:The maximum resident set size (KB)                   = 735040
+0:The total amount of wall time                        = 392.773487
+0:The maximum resident set size (KB)                   = 735224
 
 Test 135 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/hafs_regional_datm_cdeps
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/hafs_regional_datm_cdeps
 Checking test 136 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1276.161233
-0:The maximum resident set size (KB)                   = 887840
+0:The total amount of wall time                        = 1160.652538
+0:The maximum resident set size (KB)                   = 887248
 
 Test 136 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_control_cfsr
 Checking test 137 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.766498
-0:The maximum resident set size (KB)                   = 716680
+0:The total amount of wall time                        = 167.960899
+0:The maximum resident set size (KB)                   = 727708
 
 Test 137 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_restart_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_restart_cfsr
 Checking test 138 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 100.898869
-0:The maximum resident set size (KB)                   = 716224
+0:The total amount of wall time                        = 100.923811
+0:The maximum resident set size (KB)                   = 715936
 
 Test 138 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_control_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_control_gefs
 Checking test 139 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 155.670076
-0:The maximum resident set size (KB)                   = 607484
+0:The total amount of wall time                        = 160.846763
+0:The maximum resident set size (KB)                   = 607508
 
 Test 139 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_iau_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_iau_gefs
 Checking test 140 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 164.454290
-0:The maximum resident set size (KB)                   = 607484
+0:The total amount of wall time                        = 163.209346
+0:The maximum resident set size (KB)                   = 607496
 
 Test 140 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_stochy_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_stochy_gefs
 Checking test 141 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 164.688733
-0:The maximum resident set size (KB)                   = 607532
+0:The total amount of wall time                        = 163.830525
+0:The maximum resident set size (KB)                   = 607500
 
 Test 141 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_ciceC_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_ciceC_cfsr
 Checking test 142 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 169.122143
-0:The maximum resident set size (KB)                   = 727724
+0:The total amount of wall time                        = 167.775543
+0:The maximum resident set size (KB)                   = 716688
 
 Test 142 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_bulk_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_bulk_cfsr
 Checking test 143 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 169.012426
-0:The maximum resident set size (KB)                   = 716712
+0:The total amount of wall time                        = 167.876101
+0:The maximum resident set size (KB)                   = 716696
 
 Test 143 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_bulk_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_bulk_gefs
 Checking test 144 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.203569
-0:The maximum resident set size (KB)                   = 607472
+0:The total amount of wall time                        = 155.505139
+0:The maximum resident set size (KB)                   = 607468
 
 Test 144 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_mx025_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_mx025_cfsr
 Checking test 145 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4441,14 +4443,14 @@ Checking test 145 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 424.041391
-0:The maximum resident set size (KB)                   = 514328
+0:The total amount of wall time                        = 419.366060
+0:The maximum resident set size (KB)                   = 514440
 
 Test 145 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_mx025_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_mx025_gefs
 Checking test 146 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4457,77 +4459,77 @@ Checking test 146 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 448.683812
-0:The maximum resident set size (KB)                   = 494784
+0:The total amount of wall time                        = 414.294541
+0:The maximum resident set size (KB)                   = 494788
 
 Test 146 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_multiple_files_cfsr
 Checking test 147 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.620578
-0:The maximum resident set size (KB)                   = 716764
+0:The total amount of wall time                        = 161.603854
+0:The maximum resident set size (KB)                   = 716748
 
 Test 147 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_3072x1536_cfsr
 Checking test 148 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 257.443345
-0:The maximum resident set size (KB)                   = 1940332
+0:The total amount of wall time                        = 241.479613
+0:The maximum resident set size (KB)                   = 1940300
 
 Test 148 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_gfs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_gfs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_gfs
 Checking test 149 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 255.750273
-0:The maximum resident set size (KB)                   = 1940300
+0:The total amount of wall time                        = 240.458291
+0:The maximum resident set size (KB)                   = 1933664
 
 Test 149 datm_cdeps_gfs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_debug_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_debug_cfsr
 Checking test 150 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 466.665611
-0:The maximum resident set size (KB)                   = 706636
+0:The total amount of wall time                        = 457.195281
+0:The maximum resident set size (KB)                   = 706672
 
 Test 150 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_control_cfsr_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_control_cfsr_faster
 Checking test 151 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.578577
-0:The maximum resident set size (KB)                   = 716724
+0:The total amount of wall time                        = 166.612110
+0:The maximum resident set size (KB)                   = 727792
 
 Test 151 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_lnd_gswp3
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_lnd_gswp3
 Checking test 152 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4536,14 +4538,14 @@ Checking test 152 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 11.287246
-0:The maximum resident set size (KB)                   = 204568
+0:The total amount of wall time                        = 10.257046
+0:The maximum resident set size (KB)                   = 208228
 
 Test 152 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/datm_cdeps_lnd_gswp3_rst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/datm_cdeps_lnd_gswp3_rst
 Checking test 153 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4552,14 +4554,14 @@ Checking test 153 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 15.387472
-0:The maximum resident set size (KB)                   = 210120
+0:The total amount of wall time                        = 15.509588
+0:The maximum resident set size (KB)                   = 208268
 
 Test 153 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_p8_atmlnd_sbs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_p8_atmlnd_sbs
 Checking test 154 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4644,14 +4646,14 @@ Checking test 154 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-0:The total amount of wall time                        = 233.608333
-0:The maximum resident set size (KB)                   = 1462964
+0:The total amount of wall time                        = 233.664393
+0:The maximum resident set size (KB)                   = 1462940
 
 Test 154 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/control_atmwav
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/control_atmwav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/control_atmwav
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/control_atmwav
 Checking test 155 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4695,14 +4697,14 @@ Checking test 155 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 100.977513
-0:The maximum resident set size (KB)                   = 474568
+0:The total amount of wall time                        = 100.180884
+0:The maximum resident set size (KB)                   = 475236
 
 Test 155 control_atmwav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/atmaero_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/atmaero_control_p8
 Checking test 156 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4746,14 +4748,14 @@ Checking test 156 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 250.080174
-0:The maximum resident set size (KB)                   = 2704016
+0:The total amount of wall time                        = 253.249726
+0:The maximum resident set size (KB)                   = 2704032
 
 Test 156 atmaero_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/atmaero_control_p8_rad
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/atmaero_control_p8_rad
 Checking test 157 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4797,14 +4799,14 @@ Checking test 157 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 303.389420
-0:The maximum resident set size (KB)                   = 2758092
+0:The total amount of wall time                        = 297.542351
+0:The maximum resident set size (KB)                   = 2758052
 
 Test 157 atmaero_control_p8_rad PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad_micro
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/atmaero_control_p8_rad_micro
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/atmaero_control_p8_rad_micro
 Checking test 158 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4848,14 +4850,14 @@ Checking test 158 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 308.269046
-0:The maximum resident set size (KB)                   = 2764448
+0:The total amount of wall time                        = 310.140681
+0:The maximum resident set size (KB)                   = 2764484
 
 Test 158 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_atmaq
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_atmaq
 Checking test 159 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4871,14 +4873,14 @@ Checking test 159 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 753.452314
-0:The maximum resident set size (KB)                   = 999516
+0:The total amount of wall time                        = 741.578007
+0:The maximum resident set size (KB)                   = 999528
 
 Test 159 regional_atmaq PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_26534/regional_atmaq_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_faster
+working dir  = /glade/scratch/jongkim/rt-1692-intel/jongkim/FV3_RT/rt_8336/regional_atmaq_faster
 Checking test 160 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4894,12 +4896,12 @@ Checking test 160 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 704.415345
-0:The maximum resident set size (KB)                   = 999412
+0:The total amount of wall time                        = 697.408164
+0:The maximum resident set size (KB)                   = 999356
 
 Test 160 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 15:24:26 MDT 2023
-Elapsed time: 01h:15m:41s. Have a nice day!
+Mon Apr  3 09:35:47 MDT 2023
+Elapsed time: 01h:40m:25s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,42 +1,42 @@
-Thu Mar 30 13:33:29 EDT 2023
+Sun Apr  2 09:24:39 EDT 2023
 Start Regression test
 
-Compile 001 elapsed time 927 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 919 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 837 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 390 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 309 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 779 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 832 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 1122 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 786 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 742 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 735 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 709 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 920 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 310 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 332 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 687 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 697 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 244 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 239 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 765 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 305 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 953 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 808 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 309 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 277 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 340 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 201 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 817 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 776 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 786 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 790 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 302 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 033 elapsed time 920 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 915 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 915 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 824 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 353 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 334 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 782 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 782 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1046 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 820 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 746 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 666 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 625 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 841 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 272 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 219 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 655 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 684 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 222 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 706 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 244 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 888 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 710 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 282 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 167 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 291 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 103 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 674 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 671 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 693 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 621 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 231 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 033 elapsed time 785 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_p8_mixedmode
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -101,14 +101,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 354.660131
-  0: The maximum resident set size (KB)                   = 1535244
+  0: The total amount of wall time                        = 337.379104
+  0: The maximum resident set size (KB)                   = 1533360
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_gfsv17
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_gfsv17
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_gfsv17
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -172,14 +172,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 270.517015
-  0: The maximum resident set size (KB)                   = 1444704
+  0: The total amount of wall time                        = 243.804098
+  0: The maximum resident set size (KB)                   = 1443808
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -244,14 +244,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 400.503709
-  0: The maximum resident set size (KB)                   = 1568816
+  0: The total amount of wall time                        = 375.275648
+  0: The maximum resident set size (KB)                   = 1567108
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -304,14 +304,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 243.870455
-  0: The maximum resident set size (KB)                   = 1018768
+  0: The total amount of wall time                        = 221.913359
+  0: The maximum resident set size (KB)                   = 1018000
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_qr_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -376,14 +376,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 399.315919
-  0: The maximum resident set size (KB)                   = 1578864
+  0: The total amount of wall time                        = 386.958238
+  0: The maximum resident set size (KB)                   = 1578516
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_restart_qr_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -436,14 +436,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 240.825454
-  0: The maximum resident set size (KB)                   = 1032732
+  0: The total amount of wall time                        = 234.547171
+  0: The maximum resident set size (KB)                   = 1031216
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -496,14 +496,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 427.074361
-  0: The maximum resident set size (KB)                   = 1758276
+  0: The total amount of wall time                        = 396.835696
+  0: The maximum resident set size (KB)                   = 1762064
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -556,14 +556,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 404.300273
-  0: The maximum resident set size (KB)                   = 1563084
+  0: The total amount of wall time                        = 377.292994
+  0: The maximum resident set size (KB)                   = 1562028
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -616,14 +616,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 347.624854
-  0: The maximum resident set size (KB)                   = 1526744
+  0: The total amount of wall time                        = 313.068124
+  0: The maximum resident set size (KB)                   = 1526904
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,14 +671,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 909.526947
-   0: The maximum resident set size (KB)                   = 2510300
+   0: The total amount of wall time                        = 880.657538
+   0: The maximum resident set size (KB)                   = 2502660
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_restart_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -726,14 +726,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 669.235366
-   0: The maximum resident set size (KB)                   = 2336236
+   0: The total amount of wall time                        = 655.415980
+   0: The maximum resident set size (KB)                   = 2323520
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_noaero_p8
 Checking test 012 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -797,14 +797,14 @@ Checking test 012 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 307.461578
-  0: The maximum resident set size (KB)                   = 1442468
+  0: The total amount of wall time                        = 289.252843
+  0: The maximum resident set size (KB)                   = 1441076
 
 Test 012 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_nowave_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_nowave_noaero_p8
 Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -866,14 +866,14 @@ Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 318.556115
-  0: The maximum resident set size (KB)                   = 1474700
+  0: The total amount of wall time                        = 296.679556
+  0: The maximum resident set size (KB)                   = 1475292
 
 Test 013 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_debug_p8
 Checking test 014 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -926,14 +926,14 @@ Checking test 014 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 607.235690
-  0: The maximum resident set size (KB)                   = 1595960
+  0: The total amount of wall time                        = 594.321638
+  0: The maximum resident set size (KB)                   = 1603436
 
 Test 014 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_noaero_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_debug_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_debug_noaero_p8
 Checking test 015 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -985,14 +985,14 @@ Checking test 015 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 424.380613
-  0: The maximum resident set size (KB)                   = 1442312
+  0: The total amount of wall time                        = 402.331892
+  0: The maximum resident set size (KB)                   = 1441804
 
 Test 015 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_noaero_p8_agrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_noaero_p8_agrid
 Checking test 016 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1054,14 +1054,14 @@ Checking test 016 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 331.087903
-  0: The maximum resident set size (KB)                   = 1478140
+  0: The total amount of wall time                        = 298.330136
+  0: The maximum resident set size (KB)                   = 1478176
 
 Test 016 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_c48
 Checking test 017 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1111,14 +1111,14 @@ Checking test 017 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 614.873827
- 0: The maximum resident set size (KB)                   = 2562984
+ 0: The total amount of wall time                        = 604.869699
+ 0: The maximum resident set size (KB)                   = 2575148
 
 Test 017 cpld_control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_warmstart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_warmstart_c48
 Checking test 018 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1168,14 +1168,14 @@ Checking test 018 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 162.308126
- 0: The maximum resident set size (KB)                   = 2575184
+ 0: The total amount of wall time                        = 160.794785
+ 0: The maximum resident set size (KB)                   = 2588648
 
 Test 018 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_restart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_restart_c48
 Checking test 019 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1225,14 +1225,14 @@ Checking test 019 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 93.786835
- 0: The maximum resident set size (KB)                   = 1989736
+ 0: The total amount of wall time                        = 85.028201
+ 0: The maximum resident set size (KB)                   = 2007272
 
 Test 019 cpld_restart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_faster
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/cpld_control_p8_faster
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/cpld_control_p8_faster
 Checking test 020 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1297,14 +1297,14 @@ Checking test 020 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 393.249795
-  0: The maximum resident set size (KB)                   = 1567804
+  0: The total amount of wall time                        = 367.618696
+  0: The maximum resident set size (KB)                   = 1566572
 
 Test 020 cpld_control_p8_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1331,28 +1331,28 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 143.810637
-  0: The maximum resident set size (KB)                   = 437708
+  0: The total amount of wall time                        = 141.617967
+  0: The maximum resident set size (KB)                   = 437704
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_CubedSphereGrid_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_CubedSphereGrid_parallel
 Checking test 022 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 189.202455
-  0: The maximum resident set size (KB)                   = 438068
+  0: The total amount of wall time                        = 146.339181
+  0: The maximum resident set size (KB)                   = 437792
 
 Test 022 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1363,14 +1363,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 146.391579
-  0: The maximum resident set size (KB)                   = 437872
+  0: The total amount of wall time                        = 147.509240
+  0: The maximum resident set size (KB)                   = 437732
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1381,14 +1381,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 202.348695
-  0: The maximum resident set size (KB)                   = 437816
+  0: The total amount of wall time                        = 148.462769
+  0: The maximum resident set size (KB)                   = 437716
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1427,14 +1427,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 421.209655
-0: The maximum resident set size (KB)                   = 634780
+0: The total amount of wall time                        = 422.458628
+0: The maximum resident set size (KB)                   = 634784
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1445,14 +1445,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 590.698489
-  0: The maximum resident set size (KB)                   = 544724
+  0: The total amount of wall time                        = 579.449446
+  0: The maximum resident set size (KB)                   = 544692
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1463,14 +1463,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1116.398335
-  0: The maximum resident set size (KB)                   = 823096
+  0: The total amount of wall time                        = 1101.496469
+  0: The maximum resident set size (KB)                   = 823444
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1513,14 +1513,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 946.437792
-  0: The maximum resident set size (KB)                   = 954740
+  0: The total amount of wall time                        = 937.409324
+  0: The maximum resident set size (KB)                   = 954444
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1531,28 +1531,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.664406
-  0: The maximum resident set size (KB)                   = 441380
+  0: The total amount of wall time                        = 107.873376
+  0: The maximum resident set size (KB)                   = 441372
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 52.479023
-  0: The maximum resident set size (KB)                   = 195784
+  0: The total amount of wall time                        = 56.848472
+  0: The maximum resident set size (KB)                   = 195708
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1563,14 +1563,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 92.521995
-  0: The maximum resident set size (KB)                   = 440876
+  0: The total amount of wall time                        = 88.530562
+  0: The maximum resident set size (KB)                   = 441016
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_iovr4
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 151.094709
-  0: The maximum resident set size (KB)                   = 437772
+  0: The total amount of wall time                        = 145.189935
+  0: The maximum resident set size (KB)                   = 437784
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_iovr5
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 173.289795
-  0: The maximum resident set size (KB)                   = 437816
+  0: The total amount of wall time                        = 146.690051
+  0: The maximum resident set size (KB)                   = 437672
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1661,14 +1661,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.332097
-  0: The maximum resident set size (KB)                   = 1380064
+  0: The total amount of wall time                        = 199.435120
+  0: The maximum resident set size (KB)                   = 1380124
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1707,14 +1707,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.868484
-  0: The maximum resident set size (KB)                   = 556668
+  0: The total amount of wall time                        = 109.339861
+  0: The maximum resident set size (KB)                   = 556640
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_qr_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_qr_p8
 Checking test 036 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1761,14 +1761,14 @@ Checking test 036 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 202.753107
-  0: The maximum resident set size (KB)                   = 1383284
+  0: The total amount of wall time                        = 187.484069
+  0: The maximum resident set size (KB)                   = 1383216
 
 Test 036 control_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_restart_qr_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_restart_qr_p8
 Checking test 037 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1807,14 +1807,14 @@ Checking test 037 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 113.283489
-  0: The maximum resident set size (KB)                   = 581496
+  0: The total amount of wall time                        = 105.297828
+  0: The maximum resident set size (KB)                   = 581436
 
 Test 037 control_restart_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_decomp_p8
 Checking test 038 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1857,14 +1857,14 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 209.766487
-  0: The maximum resident set size (KB)                   = 1373956
+  0: The total amount of wall time                        = 199.119694
+  0: The maximum resident set size (KB)                   = 1373992
 
 Test 038 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_2threads_p8
 Checking test 039 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1907,14 +1907,14 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.609388
-  0: The maximum resident set size (KB)                   = 1464144
+  0: The total amount of wall time                        = 181.332271
+  0: The maximum resident set size (KB)                   = 1463960
 
 Test 039 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_p8_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_p8_lndp
 Checking test 040 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1933,14 +1933,14 @@ Checking test 040 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 353.432983
-  0: The maximum resident set size (KB)                   = 1381164
+  0: The total amount of wall time                        = 332.113721
+  0: The maximum resident set size (KB)                   = 1381152
 
 Test 040 control_p8_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_p8_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_p8_rrtmgp
 Checking test 041 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1987,14 +1987,14 @@ Checking test 041 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 273.800419
-  0: The maximum resident set size (KB)                   = 1437480
+  0: The total amount of wall time                        = 256.529293
+  0: The maximum resident set size (KB)                   = 1437508
 
 Test 041 control_p8_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_p8_mynn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_p8_mynn
 Checking test 042 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2041,14 +2041,14 @@ Checking test 042 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.460321
-  0: The maximum resident set size (KB)                   = 1384124
+  0: The total amount of wall time                        = 209.338087
+  0: The maximum resident set size (KB)                   = 1384144
 
 Test 042 control_p8_mynn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/merra2_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/merra2_thompson
 Checking test 043 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2095,14 +2095,14 @@ Checking test 043 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 225.040739
-  0: The maximum resident set size (KB)                   = 1385508
+  0: The total amount of wall time                        = 210.998743
+  0: The maximum resident set size (KB)                   = 1385524
 
 Test 043 merra2_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_control
 Checking test 044 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2113,28 +2113,28 @@ Checking test 044 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 372.787945
-  0: The maximum resident set size (KB)                   = 578856
+  0: The total amount of wall time                        = 336.527363
+  0: The maximum resident set size (KB)                   = 578968
 
 Test 044 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_restart
 Checking test 045 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 176.448811
-  0: The maximum resident set size (KB)                   = 578584
+  0: The total amount of wall time                        = 172.991984
+  0: The maximum resident set size (KB)                   = 578924
 
 Test 045 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_control_qr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_control_qr
 Checking test 046 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2145,28 +2145,28 @@ Checking test 046 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 352.725543
-  0: The maximum resident set size (KB)                   = 578964
+  0: The total amount of wall time                        = 341.668663
+  0: The maximum resident set size (KB)                   = 578860
 
 Test 046 regional_control_qr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_restart_qr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_restart_qr
 Checking test 047 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 186.317886
-  0: The maximum resident set size (KB)                   = 578592
+  0: The total amount of wall time                        = 181.600885
+  0: The maximum resident set size (KB)                   = 578400
 
 Test 047 regional_restart_qr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_decomp
 Checking test 048 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2177,14 +2177,14 @@ Checking test 048 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 346.398887
-  0: The maximum resident set size (KB)                   = 580756
+  0: The total amount of wall time                        = 347.356497
+  0: The maximum resident set size (KB)                   = 580732
 
 Test 048 regional_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_2threads
 Checking test 049 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2195,14 +2195,14 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 220.099107
-  0: The maximum resident set size (KB)                   = 585352
+  0: The total amount of wall time                        = 199.889137
+  0: The maximum resident set size (KB)                   = 586140
 
 Test 049 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_noquilt
 Checking test 050 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2210,28 +2210,28 @@ Checking test 050 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 371.085026
-  0: The maximum resident set size (KB)                   = 573128
+  0: The total amount of wall time                        = 358.079215
+  0: The maximum resident set size (KB)                   = 573140
 
 Test 050 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_netcdf_parallel
 Checking test 051 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 352.110650
-  0: The maximum resident set size (KB)                   = 578620
+  0: The total amount of wall time                        = 335.771778
+  0: The maximum resident set size (KB)                   = 578532
 
 Test 051 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_2dwrtdecomp
 Checking test 052 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2242,14 +2242,14 @@ Checking test 052 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 348.466728
-  0: The maximum resident set size (KB)                   = 578952
+  0: The total amount of wall time                        = 341.785629
+  0: The maximum resident set size (KB)                   = 578896
 
 Test 052 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_wofs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/fv3_regional_wofs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_wofs
 Checking test 053 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2260,14 +2260,14 @@ Checking test 053 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 421.710683
-  0: The maximum resident set size (KB)                   = 263764
+  0: The total amount of wall time                        = 426.371150
+  0: The maximum resident set size (KB)                   = 263940
 
 Test 053 regional_wofs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_control
 Checking test 054 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2314,14 +2314,14 @@ Checking test 054 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 488.192699
-  0: The maximum resident set size (KB)                   = 808048
+  0: The total amount of wall time                        = 472.430181
+  0: The maximum resident set size (KB)                   = 808228
 
 Test 054 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_spp_sppt_shum_skeb
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_spp_sppt_shum_skeb
 Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2332,14 +2332,14 @@ Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 276.231184
-  0: The maximum resident set size (KB)                   = 908112
+  0: The total amount of wall time                        = 262.620519
+  0: The maximum resident set size (KB)                   = 908600
 
 Test 055 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_decomp
 Checking test 056 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2386,14 +2386,14 @@ Checking test 056 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 502.508227
-  0: The maximum resident set size (KB)                   = 806472
+  0: The total amount of wall time                        = 494.513841
+  0: The maximum resident set size (KB)                   = 806440
 
 Test 056 rap_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_2threads
 Checking test 057 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2440,14 +2440,14 @@ Checking test 057 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.782906
-  0: The maximum resident set size (KB)                   = 875124
+  0: The total amount of wall time                        = 450.545995
+  0: The maximum resident set size (KB)                   = 875168
 
 Test 057 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_restart
 Checking test 058 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2486,14 +2486,14 @@ Checking test 058 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 245.059912
-  0: The maximum resident set size (KB)                   = 552740
+  0: The total amount of wall time                        = 240.842644
+  0: The maximum resident set size (KB)                   = 553428
 
 Test 058 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_sfcdiff
 Checking test 059 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2540,14 +2540,14 @@ Checking test 059 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 486.899727
-  0: The maximum resident set size (KB)                   = 808044
+  0: The total amount of wall time                        = 472.640228
+  0: The maximum resident set size (KB)                   = 807944
 
 Test 059 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_sfcdiff_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_sfcdiff_decomp
 Checking test 060 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2594,14 +2594,14 @@ Checking test 060 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 507.764785
-  0: The maximum resident set size (KB)                   = 806500
+  0: The total amount of wall time                        = 496.275291
+  0: The maximum resident set size (KB)                   = 806372
 
 Test 060 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_sfcdiff_restart
 Checking test 061 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2640,14 +2640,14 @@ Checking test 061 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 356.165266
-  0: The maximum resident set size (KB)                   = 552376
+  0: The total amount of wall time                        = 360.156033
+  0: The maximum resident set size (KB)                   = 552524
 
 Test 061 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control
 Checking test 062 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2694,14 +2694,14 @@ Checking test 062 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 465.522405
-  0: The maximum resident set size (KB)                   = 806036
+  0: The total amount of wall time                        = 458.829252
+  0: The maximum resident set size (KB)                   = 805980
 
 Test 062 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_decomp
 Checking test 063 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2748,14 +2748,14 @@ Checking test 063 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 486.746782
-  0: The maximum resident set size (KB)                   = 805484
+  0: The total amount of wall time                        = 473.522010
+  0: The maximum resident set size (KB)                   = 805352
 
 Test 063 hrrr_control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_2threads
 Checking test 064 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2802,14 +2802,14 @@ Checking test 064 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 438.603372
-  0: The maximum resident set size (KB)                   = 873064
+  0: The total amount of wall time                        = 431.019473
+  0: The maximum resident set size (KB)                   = 873164
 
 Test 064 hrrr_control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_restart
 Checking test 065 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2848,14 +2848,14 @@ Checking test 065 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 345.470751
-  0: The maximum resident set size (KB)                   = 547896
+  0: The total amount of wall time                        = 340.062857
+  0: The maximum resident set size (KB)                   = 547932
 
 Test 065 hrrr_control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_v1beta
 Checking test 066 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2902,14 +2902,14 @@ Checking test 066 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 476.775106
-  0: The maximum resident set size (KB)                   = 805016
+  0: The total amount of wall time                        = 466.812312
+  0: The maximum resident set size (KB)                   = 805184
 
 Test 066 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_v1nssl
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_v1nssl
 Checking test 067 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2924,14 +2924,14 @@ Checking test 067 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 590.661374
-  0: The maximum resident set size (KB)                   = 493488
+  0: The total amount of wall time                        = 578.572173
+  0: The maximum resident set size (KB)                   = 493548
 
 Test 067 rrfs_v1nssl PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_v1nssl_nohailnoccn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_v1nssl_nohailnoccn
 Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2946,14 +2946,14 @@ Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 568.490251
-  0: The maximum resident set size (KB)                   = 485888
+  0: The total amount of wall time                        = 559.528961
+  0: The maximum resident set size (KB)                   = 486176
 
 Test 068 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_smoke_conus13km_hrrr_warm
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2962,14 +2962,14 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 190.648618
-  0: The maximum resident set size (KB)                   = 658128
+  0: The total amount of wall time                        = 173.892688
+  0: The maximum resident set size (KB)                   = 658096
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2978,14 +2978,14 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 130.345413
-  0: The maximum resident set size (KB)                   = 670888
+  0: The total amount of wall time                        = 106.739012
+  0: The maximum resident set size (KB)                   = 671480
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_conus13km_hrrr_warm
 Checking test 071 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2994,14 +2994,14 @@ Checking test 071 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 172.184682
-  0: The maximum resident set size (KB)                   = 635288
+  0: The total amount of wall time                        = 134.842785
+  0: The maximum resident set size (KB)                   = 634756
 
 Test 071 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 072 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3010,26 +3010,26 @@ Checking test 072 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 190.917680
-  0: The maximum resident set size (KB)                   = 660800
+  0: The total amount of wall time                        = 159.554214
+  0: The maximum resident set size (KB)                   = 660952
 
 Test 072 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 073 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 96.387111
-  0: The maximum resident set size (KB)                   = 615396
+  0: The total amount of wall time                        = 81.302413
+  0: The maximum resident set size (KB)                   = 615240
 
 Test 073 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_csawmgt
 Checking test 074 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3040,14 +3040,14 @@ Checking test 074 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 395.504846
-  0: The maximum resident set size (KB)                   = 502644
+  0: The total amount of wall time                        = 389.662597
+  0: The maximum resident set size (KB)                   = 502692
 
 Test 074 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_ras
 Checking test 075 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3058,26 +3058,26 @@ Checking test 075 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 201.640236
-  0: The maximum resident set size (KB)                   = 472816
+  0: The total amount of wall time                        = 202.450589
+  0: The maximum resident set size (KB)                   = 472940
 
 Test 075 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_wam
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_wam
 Checking test 076 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 126.139231
-  0: The maximum resident set size (KB)                   = 188804
+  0: The total amount of wall time                        = 126.240206
+  0: The maximum resident set size (KB)                   = 188856
 
 Test 076 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_p8_faster
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_p8_faster
 Checking test 077 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3124,14 +3124,14 @@ Checking test 077 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 186.820543
-  0: The maximum resident set size (KB)                   = 1380084
+  0: The total amount of wall time                        = 183.921476
+  0: The maximum resident set size (KB)                   = 1380068
 
 Test 077 control_p8_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_control_faster
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_control_faster
 Checking test 078 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3142,56 +3142,56 @@ Checking test 078 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 318.315236
-  0: The maximum resident set size (KB)                   = 578712
+  0: The total amount of wall time                        = 319.549164
+  0: The maximum resident set size (KB)                   = 578748
 
 Test 078 regional_control_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 913.704758
-  0: The maximum resident set size (KB)                   = 692440
+  0: The total amount of wall time                        = 901.752497
+  0: The maximum resident set size (KB)                   = 692556
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 538.025806
-  0: The maximum resident set size (KB)                   = 704928
+  0: The total amount of wall time                        = 521.192109
+  0: The maximum resident set size (KB)                   = 706240
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_conus13km_hrrr_warm_debug
 Checking test 081 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 825.934387
-  0: The maximum resident set size (KB)                   = 667360
+  0: The total amount of wall time                        = 806.701897
+  0: The maximum resident set size (KB)                   = 667324
 
 Test 081 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_CubedSphereGrid_debug
 Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3218,334 +3218,334 @@ Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.437471
-  0: The maximum resident set size (KB)                   = 604892
+  0: The total amount of wall time                        = 169.809115
+  0: The maximum resident set size (KB)                   = 604484
 
 Test 082 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_wrtGauss_netcdf_parallel_debug
 Checking test 083 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 223.680027
-  0: The maximum resident set size (KB)                   = 602272
+  0: The total amount of wall time                        = 164.146056
+  0: The maximum resident set size (KB)                   = 602244
 
 Test 083 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_stochy_debug
 Checking test 084 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.100701
-  0: The maximum resident set size (KB)                   = 607248
+  0: The total amount of wall time                        = 177.676328
+  0: The maximum resident set size (KB)                   = 607104
 
 Test 084 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_lndp_debug
 Checking test 085 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.382466
-  0: The maximum resident set size (KB)                   = 606836
+  0: The total amount of wall time                        = 162.121764
+  0: The maximum resident set size (KB)                   = 606756
 
 Test 085 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_csawmg_debug
 Checking test 086 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.179325
-  0: The maximum resident set size (KB)                   = 644088
+  0: The total amount of wall time                        = 259.290194
+  0: The maximum resident set size (KB)                   = 644028
 
 Test 086 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_csawmgt_debug
 Checking test 087 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.584086
-  0: The maximum resident set size (KB)                   = 643680
+  0: The total amount of wall time                        = 251.494114
+  0: The maximum resident set size (KB)                   = 643640
 
 Test 087 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_ras_debug
 Checking test 088 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.192508
-  0: The maximum resident set size (KB)                   = 615868
+  0: The total amount of wall time                        = 164.229631
+  0: The maximum resident set size (KB)                   = 615732
 
 Test 088 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_diag_debug
 Checking test 089 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.988475
-  0: The maximum resident set size (KB)                   = 661716
+  0: The total amount of wall time                        = 165.425065
+  0: The maximum resident set size (KB)                   = 661512
 
 Test 089 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_debug_p8
 Checking test 090 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.218900
-  0: The maximum resident set size (KB)                   = 1382832
+  0: The total amount of wall time                        = 179.788969
+  0: The maximum resident set size (KB)                   = 1382712
 
 Test 090 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_debug
 Checking test 091 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1044.641443
-  0: The maximum resident set size (KB)                   = 608464
+  0: The total amount of wall time                        = 1049.065429
+  0: The maximum resident set size (KB)                   = 608436
 
 Test 091 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_control_debug
 Checking test 092 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.262950
-  0: The maximum resident set size (KB)                   = 973044
+  0: The total amount of wall time                        = 292.177628
+  0: The maximum resident set size (KB)                   = 973008
 
 Test 092 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_debug
 Checking test 093 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.182432
-  0: The maximum resident set size (KB)                   = 971528
+  0: The total amount of wall time                        = 296.805695
+  0: The maximum resident set size (KB)                   = 971576
 
 Test 093 hrrr_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_unified_drag_suite_debug
 Checking test 094 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.465182
-  0: The maximum resident set size (KB)                   = 973144
+  0: The total amount of wall time                        = 296.155052
+  0: The maximum resident set size (KB)                   = 973132
 
 Test 094 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_diag_debug
 Checking test 095 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 311.063910
-  0: The maximum resident set size (KB)                   = 1056896
+  0: The total amount of wall time                        = 310.328564
+  0: The maximum resident set size (KB)                   = 1056764
 
 Test 095 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_cires_ugwp_debug
 Checking test 096 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 304.208497
-  0: The maximum resident set size (KB)                   = 972512
+  0: The total amount of wall time                        = 301.325261
+  0: The maximum resident set size (KB)                   = 972356
 
 Test 096 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_unified_ugwp_debug
 Checking test 097 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 301.585530
-  0: The maximum resident set size (KB)                   = 974412
+  0: The total amount of wall time                        = 300.357436
+  0: The maximum resident set size (KB)                   = 974428
 
 Test 097 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_lndp_debug
 Checking test 098 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 300.319799
-  0: The maximum resident set size (KB)                   = 973832
+  0: The total amount of wall time                        = 297.077814
+  0: The maximum resident set size (KB)                   = 973532
 
 Test 098 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_flake_debug
 Checking test 099 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 301.468220
-  0: The maximum resident set size (KB)                   = 972844
+  0: The total amount of wall time                        = 294.651839
+  0: The maximum resident set size (KB)                   = 973112
 
 Test 099 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_progcld_thompson_debug
 Checking test 100 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 297.331269
-  0: The maximum resident set size (KB)                   = 973108
+  0: The total amount of wall time                        = 294.316045
+  0: The maximum resident set size (KB)                   = 972980
 
 Test 100 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_noah_debug
 Checking test 101 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 304.084059
-  0: The maximum resident set size (KB)                   = 971836
+  0: The total amount of wall time                        = 288.404921
+  0: The maximum resident set size (KB)                   = 971624
 
 Test 101 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_sfcdiff_debug
 Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.709904
-  0: The maximum resident set size (KB)                   = 973036
+  0: The total amount of wall time                        = 294.120618
+  0: The maximum resident set size (KB)                   = 973104
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 482.103591
-  0: The maximum resident set size (KB)                   = 971432
+  0: The total amount of wall time                        = 478.092106
+  0: The maximum resident set size (KB)                   = 971376
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rrfs_v1beta_debug
 Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.456532
-  0: The maximum resident set size (KB)                   = 968960
+  0: The total amount of wall time                        = 289.297021
+  0: The maximum resident set size (KB)                   = 969088
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_wam_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 295.193040
-  0: The maximum resident set size (KB)                   = 220444
+  0: The total amount of wall time                        = 293.071579
+  0: The maximum resident set size (KB)                   = 220312
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3556,14 +3556,14 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 269.983197
-  0: The maximum resident set size (KB)                   = 803152
+  0: The total amount of wall time                        = 255.838639
+  0: The maximum resident set size (KB)                   = 802920
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_control_dyn32_phy32
 Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3610,14 +3610,14 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 402.120967
-  0: The maximum resident set size (KB)                   = 691380
+  0: The total amount of wall time                        = 409.036427
+  0: The maximum resident set size (KB)                   = 691312
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_dyn32_phy32
 Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3664,14 +3664,14 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 224.217071
-  0: The maximum resident set size (KB)                   = 689892
+  0: The total amount of wall time                        = 215.777240
+  0: The maximum resident set size (KB)                   = 689592
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_2threads_dyn32_phy32
 Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3718,14 +3718,14 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 385.227372
-  0: The maximum resident set size (KB)                   = 743472
+  0: The total amount of wall time                        = 380.264490
+  0: The maximum resident set size (KB)                   = 743704
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_2threads_dyn32_phy32
 Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3772,14 +3772,14 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 202.031306
-  0: The maximum resident set size (KB)                   = 741224
+  0: The total amount of wall time                        = 196.848230
+  0: The maximum resident set size (KB)                   = 741320
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_decomp_dyn32_phy32
 Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3826,14 +3826,14 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 222.970065
-  0: The maximum resident set size (KB)                   = 688516
+  0: The total amount of wall time                        = 218.725587
+  0: The maximum resident set size (KB)                   = 688356
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_restart_dyn32_phy32
 Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3872,14 +3872,14 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 297.050560
+  0: The total amount of wall time                        = 299.360446
   0: The maximum resident set size (KB)                   = 526376
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_restart_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_restart_dyn32_phy32
 Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3918,14 +3918,14 @@ Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 108.889903
-  0: The maximum resident set size (KB)                   = 518612
+  0: The total amount of wall time                        = 107.433071
+  0: The maximum resident set size (KB)                   = 518596
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_control_dyn64_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_control_dyn64_phy32
 Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3972,173 +3972,439 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 271.622746
-  0: The maximum resident set size (KB)                   = 713460
+  0: The total amount of wall time                        = 264.118057
+  0: The maximum resident set size (KB)                   = 713632
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_control_debug_dyn32_phy32
 Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 294.439047
-  0: The maximum resident set size (KB)                   = 858448
+  0: The total amount of wall time                        = 285.055400
+  0: The maximum resident set size (KB)                   = 858384
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hrrr_control_debug_dyn32_phy32
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hrrr_control_debug_dyn32_phy32
 Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.519738
-  0: The maximum resident set size (KB)                   = 855776
+  0: The total amount of wall time                        = 284.190927
+  0: The maximum resident set size (KB)                   = 855864
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/rap_control_dyn64_phy32_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/rap_control_dyn64_phy32_debug
 Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 299.443424
-  0: The maximum resident set size (KB)                   = 879192
+  0: The total amount of wall time                        = 290.805339
+  0: The maximum resident set size (KB)                   = 879348
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_atm
+Checking test 118 hafs_regional_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing HURPRS.GrbF06 .........OK
+
+  0: The total amount of wall time                        = 275.247951
+  0: The maximum resident set size (KB)                   = 687560
+
+Test 118 hafs_regional_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_atm_thompson_gfdlsf
+Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+
+  0: The total amount of wall time                        = 315.406136
+  0: The maximum resident set size (KB)                   = 1039124
+
+Test 119 hafs_regional_atm_thompson_gfdlsf PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_atm_ocn
+Checking test 120 hafs_regional_atm_ocn results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing archv.2019_241_06.a .........OK
+ Comparing archs.2019_241_06.a .........OK
+ Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 450.309166
+  0: The maximum resident set size (KB)                   = 715640
+
+Test 120 hafs_regional_atm_ocn PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_atm_wav
+Checking test 121 hafs_regional_atm_wav results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 949.798387
+  0: The maximum resident set size (KB)                   = 750040
+
+Test 121 hafs_regional_atm_wav PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_atm_ocn_wav
+Checking test 122 hafs_regional_atm_ocn_wav results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing archv.2019_241_06.a .........OK
+ Comparing archs.2019_241_06.a .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 1039.785526
+  0: The maximum resident set size (KB)                   = 766104
+
+Test 122 hafs_regional_atm_ocn_wav PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_1nest_atm
+Checking test 123 hafs_regional_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+
+  0: The total amount of wall time                        = 391.723237
+  0: The maximum resident set size (KB)                   = 278784
+
+Test 123 hafs_regional_1nest_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_telescopic_2nests_atm
+Checking test 124 hafs_regional_telescopic_2nests_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing atm.nest03.f006.nc .........OK
+ Comparing sfc.nest03.f006.nc .........OK
+
+  0: The total amount of wall time                        = 434.164432
+  0: The maximum resident set size (KB)                   = 288896
+
+Test 124 hafs_regional_telescopic_2nests_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_global_1nest_atm
+Checking test 125 hafs_global_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+
+  0: The total amount of wall time                        = 180.407550
+  0: The maximum resident set size (KB)                   = 184088
+
+Test 125 hafs_global_1nest_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_global_multiple_4nests_atm
+Checking test 126 hafs_global_multiple_4nests_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing atm.nest03.f006.nc .........OK
+ Comparing sfc.nest03.f006.nc .........OK
+ Comparing atm.nest04.f006.nc .........OK
+ Comparing sfc.nest04.f006.nc .........OK
+ Comparing atm.nest05.f006.nc .........OK
+ Comparing sfc.nest05.f006.nc .........OK
+ Comparing HURPRS.GrbF06 .........OK
+ Comparing HURPRS.GrbF06.nest02 .........OK
+ Comparing HURPRS.GrbF06.nest03 .........OK
+ Comparing HURPRS.GrbF06.nest04 .........OK
+ Comparing HURPRS.GrbF06.nest05 .........OK
+
+  0: The total amount of wall time                        = 490.987154
+  0: The maximum resident set size (KB)                   = 233164
+
+Test 126 hafs_global_multiple_4nests_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_specified_moving_1nest_atm
+Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing HURPRS.GrbF06 .........OK
+ Comparing HURPRS.GrbF06.nest02 .........OK
+
+  0: The total amount of wall time                        = 241.236595
+  0: The maximum resident set size (KB)                   = 294512
+
+Test 127 hafs_regional_specified_moving_1nest_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_storm_following_1nest_atm
+Checking test 128 hafs_regional_storm_following_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+
+  0: The total amount of wall time                        = 229.982224
+  0: The maximum resident set size (KB)                   = 294432
+
+Test 128 hafs_regional_storm_following_1nest_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_storm_following_1nest_atm_ocn
+Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing archv.2020_238_18.a .........OK
+ Comparing archs.2020_238_18.a .........OK
+
+  0: The total amount of wall time                        = 272.756971
+  0: The maximum resident set size (KB)                   = 322988
+
+Test 129 hafs_regional_storm_following_1nest_atm_ocn PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_global_storm_following_1nest_atm
+Checking test 130 hafs_global_storm_following_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+
+  0: The total amount of wall time                        = 69.675565
+  0: The maximum resident set size (KB)                   = 203112
+
+Test 130 hafs_global_storm_following_1nest_atm PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_storm_following_1nest_atm_ocn_debug
+Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
+ Comparing atmf001.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atm.nest02.f001.nc .........OK
+ Comparing sfc.nest02.f001.nc .........OK
+
+  0: The total amount of wall time                        = 781.601900
+  0: The maximum resident set size (KB)                   = 353772
+
+Test 131 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_storm_following_1nest_atm_ocn_wav
+Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing archv.2020_238_18.a .........OK
+ Comparing archs.2020_238_18.a .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+
+  0: The total amount of wall time                        = 709.043397
+  0: The maximum resident set size (KB)                   = 373160
+
+Test 132 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_docn
+Checking test 133 hafs_regional_docn results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 398.146771
+  0: The maximum resident set size (KB)                   = 723860
+
+Test 133 hafs_regional_docn PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_docn_oisst
+Checking test 134 hafs_regional_docn_oisst results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
+
+  0: The total amount of wall time                        = 403.310532
+  0: The maximum resident set size (KB)                   = 713140
+
+Test 134 hafs_regional_docn_oisst PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/hafs_regional_datm_cdeps
 Checking test 135 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1172.621769
-  0: The maximum resident set size (KB)                   = 809136
+  0: The total amount of wall time                        = 1175.684696
+  0: The maximum resident set size (KB)                   = 809168
 
-Test 118 hafs_regional_datm_cdeps PASS
+Test 135 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_control_cfsr
 Checking test 136 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 166.363550
- 0: The maximum resident set size (KB)                   = 715852
+ 0: The total amount of wall time                        = 169.737674
+ 0: The maximum resident set size (KB)                   = 715796
 
-Test 119 datm_cdeps_control_cfsr PASS
+Test 136 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_restart_cfsr
 Checking test 137 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.689626
- 0: The maximum resident set size (KB)                   = 716048
+ 0: The total amount of wall time                        = 96.139395
+ 0: The maximum resident set size (KB)                   = 708888
 
-Test 120 datm_cdeps_restart_cfsr PASS
+Test 137 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_control_gefs
 Checking test 138 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 162.094019
- 0: The maximum resident set size (KB)                   = 602212
+ 0: The total amount of wall time                        = 163.352836
+ 0: The maximum resident set size (KB)                   = 598020
 
-Test 121 datm_cdeps_control_gefs PASS
+Test 138 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_iau_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_iau_gefs
 Checking test 139 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.924738
- 0: The maximum resident set size (KB)                   = 600192
+ 0: The total amount of wall time                        = 163.241148
+ 0: The maximum resident set size (KB)                   = 598220
 
-Test 122 datm_cdeps_iau_gefs PASS
+Test 139 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_stochy_gefs
 Checking test 140 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.866958
- 0: The maximum resident set size (KB)                   = 597408
+ 0: The total amount of wall time                        = 164.473608
+ 0: The maximum resident set size (KB)                   = 593432
 
-Test 123 datm_cdeps_stochy_gefs PASS
+Test 140 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_ciceC_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_ciceC_cfsr
 Checking test 141 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 169.080673
- 0: The maximum resident set size (KB)                   = 715796
+ 0: The total amount of wall time                        = 166.855280
+ 0: The maximum resident set size (KB)                   = 716000
 
-Test 124 datm_cdeps_ciceC_cfsr PASS
+Test 141 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_bulk_cfsr
 Checking test 142 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 169.206393
- 0: The maximum resident set size (KB)                   = 706024
+ 0: The total amount of wall time                        = 166.328408
+ 0: The maximum resident set size (KB)                   = 715784
 
-Test 125 datm_cdeps_bulk_cfsr PASS
+Test 142 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_bulk_gefs
 Checking test 143 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.412764
- 0: The maximum resident set size (KB)                   = 601076
+ 0: The total amount of wall time                        = 159.540381
+ 0: The maximum resident set size (KB)                   = 598268
 
-Test 126 datm_cdeps_bulk_gefs PASS
+Test 143 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_mx025_cfsr
 Checking test 144 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4147,143 +4413,126 @@ Checking test 144 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 428.574049
-  0: The maximum resident set size (KB)                   = 494344
+  0: The total amount of wall time                        = 472.497393
+  0: The maximum resident set size (KB)                   = 496572
 
-Test 127 datm_cdeps_mx025_cfsr PASS
+Test 144 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_mx025_gefs
+Checking test 145 datm_cdeps_mx025_gefs results ....
+ Comparing RESTART/20111001.120000.MOM.res.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2011-10-01-43200.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
+
+  0: The total amount of wall time                        = 447.958772
+  0: The maximum resident set size (KB)                   = 476216
+
+Test 145 datm_cdeps_mx025_gefs PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_multiple_files_cfsr
 Checking test 146 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 167.810316
- 0: The maximum resident set size (KB)                   = 715792
+ 0: The total amount of wall time                        = 165.839884
+ 0: The maximum resident set size (KB)                   = 715700
 
-Test 128 datm_cdeps_multiple_files_cfsr PASS
+Test 146 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_3072x1536_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_3072x1536_cfsr
 Checking test 147 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 252.285460
- 0: The maximum resident set size (KB)                   = 1948112
+ 0: The total amount of wall time                        = 255.208497
+ 0: The maximum resident set size (KB)                   = 1948000
 
-Test 129 datm_cdeps_3072x1536_cfsr PASS
+Test 147 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_gfs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_gfs
 Checking test 148 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 254.712674
- 0: The maximum resident set size (KB)                   = 1947984
+ 0: The total amount of wall time                        = 256.625205
+ 0: The maximum resident set size (KB)                   = 1947916
 
-Test 130 datm_cdeps_gfs PASS
+Test 148 datm_cdeps_gfs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_debug_cfsr
 Checking test 149 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 374.115317
- 0: The maximum resident set size (KB)                   = 714896
+ 0: The total amount of wall time                        = 373.509019
+ 0: The maximum resident set size (KB)                   = 714736
 
-Test 131 datm_cdeps_debug_cfsr PASS
+Test 149 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/datm_cdeps_control_cfsr_faster
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_control_cfsr_faster
 Checking test 150 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 166.950644
- 0: The maximum resident set size (KB)                   = 721412
+ 0: The total amount of wall time                        = 169.727635
+ 0: The maximum resident set size (KB)                   = 715688
 
-Test 132 datm_cdeps_control_cfsr_faster PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_28519/control_atmwav
-Checking test 154 control_atmwav results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.180000.coupler.res .........OK
- Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
- Comparing 20210322.180000.restart.glo_1deg .........OK
-
-  0: The total amount of wall time                        = 98.568332
-  0: The maximum resident set size (KB)                   = 451520
-
-Test 133 control_atmwav PASS
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_35325/hafs_regional_docn
-Checking test 002 hafs_regional_docn results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
- Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
-
-  0: The total amount of wall time                        = 399.697354
-  0: The maximum resident set size (KB)                   = 724220
-
-Test 135 hafs_regional_docn PASS
+Test 150 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_35325/control_p8_atmlnd_sbs
-Checking test 003 control_p8_atmlnd_sbs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_lnd_gswp3
+Checking test 151 datm_cdeps_lnd_gswp3 results ....
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 12.006396
+  0: The maximum resident set size (KB)                   = 153964
+
+Test 151 datm_cdeps_lnd_gswp3 PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/datm_cdeps_lnd_gswp3_rst
+Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 22.095141
+  0: The maximum resident set size (KB)                   = 145892
+
+Test 152 datm_cdeps_lnd_gswp3_rst PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_p8_atmlnd_sbs
+Checking test 153 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4367,15 +4616,66 @@ Checking test 003 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 260.599666
-  0: The maximum resident set size (KB)                   = 1413308
+  0: The total amount of wall time                        = 233.708308
+  0: The maximum resident set size (KB)                   = 1413572
 
-Test 136 control_p8_atmlnd_sbs PASS
+Test 153 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_35325/atmaero_control_p8
-Checking test 004 atmaero_control_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/control_atmwav
+Checking test 154 control_atmwav results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.180000.coupler.res .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+ Comparing 20210322.180000.restart.glo_1deg .........OK
+
+  0: The total amount of wall time                        = 96.265012
+  0: The maximum resident set size (KB)                   = 451576
+
+Test 154 control_atmwav PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/atmaero_control_p8
+Checking test 155 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4418,15 +4718,117 @@ Checking test 004 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 276.089463
-  0: The maximum resident set size (KB)                   = 1448108
+  0: The total amount of wall time                        = 252.013915
+  0: The maximum resident set size (KB)                   = 1448192
 
-Test 137 atmaero_control_p8 PASS
+Test 155 atmaero_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_35325/regional_atmaq
-Checking test 005 regional_atmaq results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/atmaero_control_p8_rad
+Checking test 156 atmaero_control_p8_rad results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 300.133172
+  0: The maximum resident set size (KB)                   = 1469736
+
+Test 156 atmaero_control_p8_rad PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/atmaero_control_p8_rad_micro
+Checking test 157 atmaero_control_p8_rad_micro results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 301.713659
+  0: The maximum resident set size (KB)                   = 1473612
+
+Test 157 atmaero_control_p8_rad_micro PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_atmaq
+Checking test 158 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4441,15 +4843,15 @@ Checking test 005 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 705.498555
-  0: The maximum resident set size (KB)                   = 965176
+  0: The total amount of wall time                        = 668.521100
+  0: The maximum resident set size (KB)                   = 964560
 
-Test 138 regional_atmaq PASS
+Test 158 regional_atmaq PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_35325/regional_atmaq_faster
-Checking test 006 regional_atmaq_faster results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10225/regional_atmaq_faster
+Checking test 159 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4464,25 +4866,12 @@ Checking test 006 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 641.565956
-  0: The maximum resident set size (KB)                   = 941320
+  0: The total amount of wall time                        = 615.125444
+  0: The maximum resident set size (KB)                   = 968088
 
-Test 139 regional_atmaq_faster PASS
+Test 159 regional_atmaq_faster PASS
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_35325/hafs_regional_storm_following_1nest_atm_ocn_debug
-Checking test 001 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
- Comparing atmf001.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atm.nest02.f001.nc .........OK
- Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 795.747084
-  0: The maximum resident set size (KB)                   = 353160
-
-Test 140 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
-
-REGRESSION TEST SUCCESS
-Thu Mar 30 22:14:04 EDT 2023
-Elapsed time: 08h:40m:52s. Have a nice day!
-
+REGRESSION TEST WAS SUCCESSFUL
+Sun Apr  2 12:40:20 EDT 2023
+Elapsed time: 03h:15m:59s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,21 +1,21 @@
-Thu Mar 30 14:18:18 UTC 2023
+Sun Apr  2 12:45:16 UTC 2023
 Start Regression test
 
 Compile 001 elapsed time 185 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 328 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 002 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 332 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 004 elapsed time 102 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 186 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 397 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 328 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 324 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 265 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 230 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 153 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 114 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 401 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 334 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 338 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 269 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 229 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 148 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 121 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_c48
 Checking test 001 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,14 +54,14 @@ Checking test 001 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 684.791706
-0: The maximum resident set size (KB)                   = 702668
+0: The total amount of wall time                        = 687.671316
+0: The maximum resident set size (KB)                   = 702820
 
 Test 001 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_stochy
 Checking test 002 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -72,14 +72,14 @@ Checking test 002 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 658.633179
-  0: The maximum resident set size (KB)                   = 479952
+  0: The total amount of wall time                        = 649.158186
+  0: The maximum resident set size (KB)                   = 480956
 
 Test 002 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_ras
 Checking test 003 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -90,14 +90,14 @@ Checking test 003 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 832.483812
-  0: The maximum resident set size (KB)                   = 487504
+  0: The total amount of wall time                        = 843.327587
+  0: The maximum resident set size (KB)                   = 485596
 
 Test 003 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_p8
 Checking test 004 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 004 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 889.233721
-  0: The maximum resident set size (KB)                   = 1235264
+  0: The total amount of wall time                        = 920.177696
+  0: The maximum resident set size (KB)                   = 1235428
 
 Test 004 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_control
 Checking test 005 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 005 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1492.203953
-  0: The maximum resident set size (KB)                   = 830040
+  0: The total amount of wall time                        = 1484.815875
+  0: The maximum resident set size (KB)                   = 836708
 
 Test 005 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_decomp
 Checking test 006 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -252,14 +252,14 @@ Checking test 006 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1449.146238
-  0: The maximum resident set size (KB)                   = 833872
+  0: The total amount of wall time                        = 1467.071364
+  0: The maximum resident set size (KB)                   = 836660
 
 Test 006 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_2threads
 Checking test 007 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -306,14 +306,14 @@ Checking test 007 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1354.320357
-  0: The maximum resident set size (KB)                   = 900424
+  0: The total amount of wall time                        = 1369.479677
+  0: The maximum resident set size (KB)                   = 905860
 
 Test 007 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_restart
 Checking test 008 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -352,14 +352,14 @@ Checking test 008 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 723.415235
-  0: The maximum resident set size (KB)                   = 547700
+  0: The total amount of wall time                        = 727.922600
+  0: The maximum resident set size (KB)                   = 553896
 
 Test 008 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_sfcdiff
 Checking test 009 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -406,14 +406,14 @@ Checking test 009 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1465.926440
-  0: The maximum resident set size (KB)                   = 829744
+  0: The total amount of wall time                        = 1477.003409
+  0: The maximum resident set size (KB)                   = 832576
 
 Test 009 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_sfcdiff_decomp
 Checking test 010 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -460,14 +460,14 @@ Checking test 010 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1466.695726
-  0: The maximum resident set size (KB)                   = 826364
+  0: The total amount of wall time                        = 1441.836902
+  0: The maximum resident set size (KB)                   = 836744
 
 Test 010 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_sfcdiff_restart
 Checking test 011 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -506,14 +506,14 @@ Checking test 011 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1088.811097
-  0: The maximum resident set size (KB)                   = 552972
+  0: The total amount of wall time                        = 1081.111183
+  0: The maximum resident set size (KB)                   = 551180
 
 Test 011 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control
 Checking test 012 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,14 +560,14 @@ Checking test 012 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1419.018726
-  0: The maximum resident set size (KB)                   = 824532
+  0: The total amount of wall time                        = 1433.205837
+  0: The maximum resident set size (KB)                   = 834528
 
 Test 012 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_2threads
 Checking test 013 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -614,14 +614,14 @@ Checking test 013 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1323.496860
-  0: The maximum resident set size (KB)                   = 893604
+  0: The total amount of wall time                        = 1308.165137
+  0: The maximum resident set size (KB)                   = 894128
 
 Test 013 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_decomp
 Checking test 014 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -668,14 +668,14 @@ Checking test 014 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1448.886648
-  0: The maximum resident set size (KB)                   = 825212
+  0: The total amount of wall time                        = 1440.303393
+  0: The maximum resident set size (KB)                   = 831012
 
 Test 014 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_restart
 Checking test 015 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -714,14 +714,14 @@ Checking test 015 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1049.535059
-  0: The maximum resident set size (KB)                   = 551732
+  0: The total amount of wall time                        = 1079.955112
+  0: The maximum resident set size (KB)                   = 549592
 
 Test 015 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_v1beta
 Checking test 016 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -768,14 +768,14 @@ Checking test 016 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1470.334653
-  0: The maximum resident set size (KB)                   = 823344
+  0: The total amount of wall time                        = 1478.232025
+  0: The maximum resident set size (KB)                   = 833300
 
 Test 016 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_smoke_conus13km_hrrr_warm
 Checking test 017 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -784,14 +784,14 @@ Checking test 017 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 790.544990
-  0: The maximum resident set size (KB)                   = 666824
+  0: The total amount of wall time                        = 771.892099
+  0: The maximum resident set size (KB)                   = 668424
 
 Test 017 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 018 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -800,14 +800,14 @@ Checking test 018 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1065.961119
-  0: The maximum resident set size (KB)                   = 668288
+  0: The total amount of wall time                        = 1066.711069
+  0: The maximum resident set size (KB)                   = 669248
 
 Test 018 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_conus13km_hrrr_warm
 Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -816,14 +816,14 @@ Checking test 019 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 759.427221
-  0: The maximum resident set size (KB)                   = 644000
+  0: The total amount of wall time                        = 764.756423
+  0: The maximum resident set size (KB)                   = 646212
 
 Test 019 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 020 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -832,234 +832,234 @@ Checking test 020 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 811.920119
-  0: The maximum resident set size (KB)                   = 676168
+  0: The total amount of wall time                        = 818.329647
+  0: The maximum resident set size (KB)                   = 672000
 
 Test 020 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 021 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 380.261214
-  0: The maximum resident set size (KB)                   = 633596
+  0: The total amount of wall time                        = 394.262414
+  0: The maximum resident set size (KB)                   = 637000
 
 Test 021 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_diag_debug
 Checking test 022 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 129.767261
-  0: The maximum resident set size (KB)                   = 525624
+  0: The total amount of wall time                        = 129.309261
+  0: The maximum resident set size (KB)                   = 530840
 
 Test 022 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/regional_debug
 Checking test 023 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 712.513732
-  0: The maximum resident set size (KB)                   = 595340
+  0: The total amount of wall time                        = 652.145078
+  0: The maximum resident set size (KB)                   = 593180
 
 Test 023 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_control_debug
 Checking test 024 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.814346
-  0: The maximum resident set size (KB)                   = 849124
+  0: The total amount of wall time                        = 180.418548
+  0: The maximum resident set size (KB)                   = 843220
 
 Test 024 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_debug
 Checking test 025 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.040819
-  0: The maximum resident set size (KB)                   = 843636
+  0: The total amount of wall time                        = 174.862079
+  0: The maximum resident set size (KB)                   = 839268
 
 Test 025 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_diag_debug
 Checking test 026 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 220.185152
-  0: The maximum resident set size (KB)                   = 931892
+  0: The total amount of wall time                        = 214.238217
+  0: The maximum resident set size (KB)                   = 926088
 
 Test 026 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 027 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.157997
-  0: The maximum resident set size (KB)                   = 848240
+  0: The total amount of wall time                        = 280.334824
+  0: The maximum resident set size (KB)                   = 845516
 
 Test 027 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_progcld_thompson_debug
 Checking test 028 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.040716
-  0: The maximum resident set size (KB)                   = 849664
+  0: The total amount of wall time                        = 176.079048
+  0: The maximum resident set size (KB)                   = 840212
 
 Test 028 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_v1beta_debug
 Checking test 029 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.950632
-  0: The maximum resident set size (KB)                   = 841880
+  0: The total amount of wall time                        = 173.850795
+  0: The maximum resident set size (KB)                   = 836304
 
 Test 029 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_ras_debug
 Checking test 030 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 106.025687
-  0: The maximum resident set size (KB)                   = 486832
+  0: The total amount of wall time                        = 105.616793
+  0: The maximum resident set size (KB)                   = 482264
 
 Test 030 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_stochy_debug
 Checking test 031 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 119.963690
-  0: The maximum resident set size (KB)                   = 475416
+  0: The total amount of wall time                        = 122.220244
+  0: The maximum resident set size (KB)                   = 473712
 
 Test 031 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_debug_p8
 Checking test 032 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 120.295374
-  0: The maximum resident set size (KB)                   = 1233992
+  0: The total amount of wall time                        = 117.928218
+  0: The maximum resident set size (KB)                   = 1231176
 
 Test 032 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 033 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 625.285306
-  0: The maximum resident set size (KB)                   = 689548
+  0: The total amount of wall time                        = 649.115665
+  0: The maximum resident set size (KB)                   = 687912
 
 Test 033 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 034 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 749.330385
-  0: The maximum resident set size (KB)                   = 683280
+  0: The total amount of wall time                        = 725.908199
+  0: The maximum resident set size (KB)                   = 688536
 
 Test 034 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rrfs_conus13km_hrrr_warm_debug
 Checking test 035 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 599.409964
-  0: The maximum resident set size (KB)                   = 662292
+  0: The total amount of wall time                        = 581.360784
+  0: The maximum resident set size (KB)                   = 659996
 
 Test 035 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 186.662116
-  0: The maximum resident set size (KB)                   = 198104
+  0: The total amount of wall time                        = 185.024363
+  0: The maximum resident set size (KB)                   = 195104
 
 Test 036 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_control_dyn32_phy32
 Checking test 037 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1106,14 +1106,14 @@ Checking test 037 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1460.926012
-  0: The maximum resident set size (KB)                   = 682784
+  0: The total amount of wall time                        = 1490.319526
+  0: The maximum resident set size (KB)                   = 688448
 
 Test 037 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_dyn32_phy32
 Checking test 038 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1160,14 +1160,14 @@ Checking test 038 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 737.336100
-  0: The maximum resident set size (KB)                   = 683796
+  0: The total amount of wall time                        = 736.797336
+  0: The maximum resident set size (KB)                   = 683664
 
 Test 038 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_2threads_dyn32_phy32
 Checking test 039 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1214,14 +1214,14 @@ Checking test 039 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1350.442511
-  0: The maximum resident set size (KB)                   = 730540
+  0: The total amount of wall time                        = 1374.975088
+  0: The maximum resident set size (KB)                   = 729204
 
 Test 039 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_2threads_dyn32_phy32
 Checking test 040 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1268,14 +1268,14 @@ Checking test 040 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 673.877481
-  0: The maximum resident set size (KB)                   = 726856
+  0: The total amount of wall time                        = 671.721772
+  0: The maximum resident set size (KB)                   = 728472
 
 Test 040 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_decomp_dyn32_phy32
 Checking test 041 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1322,14 +1322,14 @@ Checking test 041 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 732.255928
-  0: The maximum resident set size (KB)                   = 687940
+  0: The total amount of wall time                        = 734.584201
+  0: The maximum resident set size (KB)                   = 683384
 
 Test 041 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_restart_dyn32_phy32
 Checking test 042 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1368,14 +1368,14 @@ Checking test 042 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1071.305334
-  0: The maximum resident set size (KB)                   = 516168
+  0: The total amount of wall time                        = 1085.169867
+  0: The maximum resident set size (KB)                   = 511520
 
 Test 042 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_restart_dyn32_phy32
 Checking test 043 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1414,14 +1414,14 @@ Checking test 043 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 368.793082
-  0: The maximum resident set size (KB)                   = 508368
+  0: The total amount of wall time                        = 370.173063
+  0: The maximum resident set size (KB)                   = 511024
 
 Test 043 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_control_dyn64_phy32
 Checking test 044 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1468,56 +1468,56 @@ Checking test 044 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1073.828699
-  0: The maximum resident set size (KB)                   = 711488
+  0: The total amount of wall time                        = 1046.117433
+  0: The maximum resident set size (KB)                   = 708732
 
 Test 044 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_control_debug_dyn32_phy32
 Checking test 045 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.224928
-  0: The maximum resident set size (KB)                   = 700400
+  0: The total amount of wall time                        = 176.778426
+  0: The maximum resident set size (KB)                   = 698776
 
 Test 045 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/hrrr_control_debug_dyn32_phy32
 Checking test 046 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.327245
-  0: The maximum resident set size (KB)                   = 698012
+  0: The total amount of wall time                        = 178.494603
+  0: The maximum resident set size (KB)                   = 699988
 
 Test 046 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/rap_control_dyn64_phy32_debug
 Checking test 047 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.508787
-  0: The maximum resident set size (KB)                   = 721140
+  0: The total amount of wall time                        = 210.136012
+  0: The maximum resident set size (KB)                   = 719064
 
 Test 047 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/cpld_control_p8
 Checking test 048 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1582,14 +1582,14 @@ Checking test 048 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1757.571790
-  0: The maximum resident set size (KB)                   = 1431188
+  0: The total amount of wall time                        = 1697.038649
+  0: The maximum resident set size (KB)                   = 1428632
 
 Test 048 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/cpld_control_nowave_noaero_p8
 Checking test 049 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1651,14 +1651,14 @@ Checking test 049 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1241.292645
-  0: The maximum resident set size (KB)                   = 1333876
+  0: The total amount of wall time                        = 1227.457985
+  0: The maximum resident set size (KB)                   = 1334368
 
 Test 049 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/cpld_debug_p8
 Checking test 050 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1711,25 +1711,25 @@ Checking test 050 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 932.708774
-  0: The maximum resident set size (KB)                   = 1444396
+  0: The total amount of wall time                        = 894.685483
+  0: The maximum resident set size (KB)                   = 1449692
 
 Test 050 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_22734/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_28119/datm_cdeps_control_cfsr
 Checking test 051 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 176.013292
- 0: The maximum resident set size (KB)                   = 664004
+ 0: The total amount of wall time                        = 172.776866
+ 0: The maximum resident set size (KB)                   = 668112
 
 Test 051 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 15:12:15 UTC 2023
-Elapsed time: 00h:53m:58s. Have a nice day!
+Sun Apr  2 13:40:00 UTC 2023
+Elapsed time: 00h:54m:45s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,42 +1,42 @@
-Thu Mar 30 14:03:57 UTC 2023
+Sun Apr  2 12:44:33 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 601 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 638 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 566 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 242 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 619 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 621 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 582 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 243 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 Compile 005 elapsed time 212 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 524 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 515 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 702 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 525 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 498 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 481 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 445 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 592 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 211 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 183 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 450 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 465 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 166 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 564 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 187 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 630 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 584 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 176 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 111 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 196 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 53 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 486 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 570 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 486 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 460 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 187 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 033 elapsed time 540 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 529 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 536 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 707 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 541 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 486 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 480 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 437 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 605 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 227 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 172 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 457 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 460 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 172 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 163 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 569 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 213 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 623 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 579 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 182 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 113 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 182 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 57 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 484 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 526 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 477 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 464 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 171 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 033 elapsed time 548 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_p8_mixedmode
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -101,14 +101,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 307.142600
-  0: The maximum resident set size (KB)                   = 3148088
+  0: The total amount of wall time                        = 308.160471
+  0: The maximum resident set size (KB)                   = 3151244
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_gfsv17
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_gfsv17
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_gfsv17
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -172,14 +172,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 222.857220
-  0: The maximum resident set size (KB)                   = 1731728
+  0: The total amount of wall time                        = 221.784633
+  0: The maximum resident set size (KB)                   = 1723080
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -244,14 +244,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 338.649591
-  0: The maximum resident set size (KB)                   = 3184152
+  0: The total amount of wall time                        = 336.917424
+  0: The maximum resident set size (KB)                   = 3174444
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -304,14 +304,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 197.195333
-  0: The maximum resident set size (KB)                   = 3055336
+  0: The total amount of wall time                        = 194.191255
+  0: The maximum resident set size (KB)                   = 3048180
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -376,14 +376,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 337.930509
-  0: The maximum resident set size (KB)                   = 3195044
+  0: The total amount of wall time                        = 337.255240
+  0: The maximum resident set size (KB)                   = 3196460
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_restart_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -436,14 +436,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 199.113699
-  0: The maximum resident set size (KB)                   = 3065284
+  0: The total amount of wall time                        = 196.909686
+  0: The maximum resident set size (KB)                   = 3068680
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -496,14 +496,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.845317
-  0: The maximum resident set size (KB)                   = 3507928
+  0: The total amount of wall time                        = 346.893769
+  0: The maximum resident set size (KB)                   = 3517724
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -556,14 +556,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 338.138733
-  0: The maximum resident set size (KB)                   = 3167068
+  0: The total amount of wall time                        = 340.055386
+  0: The maximum resident set size (KB)                   = 3170560
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -616,14 +616,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 277.052693
-  0: The maximum resident set size (KB)                   = 3022380
+  0: The total amount of wall time                        = 279.929277
+  0: The maximum resident set size (KB)                   = 3023236
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_ciceC_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_ciceC_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_ciceC_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -688,14 +688,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 338.119606
-  0: The maximum resident set size (KB)                   = 3185284
+  0: The total amount of wall time                        = 339.903835
+  0: The maximum resident set size (KB)                   = 3185052
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -748,14 +748,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 585.247354
-  0: The maximum resident set size (KB)                   = 3254536
+  0: The total amount of wall time                        = 594.945909
+  0: The maximum resident set size (KB)                   = 3258384
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -808,14 +808,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 381.958524
-  0: The maximum resident set size (KB)                   = 3164280
+  0: The total amount of wall time                        = 388.316331
+  0: The maximum resident set size (KB)                   = 3157532
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_bmark_p8
 Checking test 013 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -863,14 +863,14 @@ Checking test 013 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 707.373865
-   0: The maximum resident set size (KB)                   = 4039416
+   0: The total amount of wall time                        = 698.555048
+   0: The maximum resident set size (KB)                   = 4044672
 
 Test 013 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_restart_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_restart_bmark_p8
 Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -918,14 +918,14 @@ Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 444.277907
-   0: The maximum resident set size (KB)                   = 3982364
+   0: The total amount of wall time                        = 438.627630
+   0: The maximum resident set size (KB)                   = 3981580
 
 Test 014 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_noaero_p8
 Checking test 015 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -989,14 +989,14 @@ Checking test 015 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 263.217062
-  0: The maximum resident set size (KB)                   = 1720152
+  0: The total amount of wall time                        = 262.008956
+  0: The maximum resident set size (KB)                   = 1733240
 
 Test 015 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_nowave_noaero_p8
 Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1058,14 +1058,14 @@ Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 259.833873
-  0: The maximum resident set size (KB)                   = 1767648
+  0: The total amount of wall time                        = 261.133107
+  0: The maximum resident set size (KB)                   = 1765592
 
 Test 016 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_debug_p8
 Checking test 017 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1118,14 +1118,14 @@ Checking test 017 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 649.240559
-  0: The maximum resident set size (KB)                   = 3244824
+  0: The total amount of wall time                        = 638.994153
+  0: The maximum resident set size (KB)                   = 3242712
 
 Test 017 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_debug_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_debug_noaero_p8
 Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1177,14 +1177,14 @@ Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 402.117454
-  0: The maximum resident set size (KB)                   = 1740092
+  0: The total amount of wall time                        = 399.317435
+  0: The maximum resident set size (KB)                   = 1747328
 
 Test 018 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_noaero_p8_agrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_noaero_p8_agrid
 Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1246,14 +1246,14 @@ Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 264.955329
-  0: The maximum resident set size (KB)                   = 1763244
+  0: The total amount of wall time                        = 270.701112
+  0: The maximum resident set size (KB)                   = 1765608
 
 Test 019 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_c48
 Checking test 020 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1303,14 +1303,14 @@ Checking test 020 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 576.858537
- 0: The maximum resident set size (KB)                   = 2803852
+ 0: The total amount of wall time                        = 580.525654
+ 0: The maximum resident set size (KB)                   = 2809392
 
 Test 020 cpld_control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_warmstart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_warmstart_c48
 Checking test 021 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1360,14 +1360,14 @@ Checking test 021 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 155.663069
- 0: The maximum resident set size (KB)                   = 2807624
+ 0: The total amount of wall time                        = 155.119456
+ 0: The maximum resident set size (KB)                   = 2801400
 
 Test 021 cpld_warmstart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_restart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_restart_c48
 Checking test 022 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1417,14 +1417,14 @@ Checking test 022 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 83.780851
- 0: The maximum resident set size (KB)                   = 2246032
+ 0: The total amount of wall time                        = 80.307218
+ 0: The maximum resident set size (KB)                   = 2240964
 
 Test 022 cpld_restart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_faster
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/cpld_control_p8_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_faster
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/cpld_control_p8_faster
 Checking test 023 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 023 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 321.376559
-  0: The maximum resident set size (KB)                   = 3182860
+  0: The total amount of wall time                        = 315.586389
+  0: The maximum resident set size (KB)                   = 3184172
 
 Test 023 cpld_control_p8_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_CubedSphereGrid
 Checking test 024 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1523,28 +1523,28 @@ Checking test 024 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.793587
-  0: The maximum resident set size (KB)                   = 631256
+  0: The total amount of wall time                        = 129.480279
+  0: The maximum resident set size (KB)                   = 632712
 
 Test 024 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_CubedSphereGrid_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_CubedSphereGrid_parallel
 Checking test 025 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 128.575517
-  0: The maximum resident set size (KB)                   = 632532
+  0: The total amount of wall time                        = 127.394139
+  0: The maximum resident set size (KB)                   = 634788
 
 Test 025 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_latlon
 Checking test 026 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1555,16 +1555,16 @@ Checking test 026 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 133.447189
-  0: The maximum resident set size (KB)                   = 628924
+  0: The total amount of wall time                        = 133.535390
+  0: The maximum resident set size (KB)                   = 630308
 
 Test 026 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_wrtGauss_netcdf_parallel
 Checking test 027 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1573,14 +1573,14 @@ Checking test 027 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.810811
-  0: The maximum resident set size (KB)                   = 629088
+  0: The total amount of wall time                        = 136.512732
+  0: The maximum resident set size (KB)                   = 632940
 
 Test 027 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_c48
 Checking test 028 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1619,14 +1619,14 @@ Checking test 028 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 372.049045
-0: The maximum resident set size (KB)                   = 820256
+0: The total amount of wall time                        = 370.531484
+0: The maximum resident set size (KB)                   = 819308
 
 Test 028 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_c192
 Checking test 029 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1637,14 +1637,14 @@ Checking test 029 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 526.898198
-  0: The maximum resident set size (KB)                   = 772312
+  0: The total amount of wall time                        = 523.811352
+  0: The maximum resident set size (KB)                   = 772760
 
 Test 029 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_c384
 Checking test 030 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1655,14 +1655,14 @@ Checking test 030 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 520.661212
-  0: The maximum resident set size (KB)                   = 1271156
+  0: The total amount of wall time                        = 519.064098
+  0: The maximum resident set size (KB)                   = 1269960
 
 Test 030 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_c384gdas
 Checking test 031 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1705,14 +1705,14 @@ Checking test 031 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 456.681588
-  0: The maximum resident set size (KB)                   = 1381260
+  0: The total amount of wall time                        = 454.410487
+  0: The maximum resident set size (KB)                   = 1391568
 
 Test 031 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_stochy
 Checking test 032 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1723,28 +1723,28 @@ Checking test 032 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 89.070107
-  0: The maximum resident set size (KB)                   = 631412
+  0: The total amount of wall time                        = 87.394307
+  0: The maximum resident set size (KB)                   = 634096
 
 Test 032 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_stochy_restart
 Checking test 033 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.228840
-  0: The maximum resident set size (KB)                   = 486576
+  0: The total amount of wall time                        = 49.462750
+  0: The maximum resident set size (KB)                   = 490124
 
 Test 033 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_lndp
 Checking test 034 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1755,14 +1755,14 @@ Checking test 034 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 82.801681
-  0: The maximum resident set size (KB)                   = 633572
+  0: The total amount of wall time                        = 80.593222
+  0: The maximum resident set size (KB)                   = 633356
 
 Test 034 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_iovr4
 Checking test 035 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1777,14 +1777,14 @@ Checking test 035 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.834284
-  0: The maximum resident set size (KB)                   = 632080
+  0: The total amount of wall time                        = 137.244319
+  0: The maximum resident set size (KB)                   = 631784
 
 Test 035 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_iovr5
 Checking test 036 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 036 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.833993
-  0: The maximum resident set size (KB)                   = 630548
+  0: The total amount of wall time                        = 134.888110
+  0: The maximum resident set size (KB)                   = 631056
 
 Test 036 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_p8
 Checking test 037 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1853,14 +1853,14 @@ Checking test 037 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.940351
-  0: The maximum resident set size (KB)                   = 1605052
+  0: The total amount of wall time                        = 165.955178
+  0: The maximum resident set size (KB)                   = 1601916
 
 Test 037 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_restart_p8
 Checking test 038 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1899,14 +1899,14 @@ Checking test 038 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.856871
-  0: The maximum resident set size (KB)                   = 871036
+  0: The total amount of wall time                        = 87.618835
+  0: The maximum resident set size (KB)                   = 873244
 
 Test 038 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_qr_p8
 Checking test 039 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1953,14 +1953,14 @@ Checking test 039 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 165.937577
-  0: The maximum resident set size (KB)                   = 1614736
+  0: The total amount of wall time                        = 167.591394
+  0: The maximum resident set size (KB)                   = 1611700
 
 Test 039 control_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_restart_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_restart_qr_p8
 Checking test 040 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1999,14 +1999,14 @@ Checking test 040 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 90.546475
-  0: The maximum resident set size (KB)                   = 871524
+  0: The total amount of wall time                        = 89.486356
+  0: The maximum resident set size (KB)                   = 870412
 
 Test 040 control_restart_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_decomp_p8
 Checking test 041 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2049,14 +2049,14 @@ Checking test 041 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.622515
-  0: The maximum resident set size (KB)                   = 1584640
+  0: The total amount of wall time                        = 172.335574
+  0: The maximum resident set size (KB)                   = 1591104
 
 Test 041 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_2threads_p8
 Checking test 042 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 042 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 157.053439
-  0: The maximum resident set size (KB)                   = 1687088
+  0: The total amount of wall time                        = 155.850775
+  0: The maximum resident set size (KB)                   = 1696020
 
 Test 042 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_p8_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_p8_lndp
 Checking test 043 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 043 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 310.999878
-  0: The maximum resident set size (KB)                   = 1607184
+  0: The total amount of wall time                        = 310.685418
+  0: The maximum resident set size (KB)                   = 1605164
 
 Test 043 control_p8_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_p8_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_p8_rrtmgp
 Checking test 044 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 044 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 222.268318
-  0: The maximum resident set size (KB)                   = 1678956
+  0: The total amount of wall time                        = 222.222941
+  0: The maximum resident set size (KB)                   = 1684588
 
 Test 044 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_p8_mynn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_p8_mynn
 Checking test 045 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2233,14 +2233,14 @@ Checking test 045 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.761832
-  0: The maximum resident set size (KB)                   = 1608436
+  0: The total amount of wall time                        = 169.009420
+  0: The maximum resident set size (KB)                   = 1603860
 
 Test 045 control_p8_mynn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/merra2_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/merra2_thompson
 Checking test 046 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2287,14 +2287,14 @@ Checking test 046 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.670516
-  0: The maximum resident set size (KB)                   = 1615628
+  0: The total amount of wall time                        = 189.068260
+  0: The maximum resident set size (KB)                   = 1614860
 
 Test 046 merra2_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_control
 Checking test 047 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2305,28 +2305,28 @@ Checking test 047 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 297.668338
-  0: The maximum resident set size (KB)                   = 876716
+  0: The total amount of wall time                        = 296.007375
+  0: The maximum resident set size (KB)                   = 874304
 
 Test 047 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_restart
 Checking test 048 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 154.031444
-  0: The maximum resident set size (KB)                   = 863088
+  0: The total amount of wall time                        = 150.719031
+  0: The maximum resident set size (KB)                   = 866744
 
 Test 048 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_control_qr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_control_qr
 Checking test 049 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2337,28 +2337,28 @@ Checking test 049 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 297.802342
-  0: The maximum resident set size (KB)                   = 873208
+  0: The total amount of wall time                        = 297.018613
+  0: The maximum resident set size (KB)                   = 872544
 
 Test 049 regional_control_qr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_restart_qr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_restart_qr
 Checking test 050 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 152.794969
-  0: The maximum resident set size (KB)                   = 869480
+  0: The total amount of wall time                        = 150.530008
+  0: The maximum resident set size (KB)                   = 862000
 
 Test 050 regional_restart_qr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_decomp
 Checking test 051 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2369,14 +2369,14 @@ Checking test 051 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 314.661253
-  0: The maximum resident set size (KB)                   = 865008
+  0: The total amount of wall time                        = 313.345722
+  0: The maximum resident set size (KB)                   = 864472
 
 Test 051 regional_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2387,14 +2387,14 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 178.943816
-  0: The maximum resident set size (KB)                   = 854956
+  0: The total amount of wall time                        = 181.054317
+  0: The maximum resident set size (KB)                   = 844288
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_noquilt
 Checking test 053 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2402,28 +2402,28 @@ Checking test 053 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 318.844697
-  0: The maximum resident set size (KB)                   = 861548
+  0: The total amount of wall time                        = 321.512538
+  0: The maximum resident set size (KB)                   = 863456
 
 Test 053 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_netcdf_parallel
 Checking test 054 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 292.084765
-  0: The maximum resident set size (KB)                   = 867952
+  0: The total amount of wall time                        = 292.951281
+  0: The maximum resident set size (KB)                   = 864192
 
 Test 054 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_2dwrtdecomp
 Checking test 055 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2434,14 +2434,14 @@ Checking test 055 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 301.160850
-  0: The maximum resident set size (KB)                   = 872540
+  0: The total amount of wall time                        = 296.993860
+  0: The maximum resident set size (KB)                   = 871536
 
 Test 055 regional_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_wofs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/fv3_regional_wofs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_wofs
 Checking test 056 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2452,14 +2452,14 @@ Checking test 056 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 375.506937
-  0: The maximum resident set size (KB)                   = 632796
+  0: The total amount of wall time                        = 375.833207
+  0: The maximum resident set size (KB)                   = 630572
 
 Test 056 regional_wofs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_control
 Checking test 057 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2506,14 +2506,14 @@ Checking test 057 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.225423
-  0: The maximum resident set size (KB)                   = 1059308
+  0: The total amount of wall time                        = 458.249343
+  0: The maximum resident set size (KB)                   = 1066044
 
 Test 057 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_spp_sppt_shum_skeb
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_spp_sppt_shum_skeb
 Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2524,14 +2524,14 @@ Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 235.332948
-  0: The maximum resident set size (KB)                   = 1180760
+  0: The total amount of wall time                        = 234.429240
+  0: The maximum resident set size (KB)                   = 1175760
 
 Test 058 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_decomp
 Checking test 059 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2578,14 +2578,14 @@ Checking test 059 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 477.119009
-  0: The maximum resident set size (KB)                   = 1007116
+  0: The total amount of wall time                        = 476.334710
+  0: The maximum resident set size (KB)                   = 1003136
 
 Test 059 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_2threads
 Checking test 060 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2632,14 +2632,14 @@ Checking test 060 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 432.691719
-  0: The maximum resident set size (KB)                   = 1134436
+  0: The total amount of wall time                        = 433.148054
+  0: The maximum resident set size (KB)                   = 1139048
 
 Test 060 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_restart
 Checking test 061 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2678,14 +2678,14 @@ Checking test 061 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.021583
-  0: The maximum resident set size (KB)                   = 967724
+  0: The total amount of wall time                        = 231.352354
+  0: The maximum resident set size (KB)                   = 970732
 
 Test 061 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_sfcdiff
 Checking test 062 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2732,14 +2732,14 @@ Checking test 062 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.889196
-  0: The maximum resident set size (KB)                   = 1067168
+  0: The total amount of wall time                        = 458.052173
+  0: The maximum resident set size (KB)                   = 1057484
 
 Test 062 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_sfcdiff_decomp
 Checking test 063 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2786,14 +2786,14 @@ Checking test 063 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 481.149516
-  0: The maximum resident set size (KB)                   = 1000992
+  0: The total amount of wall time                        = 479.726408
+  0: The maximum resident set size (KB)                   = 996168
 
 Test 063 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_sfcdiff_restart
 Checking test 064 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2832,14 +2832,14 @@ Checking test 064 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.125395
-  0: The maximum resident set size (KB)                   = 993068
+  0: The total amount of wall time                        = 339.573838
+  0: The maximum resident set size (KB)                   = 986580
 
 Test 064 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control
 Checking test 065 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2886,14 +2886,14 @@ Checking test 065 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 444.107914
-  0: The maximum resident set size (KB)                   = 1050184
+  0: The total amount of wall time                        = 442.601783
+  0: The maximum resident set size (KB)                   = 1058936
 
 Test 065 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_decomp
 Checking test 066 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2940,14 +2940,14 @@ Checking test 066 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.210825
-  0: The maximum resident set size (KB)                   = 997544
+  0: The total amount of wall time                        = 462.160831
+  0: The maximum resident set size (KB)                   = 998260
 
 Test 066 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_2threads
 Checking test 067 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2994,14 +2994,14 @@ Checking test 067 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 418.034122
-  0: The maximum resident set size (KB)                   = 1135012
+  0: The total amount of wall time                        = 419.004809
+  0: The maximum resident set size (KB)                   = 1135728
 
 Test 067 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_restart
 Checking test 068 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3040,14 +3040,14 @@ Checking test 068 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 329.498235
-  0: The maximum resident set size (KB)                   = 987852
+  0: The total amount of wall time                        = 328.716767
+  0: The maximum resident set size (KB)                   = 986024
 
 Test 068 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_v1beta
 Checking test 069 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3094,14 +3094,14 @@ Checking test 069 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 453.959161
-  0: The maximum resident set size (KB)                   = 1055304
+  0: The total amount of wall time                        = 455.688055
+  0: The maximum resident set size (KB)                   = 1057156
 
 Test 069 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_v1nssl
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_v1nssl
 Checking test 070 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3116,14 +3116,14 @@ Checking test 070 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 534.482871
-  0: The maximum resident set size (KB)                   = 690512
+  0: The total amount of wall time                        = 532.258948
+  0: The maximum resident set size (KB)                   = 693956
 
 Test 070 rrfs_v1nssl PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_v1nssl_nohailnoccn
 Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3138,14 +3138,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 521.798147
-  0: The maximum resident set size (KB)                   = 758636
+  0: The total amount of wall time                        = 522.922134
+  0: The maximum resident set size (KB)                   = 758024
 
 Test 071 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_smoke_conus13km_hrrr_warm
 Checking test 072 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3154,14 +3154,14 @@ Checking test 072 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 146.167810
-  0: The maximum resident set size (KB)                   = 1031648
+  0: The total amount of wall time                        = 146.516925
+  0: The maximum resident set size (KB)                   = 1038608
 
 Test 072 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3170,14 +3170,14 @@ Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 91.501532
-  0: The maximum resident set size (KB)                   = 941924
+  0: The total amount of wall time                        = 90.510525
+  0: The maximum resident set size (KB)                   = 943352
 
 Test 073 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_conus13km_hrrr_warm
 Checking test 074 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3186,14 +3186,14 @@ Checking test 074 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 129.583161
-  0: The maximum resident set size (KB)                   = 943912
+  0: The total amount of wall time                        = 130.346976
+  0: The maximum resident set size (KB)                   = 944028
 
 Test 074 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 075 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3202,26 +3202,26 @@ Checking test 075 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 146.323854
-  0: The maximum resident set size (KB)                   = 1038260
+  0: The total amount of wall time                        = 147.084007
+  0: The maximum resident set size (KB)                   = 1039300
 
 Test 075 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 076 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 71.319471
-  0: The maximum resident set size (KB)                   = 932116
+  0: The total amount of wall time                        = 67.981284
+  0: The maximum resident set size (KB)                   = 934508
 
 Test 076 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_csawmg
 Checking test 077 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3232,14 +3232,14 @@ Checking test 077 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 341.753268
-  0: The maximum resident set size (KB)                   = 723484
+  0: The total amount of wall time                        = 341.526716
+  0: The maximum resident set size (KB)                   = 727156
 
 Test 077 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_csawmgt
 Checking test 078 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3250,14 +3250,14 @@ Checking test 078 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 336.858079
-  0: The maximum resident set size (KB)                   = 726444
+  0: The total amount of wall time                        = 337.254188
+  0: The maximum resident set size (KB)                   = 723452
 
 Test 078 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_ras
 Checking test 079 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3268,26 +3268,26 @@ Checking test 079 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 180.367357
-  0: The maximum resident set size (KB)                   = 720068
+  0: The total amount of wall time                        = 180.318165
+  0: The maximum resident set size (KB)                   = 720664
 
 Test 079 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_wam
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_wam
 Checking test 080 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 112.014470
-  0: The maximum resident set size (KB)                   = 633964
+  0: The total amount of wall time                        = 112.550827
+  0: The maximum resident set size (KB)                   = 643132
 
 Test 080 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_p8_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_p8_faster
 Checking test 081 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3334,14 +3334,14 @@ Checking test 081 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 157.499868
-  0: The maximum resident set size (KB)                   = 1608568
+  0: The total amount of wall time                        = 150.458677
+  0: The maximum resident set size (KB)                   = 1611716
 
 Test 081 control_p8_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_control_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_control_faster
 Checking test 082 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3352,56 +3352,56 @@ Checking test 082 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 272.776973
-  0: The maximum resident set size (KB)                   = 870020
+  0: The total amount of wall time                        = 271.447110
+  0: The maximum resident set size (KB)                   = 869852
 
 Test 082 regional_control_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 837.710450
-  0: The maximum resident set size (KB)                   = 1068356
+  0: The total amount of wall time                        = 834.970575
+  0: The maximum resident set size (KB)                   = 1069808
 
 Test 083 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 477.884701
-  0: The maximum resident set size (KB)                   = 979496
+  0: The total amount of wall time                        = 468.920189
+  0: The maximum resident set size (KB)                   = 975952
 
 Test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_conus13km_hrrr_warm_debug
 Checking test 085 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 753.157060
-  0: The maximum resident set size (KB)                   = 978508
+  0: The total amount of wall time                        = 745.942670
+  0: The maximum resident set size (KB)                   = 976964
 
 Test 085 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_CubedSphereGrid_debug
 Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3428,334 +3428,334 @@ Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.905093
-  0: The maximum resident set size (KB)                   = 794816
+  0: The total amount of wall time                        = 160.855859
+  0: The maximum resident set size (KB)                   = 801672
 
 Test 086 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_wrtGauss_netcdf_parallel_debug
 Checking test 087 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.042585
-  0: The maximum resident set size (KB)                   = 799048
+  0: The total amount of wall time                        = 152.584509
+  0: The maximum resident set size (KB)                   = 800264
 
 Test 087 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_stochy_debug
 Checking test 088 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.171937
-  0: The maximum resident set size (KB)                   = 798988
+  0: The total amount of wall time                        = 168.537354
+  0: The maximum resident set size (KB)                   = 805240
 
 Test 088 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_lndp_debug
 Checking test 089 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.281131
-  0: The maximum resident set size (KB)                   = 798784
+  0: The total amount of wall time                        = 153.889298
+  0: The maximum resident set size (KB)                   = 797004
 
 Test 089 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_csawmg_debug
 Checking test 090 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.504297
-  0: The maximum resident set size (KB)                   = 845812
+  0: The total amount of wall time                        = 228.904061
+  0: The maximum resident set size (KB)                   = 846168
 
 Test 090 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_csawmgt_debug
 Checking test 091 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 230.148925
-  0: The maximum resident set size (KB)                   = 847064
+  0: The total amount of wall time                        = 230.273245
+  0: The maximum resident set size (KB)                   = 844856
 
 Test 091 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_ras_debug
 Checking test 092 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.327677
-  0: The maximum resident set size (KB)                   = 806276
+  0: The total amount of wall time                        = 153.966954
+  0: The maximum resident set size (KB)                   = 812240
 
 Test 092 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_diag_debug
 Checking test 093 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.481968
-  0: The maximum resident set size (KB)                   = 854868
+  0: The total amount of wall time                        = 159.835089
+  0: The maximum resident set size (KB)                   = 859352
 
 Test 093 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_debug_p8
 Checking test 094 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.820090
-  0: The maximum resident set size (KB)                   = 1630396
+  0: The total amount of wall time                        = 170.963516
+  0: The maximum resident set size (KB)                   = 1620556
 
 Test 094 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_debug
 Checking test 095 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 974.899857
-  0: The maximum resident set size (KB)                   = 886896
+  0: The total amount of wall time                        = 980.200353
+  0: The maximum resident set size (KB)                   = 887304
 
 Test 095 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_control_debug
 Checking test 096 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.877924
-  0: The maximum resident set size (KB)                   = 1172556
+  0: The total amount of wall time                        = 271.618182
+  0: The maximum resident set size (KB)                   = 1177116
 
 Test 096 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_debug
 Checking test 097 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.566652
-  0: The maximum resident set size (KB)                   = 1180064
+  0: The total amount of wall time                        = 268.658404
+  0: The maximum resident set size (KB)                   = 1173640
 
 Test 097 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_unified_drag_suite_debug
 Checking test 098 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.198378
-  0: The maximum resident set size (KB)                   = 1174232
+  0: The total amount of wall time                        = 274.404145
+  0: The maximum resident set size (KB)                   = 1173260
 
 Test 098 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_diag_debug
 Checking test 099 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.845498
-  0: The maximum resident set size (KB)                   = 1258216
+  0: The total amount of wall time                        = 289.438244
+  0: The maximum resident set size (KB)                   = 1258664
 
 Test 099 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_cires_ugwp_debug
 Checking test 100 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.074067
-  0: The maximum resident set size (KB)                   = 1174024
+  0: The total amount of wall time                        = 278.541826
+  0: The maximum resident set size (KB)                   = 1176192
 
 Test 100 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_unified_ugwp_debug
 Checking test 101 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.193340
-  0: The maximum resident set size (KB)                   = 1174808
+  0: The total amount of wall time                        = 280.236138
+  0: The maximum resident set size (KB)                   = 1176048
 
 Test 101 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_lndp_debug
 Checking test 102 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.270038
-  0: The maximum resident set size (KB)                   = 1179072
+  0: The total amount of wall time                        = 275.478989
+  0: The maximum resident set size (KB)                   = 1173496
 
 Test 102 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_flake_debug
 Checking test 103 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.376207
-  0: The maximum resident set size (KB)                   = 1178232
+  0: The total amount of wall time                        = 274.002116
+  0: The maximum resident set size (KB)                   = 1171912
 
 Test 103 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_progcld_thompson_debug
 Checking test 104 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.877637
-  0: The maximum resident set size (KB)                   = 1177216
+  0: The total amount of wall time                        = 279.954785
+  0: The maximum resident set size (KB)                   = 1172860
 
 Test 104 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_noah_debug
 Checking test 105 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.897488
-  0: The maximum resident set size (KB)                   = 1174928
+  0: The total amount of wall time                        = 271.809237
+  0: The maximum resident set size (KB)                   = 1175356
 
 Test 105 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_sfcdiff_debug
 Checking test 106 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.002592
-  0: The maximum resident set size (KB)                   = 1174732
+  0: The total amount of wall time                        = 274.810854
+  0: The maximum resident set size (KB)                   = 1175724
 
 Test 106 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 107 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 449.872032
-  0: The maximum resident set size (KB)                   = 1168400
+  0: The total amount of wall time                        = 451.872507
+  0: The maximum resident set size (KB)                   = 1175824
 
 Test 107 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rrfs_v1beta_debug
 Checking test 108 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.633938
-  0: The maximum resident set size (KB)                   = 1172984
+  0: The total amount of wall time                        = 267.843711
+  0: The maximum resident set size (KB)                   = 1169632
 
 Test 108 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_wam_debug
 Checking test 109 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 282.035872
-  0: The maximum resident set size (KB)                   = 523900
+  0: The total amount of wall time                        = 284.932301
+  0: The maximum resident set size (KB)                   = 540208
 
 Test 109 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3766,14 +3766,14 @@ Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 216.555576
-  0: The maximum resident set size (KB)                   = 1082064
+  0: The total amount of wall time                        = 217.017312
+  0: The maximum resident set size (KB)                   = 1079716
 
 Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_control_dyn32_phy32
 Checking test 111 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3820,14 +3820,14 @@ Checking test 111 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 380.631925
-  0: The maximum resident set size (KB)                   = 1001632
+  0: The total amount of wall time                        = 379.613457
+  0: The maximum resident set size (KB)                   = 993452
 
 Test 111 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_dyn32_phy32
 Checking test 112 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3874,14 +3874,14 @@ Checking test 112 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.997473
-  0: The maximum resident set size (KB)                   = 963560
+  0: The total amount of wall time                        = 198.800738
+  0: The maximum resident set size (KB)                   = 958324
 
 Test 112 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_2threads_dyn32_phy32
 Checking test 113 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3928,14 +3928,14 @@ Checking test 113 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 362.392862
-  0: The maximum resident set size (KB)                   = 1025948
+  0: The total amount of wall time                        = 363.952191
+  0: The maximum resident set size (KB)                   = 1019132
 
 Test 113 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_2threads_dyn32_phy32
 Checking test 114 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3982,14 +3982,14 @@ Checking test 114 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 186.947364
-  0: The maximum resident set size (KB)                   = 1002496
+  0: The total amount of wall time                        = 187.909148
+  0: The maximum resident set size (KB)                   = 997848
 
 Test 114 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_decomp_dyn32_phy32
 Checking test 115 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4036,14 +4036,14 @@ Checking test 115 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 208.743091
-  0: The maximum resident set size (KB)                   = 897864
+  0: The total amount of wall time                        = 208.353864
+  0: The maximum resident set size (KB)                   = 902328
 
 Test 115 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_restart_dyn32_phy32
 Checking test 116 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4082,14 +4082,14 @@ Checking test 116 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 281.618075
-  0: The maximum resident set size (KB)                   = 945512
+  0: The total amount of wall time                        = 285.484945
+  0: The maximum resident set size (KB)                   = 946908
 
 Test 116 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_restart_dyn32_phy32
 Checking test 117 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4128,14 +4128,14 @@ Checking test 117 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 103.784972
-  0: The maximum resident set size (KB)                   = 869908
+  0: The total amount of wall time                        = 102.948888
+  0: The maximum resident set size (KB)                   = 865148
 
 Test 117 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_control_dyn64_phy32
 Checking test 118 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4182,81 +4182,81 @@ Checking test 118 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 243.189858
-  0: The maximum resident set size (KB)                   = 964892
+  0: The total amount of wall time                        = 244.982774
+  0: The maximum resident set size (KB)                   = 965952
 
 Test 118 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_control_debug_dyn32_phy32
 Checking test 119 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.123720
-  0: The maximum resident set size (KB)                   = 1063760
+  0: The total amount of wall time                        = 269.678322
+  0: The maximum resident set size (KB)                   = 1062476
 
 Test 119 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hrrr_control_debug_dyn32_phy32
 Checking test 120 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.452259
-  0: The maximum resident set size (KB)                   = 1058328
+  0: The total amount of wall time                        = 263.957398
+  0: The maximum resident set size (KB)                   = 1064016
 
 Test 120 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/rap_control_dyn64_phy32_debug
 Checking test 121 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.460212
-  0: The maximum resident set size (KB)                   = 1098164
+  0: The total amount of wall time                        = 277.893806
+  0: The maximum resident set size (KB)                   = 1103676
 
 Test 121 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_atm
 Checking test 122 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 237.568373
-  0: The maximum resident set size (KB)                   = 1058392
+  0: The total amount of wall time                        = 234.355735
+  0: The maximum resident set size (KB)                   = 1049508
 
 Test 122 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_atm_thompson_gfdlsf
 Checking test 123 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 311.366199
-  0: The maximum resident set size (KB)                   = 1419044
+  0: The total amount of wall time                        = 315.191707
+  0: The maximum resident set size (KB)                   = 1419376
 
 Test 123 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_atm_ocn
 Checking test 124 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4265,30 +4265,30 @@ Checking test 124 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 381.833077
-  0: The maximum resident set size (KB)                   = 1232756
+  0: The total amount of wall time                        = 380.195568
+  0: The maximum resident set size (KB)                   = 1224544
 
 Test 124 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_atm_wav
 Checking test 125 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 737.591779
-  0: The maximum resident set size (KB)                   = 1255696
+  0: The total amount of wall time                        = 741.116061
+  0: The maximum resident set size (KB)                   = 1249796
 
 Test 125 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_atm_ocn_wav
 Checking test 126 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4296,31 +4296,31 @@ Checking test 126 hafs_regional_atm_ocn_wav results ....
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 841.617142
-  0: The maximum resident set size (KB)                   = 1276068
+  0: The total amount of wall time                        = 839.078845
+  0: The maximum resident set size (KB)                   = 1268888
 
 Test 126 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_1nest_atm
 Checking test 127 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 321.306505
-  0: The maximum resident set size (KB)                   = 506028
+  0: The total amount of wall time                        = 317.316864
+  0: The maximum resident set size (KB)                   = 514292
 
 Test 127 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_telescopic_2nests_atm
 Checking test 128 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4329,28 +4329,28 @@ Checking test 128 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 364.693803
-  0: The maximum resident set size (KB)                   = 514736
+  0: The total amount of wall time                        = 363.203838
+  0: The maximum resident set size (KB)                   = 518172
 
 Test 128 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_global_1nest_atm
 Checking test 129 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 149.693287
-  0: The maximum resident set size (KB)                   = 355780
+  0: The total amount of wall time                        = 146.105843
+  0: The maximum resident set size (KB)                   = 354096
 
 Test 129 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_global_multiple_4nests_atm
 Checking test 130 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4368,14 +4368,14 @@ Checking test 130 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 409.230555
-  0: The maximum resident set size (KB)                   = 425072
+  0: The total amount of wall time                        = 411.896821
+  0: The maximum resident set size (KB)                   = 423080
 
 Test 130 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_specified_moving_1nest_atm
 Checking test 131 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4384,28 +4384,28 @@ Checking test 131 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 202.639692
-  0: The maximum resident set size (KB)                   = 520564
+  0: The total amount of wall time                        = 201.637041
+  0: The maximum resident set size (KB)                   = 520636
 
 Test 131 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_storm_following_1nest_atm
 Checking test 132 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 191.183657
-  0: The maximum resident set size (KB)                   = 521500
+  0: The total amount of wall time                        = 190.846695
+  0: The maximum resident set size (KB)                   = 527188
 
 Test 132 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 133 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4414,42 +4414,42 @@ Checking test 133 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 221.671687
-  0: The maximum resident set size (KB)                   = 568856
+  0: The total amount of wall time                        = 224.090380
+  0: The maximum resident set size (KB)                   = 563576
 
 Test 133 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_global_storm_following_1nest_atm
 Checking test 134 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 58.609290
-  0: The maximum resident set size (KB)                   = 372860
+  0: The total amount of wall time                        = 58.031765
+  0: The maximum resident set size (KB)                   = 367180
 
 Test 134 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 771.578917
-  0: The maximum resident set size (KB)                   = 588124
+  0: The total amount of wall time                        = 765.717282
+  0: The maximum resident set size (KB)                   = 586764
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 136 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4460,14 +4460,14 @@ Checking test 136 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 480.566906
-  0: The maximum resident set size (KB)                   = 619888
+  0: The total amount of wall time                        = 481.320400
+  0: The maximum resident set size (KB)                   = 620324
 
 Test 136 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_docn
 Checking test 137 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4475,14 +4475,14 @@ Checking test 137 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 356.149539
-  0: The maximum resident set size (KB)                   = 1226904
+  0: The total amount of wall time                        = 359.508074
+  0: The maximum resident set size (KB)                   = 1227588
 
 Test 137 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_docn_oisst
 Checking test 138 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4490,131 +4490,131 @@ Checking test 138 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 356.346451
-  0: The maximum resident set size (KB)                   = 1214696
+  0: The total amount of wall time                        = 358.875071
+  0: The maximum resident set size (KB)                   = 1214276
 
 Test 138 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/hafs_regional_datm_cdeps
 Checking test 139 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 946.032996
-  0: The maximum resident set size (KB)                   = 1041360
+  0: The total amount of wall time                        = 966.754142
+  0: The maximum resident set size (KB)                   = 1039876
 
 Test 139 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_control_cfsr
 Checking test 140 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.205284
- 0: The maximum resident set size (KB)                   = 1058680
+ 0: The total amount of wall time                        = 156.564583
+ 0: The maximum resident set size (KB)                   = 1057280
 
 Test 140 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_restart_cfsr
 Checking test 141 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 93.463391
- 0: The maximum resident set size (KB)                   = 1044932
+ 0: The total amount of wall time                        = 92.833064
+ 0: The maximum resident set size (KB)                   = 1011248
 
 Test 141 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_control_gefs
 Checking test 142 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.361499
- 0: The maximum resident set size (KB)                   = 958508
+ 0: The total amount of wall time                        = 148.047662
+ 0: The maximum resident set size (KB)                   = 970016
 
 Test 142 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_iau_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_iau_gefs
 Checking test 143 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.962982
- 0: The maximum resident set size (KB)                   = 967132
+ 0: The total amount of wall time                        = 154.276007
+ 0: The maximum resident set size (KB)                   = 961688
 
 Test 143 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_stochy_gefs
 Checking test 144 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.861041
- 0: The maximum resident set size (KB)                   = 965964
+ 0: The total amount of wall time                        = 146.848732
+ 0: The maximum resident set size (KB)                   = 960584
 
 Test 144 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_ciceC_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_ciceC_cfsr
 Checking test 145 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.588802
- 0: The maximum resident set size (KB)                   = 1069640
+ 0: The total amount of wall time                        = 154.200763
+ 0: The maximum resident set size (KB)                   = 1059680
 
 Test 145 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_bulk_cfsr
 Checking test 146 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.782699
- 0: The maximum resident set size (KB)                   = 1058832
+ 0: The total amount of wall time                        = 154.384076
+ 0: The maximum resident set size (KB)                   = 1083480
 
 Test 146 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_bulk_gefs
 Checking test 147 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.275618
- 0: The maximum resident set size (KB)                   = 968228
+ 0: The total amount of wall time                        = 146.993248
+ 0: The maximum resident set size (KB)                   = 964212
 
 Test 147 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_mx025_cfsr
 Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4623,14 +4623,14 @@ Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 395.320969
-  0: The maximum resident set size (KB)                   = 871536
+  0: The total amount of wall time                        = 398.522889
+  0: The maximum resident set size (KB)                   = 876200
 
 Test 148 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_mx025_gefs
 Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4639,77 +4639,77 @@ Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 397.332813
-  0: The maximum resident set size (KB)                   = 926324
+  0: The total amount of wall time                        = 397.380905
+  0: The maximum resident set size (KB)                   = 930916
 
 Test 149 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_multiple_files_cfsr
 Checking test 150 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.962135
- 0: The maximum resident set size (KB)                   = 1058548
+ 0: The total amount of wall time                        = 151.923359
+ 0: The maximum resident set size (KB)                   = 1067948
 
 Test 150 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_3072x1536_cfsr
 Checking test 151 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 218.111376
- 0: The maximum resident set size (KB)                   = 2369404
+ 0: The total amount of wall time                        = 226.633339
+ 0: The maximum resident set size (KB)                   = 2312280
 
 Test 151 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_gfs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_gfs
 Checking test 152 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 218.269599
- 0: The maximum resident set size (KB)                   = 2371852
+ 0: The total amount of wall time                        = 224.587144
+ 0: The maximum resident set size (KB)                   = 2371564
 
 Test 152 datm_cdeps_gfs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_debug_cfsr
 Checking test 153 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 446.786465
- 0: The maximum resident set size (KB)                   = 986876
+ 0: The total amount of wall time                        = 435.285204
+ 0: The maximum resident set size (KB)                   = 988204
 
 Test 153 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_control_cfsr_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_control_cfsr_faster
 Checking test 154 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.325956
- 0: The maximum resident set size (KB)                   = 1069960
+ 0: The total amount of wall time                        = 153.530364
+ 0: The maximum resident set size (KB)                   = 1062504
 
 Test 154 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_lnd_gswp3
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_lnd_gswp3
 Checking test 155 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4718,14 +4718,14 @@ Checking test 155 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 7.215629
-  0: The maximum resident set size (KB)                   = 267328
+  0: The total amount of wall time                        = 6.730492
+  0: The maximum resident set size (KB)                   = 264260
 
 Test 155 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/datm_cdeps_lnd_gswp3_rst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/datm_cdeps_lnd_gswp3_rst
 Checking test 156 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4734,14 +4734,14 @@ Checking test 156 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.704865
-  0: The maximum resident set size (KB)                   = 273436
+  0: The total amount of wall time                        = 11.876085
+  0: The maximum resident set size (KB)                   = 263812
 
 Test 156 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_p8_atmlnd_sbs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_p8_atmlnd_sbs
 Checking test 157 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4826,14 +4826,14 @@ Checking test 157 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.120558
-  0: The maximum resident set size (KB)                   = 1615716
+  0: The total amount of wall time                        = 203.914941
+  0: The maximum resident set size (KB)                   = 1608840
 
 Test 157 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/control_atmwav
 Checking test 158 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4877,14 +4877,14 @@ Checking test 158 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 87.233602
-  0: The maximum resident set size (KB)                   = 663416
+  0: The total amount of wall time                        = 89.345755
+  0: The maximum resident set size (KB)                   = 660424
 
 Test 158 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/atmaero_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/atmaero_control_p8
 Checking test 159 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4928,14 +4928,14 @@ Checking test 159 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 230.974139
-  0: The maximum resident set size (KB)                   = 2977544
+  0: The total amount of wall time                        = 229.203582
+  0: The maximum resident set size (KB)                   = 2975592
 
 Test 159 atmaero_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/atmaero_control_p8_rad
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/atmaero_control_p8_rad
 Checking test 160 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4979,14 +4979,14 @@ Checking test 160 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 284.232167
-  0: The maximum resident set size (KB)                   = 3045920
+  0: The total amount of wall time                        = 280.859474
+  0: The maximum resident set size (KB)                   = 3042772
 
 Test 160 atmaero_control_p8_rad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad_micro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/atmaero_control_p8_rad_micro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/atmaero_control_p8_rad_micro
 Checking test 161 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5030,14 +5030,14 @@ Checking test 161 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 284.843515
-  0: The maximum resident set size (KB)                   = 3054668
+  0: The total amount of wall time                        = 286.106403
+  0: The maximum resident set size (KB)                   = 3053204
 
 Test 161 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_atmaq
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_atmaq
 Checking test 162 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5053,14 +5053,14 @@ Checking test 162 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 631.002126
-  0: The maximum resident set size (KB)                   = 1468172
+  0: The total amount of wall time                        = 628.654072
+  0: The maximum resident set size (KB)                   = 1469524
 
 Test 162 regional_atmaq PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_atmaq_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_atmaq_debug
 Checking test 163 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5074,14 +5074,14 @@ Checking test 163 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1208.023667
-  0: The maximum resident set size (KB)                   = 1399224
+  0: The total amount of wall time                        = 1226.243789
+  0: The maximum resident set size (KB)                   = 1398516
 
 Test 163 regional_atmaq_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4096/regional_atmaq_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_faster
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_21228/regional_atmaq_faster
 Checking test 164 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5097,12 +5097,12 @@ Checking test 164 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 558.602729
-  0: The maximum resident set size (KB)                   = 1471224
+  0: The total amount of wall time                        = 549.265792
+  0: The maximum resident set size (KB)                   = 1473148
 
 Test 164 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 15:15:27 UTC 2023
-Elapsed time: 01h:11m:31s. Have a nice day!
+Sun Apr  2 13:57:15 UTC 2023
+Elapsed time: 01h:12m:42s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,43 +1,42 @@
-Fri Mar 31 12:35:21 UTC 2023
+Mon Apr  3 01:00:27 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 1953 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 1891 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 1860 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 004 elapsed time 360 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 277 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1521 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 007 elapsed time 1548 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 008 elapsed time 3371 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 009 elapsed time 1690 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 010 elapsed time 1615 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1530 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 1440 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 013 elapsed time 2052 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 330 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 280 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 1460 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 017 elapsed time 1462 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 018 elapsed time 272 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 286 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 1728 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 021 elapsed time 309 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 2134 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 023 elapsed time 1643 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 024 elapsed time 320 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 025 elapsed time 149 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 312 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 027 elapsed time 117 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 028 elapsed time 1512 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 029 elapsed time 1738 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 030 elapsed time 1508 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 031 elapsed time 1448 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 032 elapsed time 312 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 033 elapsed time 1897 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 2268 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2177 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 1861 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 004 elapsed time 522 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 423 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1936 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1812 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 008 elapsed time 3552 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 009 elapsed time 2267 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 010 elapsed time 1861 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1703 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 1932 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 2421 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 671 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 548 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 1621 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 017 elapsed time 1629 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 018 elapsed time 481 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 464 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 1822 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 021 elapsed time 457 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 2341 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 023 elapsed time 1777 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 024 elapsed time 377 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 025 elapsed time 295 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 417 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 027 elapsed time 180 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 028 elapsed time 1776 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 029 elapsed time 1897 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 030 elapsed time 1861 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 031 elapsed time 1846 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 032 elapsed time 883 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 033 elapsed time 2301 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_p8_mixedmode
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -102,14 +101,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 595.407630
-  0: The maximum resident set size (KB)                   = 1731236
+  0: The total amount of wall time                        = 1187.930317
+  0: The maximum resident set size (KB)                   = 1730264
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_gfsv17
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_gfsv17
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_gfsv17
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -173,14 +172,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 427.951826
-  0: The maximum resident set size (KB)                   = 1615920
+  0: The total amount of wall time                        = 916.636491
+  0: The maximum resident set size (KB)                   = 1650456
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -245,14 +244,74 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 636.404599
-  0: The maximum resident set size (KB)                   = 1782580
+  0: The total amount of wall time                        = 1280.155259
+  0: The maximum resident set size (KB)                   = 1776512
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_qr_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_restart_p8
+Checking test 004 cpld_restart_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 600.467909
+  0: The maximum resident set size (KB)                   = 1486268
+
+Test 004 cpld_restart_p8 PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -317,14 +376,74 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 622.572282
-  0: The maximum resident set size (KB)                   = 1789684
+  0: The total amount of wall time                        = 1240.675889
+  0: The maximum resident set size (KB)                   = 1788000
 
-Test 005 cpld_control_qr_p8 PASS
+Test 005 cpld_control_qr_p8 PASS Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_2threads_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_restart_qr_p8
+Checking test 006 cpld_restart_qr_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 839.574368
+  0: The maximum resident set size (KB)                   = 1509920
+
+Test 006 cpld_restart_qr_p8 PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -377,14 +496,74 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 635.956681
-  0: The maximum resident set size (KB)                   = 1987396
+  0: The total amount of wall time                        = 1283.780577
+  0: The maximum resident set size (KB)                   = 1971376
 
-Test 007 cpld_2threads_p8 PASS
+Test 007 cpld_2threads_p8 PASS Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_mpi_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_decomp_p8
+Checking test 008 cpld_decomp_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 1247.443273
+  0: The maximum resident set size (KB)                   = 1772096
+
+Test 008 cpld_decomp_p8 PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -437,14 +616,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 530.467054
-  0: The maximum resident set size (KB)                   = 1722276
+  0: The total amount of wall time                        = 1179.188373
+  0: The maximum resident set size (KB)                   = 1727404
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_ciceC_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -509,14 +688,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 633.921824
-  0: The maximum resident set size (KB)                   = 1770996
+  0: The total amount of wall time                        = 1216.069211
+  0: The maximum resident set size (KB)                   = 1777828
 
-Test 010 cpld_control_ciceC_p8 PASS
+Test 010 cpld_control_ciceC_p8 PASS Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_noaero_p8
 Checking test 011 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -580,14 +759,14 @@ Checking test 011 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 515.098230
-  0: The maximum resident set size (KB)                   = 1624092
+  0: The total amount of wall time                        = 1487.954656
+  0: The maximum resident set size (KB)                   = 1622860
 
 Test 011 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_nowave_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_nowave_noaero_p8
 Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -649,14 +828,14 @@ Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 477.928168
-  0: The maximum resident set size (KB)                   = 1687096
+  0: The total amount of wall time                        = 1366.201451
+  0: The maximum resident set size (KB)                   = 1665832
 
 Test 012 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_debug_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_debug_p8
 Checking test 013 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -709,14 +888,14 @@ Checking test 013 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 897.751246
-  0: The maximum resident set size (KB)                   = 1821340
+  0: The total amount of wall time                        = 1512.437780
+  0: The maximum resident set size (KB)                   = 1824908
 
 Test 013 cpld_debug_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_debug_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_debug_noaero_p8
 Checking test 014 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -768,14 +947,83 @@ Checking test 014 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 577.139379
-  0: The maximum resident set size (KB)                   = 1646368
+  0: The total amount of wall time                        = 873.652901
+  0: The maximum resident set size (KB)                   = 1644712
 
 Test 014 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_control_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_noaero_p8_agrid
+Checking test 015 cpld_control_noaero_p8_agrid results ....
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+
+  0: The total amount of wall time                        = 1239.448211
+  0: The maximum resident set size (KB)                   = 1678864
+
+Test 015 cpld_control_noaero_p8_agrid PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_c48
 Checking test 016 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -825,14 +1073,14 @@ Checking test 016 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 837.201729
- 0: The maximum resident set size (KB)                   = 2771852
+ 0: The total amount of wall time                        = 968.933952
+ 0: The maximum resident set size (KB)                   = 2765836
 
 Test 016 cpld_control_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_warmstart_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_warmstart_c48
 Checking test 017 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -882,14 +1130,14 @@ Checking test 017 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 296.463555
- 0: The maximum resident set size (KB)                   = 2773972
+ 0: The total amount of wall time                        = 480.357976
+ 0: The maximum resident set size (KB)                   = 2766188
 
 Test 017 cpld_warmstart_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_8217/cpld_restart_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_restart_c48
 Checking test 018 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -939,15 +1187,15 @@ Checking test 018 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 125.059309
- 0: The maximum resident set size (KB)                   = 2205008
+ 0: The total amount of wall time                        = 177.217862
+ 0: The maximum resident set size (KB)                   = 2214856
 
 Test 018 cpld_restart_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_faster
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/cpld_control_p8_faster
-Checking test 002 cpld_control_p8_faster results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/cpld_control_p8_faster
+Checking test 019 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -1011,15 +1259,15 @@ Checking test 002 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 619.710038
-  0: The maximum resident set size (KB)                   = 1770336
+  0: The total amount of wall time                        = 1101.113856
+  0: The maximum resident set size (KB)                   = 1766268
 
 Test 019 cpld_control_p8_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_CubedSphereGrid
-Checking test 003 control_CubedSphereGrid results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_CubedSphereGrid
+Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -1045,29 +1293,29 @@ Checking test 003 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 194.932107
-  0: The maximum resident set size (KB)                   = 576804
+  0: The total amount of wall time                        = 522.535248
+  0: The maximum resident set size (KB)                   = 578728
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_CubedSphereGrid_parallel
-Checking test 004 control_CubedSphereGrid_parallel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_CubedSphereGrid_parallel
+Checking test 021 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 202.331102
-  0: The maximum resident set size (KB)                   = 573980
+  0: The total amount of wall time                        = 546.257707
+  0: The maximum resident set size (KB)                   = 578996
 
 Test 021 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_latlon
-Checking test 005 control_latlon results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_latlon
+Checking test 022 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1077,15 +1325,15 @@ Checking test 005 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 206.514155
-  0: The maximum resident set size (KB)                   = 575808
+  0: The total amount of wall time                        = 514.637093
+  0: The maximum resident set size (KB)                   = 575924
 
 Test 022 control_latlon PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_wrtGauss_netcdf_parallel
-Checking test 006 control_wrtGauss_netcdf_parallel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_wrtGauss_netcdf_parallel
+Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1095,15 +1343,15 @@ Checking test 006 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 210.948046
-  0: The maximum resident set size (KB)                   = 574228
+  0: The total amount of wall time                        = 515.923199
+  0: The maximum resident set size (KB)                   = 572316
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_c48
-Checking test 007 control_c48 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_c48
+Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1141,15 +1389,15 @@ Checking test 007 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 596.310545
-0: The maximum resident set size (KB)                   = 799284
+0: The total amount of wall time                        = 654.328087
+0: The maximum resident set size (KB)                   = 800572
 
 Test 024 control_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_c192
-Checking test 008 control_c192 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_c192
+Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1159,33 +1407,17 @@ Checking test 008 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 787.298675
-  0: The maximum resident set size (KB)                   = 699836
+  0: The total amount of wall time                        = 1294.260751
+  0: The maximum resident set size (KB)                   = 693588
 
 Test 025 control_c192 PASS
 
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_c384
-Checking test 009 control_c384 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 1009.031262
-  0: The maximum resident set size (KB)                   = 1055132
-
-Test 026 control_c384 PASS
+Test 026 control_c384 FAIL
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_c384gdas
-Checking test 010 control_c384gdas results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_c384gdas
+Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1227,15 +1459,15 @@ Checking test 010 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 885.445769
-  0: The maximum resident set size (KB)                   = 1206400
+  0: The total amount of wall time                        = 1620.904775
+  0: The maximum resident set size (KB)                   = 1196284
 
-Test 027 control_c384gdas PASS
+Test 027 control_c384gdas PASS Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_stochy
-Checking test 011 control_stochy results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_stochy
+Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1245,29 +1477,29 @@ Checking test 011 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 143.603676
-  0: The maximum resident set size (KB)                   = 581708
+  0: The total amount of wall time                        = 382.389479
+  0: The maximum resident set size (KB)                   = 579404
 
 Test 028 control_stochy PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_stochy_restart
-Checking test 012 control_stochy_restart results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_stochy_restart
+Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.930431
-  0: The maximum resident set size (KB)                   = 398740
+  0: The total amount of wall time                        = 135.350117
+  0: The maximum resident set size (KB)                   = 400196
 
 Test 029 control_stochy_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_lndp
-Checking test 013 control_lndp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_lndp
+Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1277,15 +1509,15 @@ Checking test 013 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 119.719950
-  0: The maximum resident set size (KB)                   = 580052
+  0: The total amount of wall time                        = 317.662756
+  0: The maximum resident set size (KB)                   = 574408
 
 Test 030 control_lndp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_iovr4
-Checking test 014 control_iovr4 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_iovr4
+Checking test 031 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1299,15 +1531,15 @@ Checking test 014 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 206.800471
-  0: The maximum resident set size (KB)                   = 573676
+  0: The total amount of wall time                        = 493.044938
+  0: The maximum resident set size (KB)                   = 576556
 
 Test 031 control_iovr4 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_iovr5
-Checking test 015 control_iovr5 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_iovr5
+Checking test 032 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1321,15 +1553,15 @@ Checking test 015 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 222.000483
-  0: The maximum resident set size (KB)                   = 578056
+  0: The total amount of wall time                        = 465.193262
+  0: The maximum resident set size (KB)                   = 575844
 
 Test 032 control_iovr5 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_p8
-Checking test 016 control_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_p8
+Checking test 033 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1375,15 +1607,15 @@ Checking test 016 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.704609
-  0: The maximum resident set size (KB)                   = 1546392
+  0: The total amount of wall time                        = 422.211889
+  0: The maximum resident set size (KB)                   = 1536352
 
 Test 033 control_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_restart_p8
-Checking test 017 control_restart_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_restart_p8
+Checking test 034 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -1421,15 +1653,15 @@ Checking test 017 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.078086
-  0: The maximum resident set size (KB)                   = 768960
+  0: The total amount of wall time                        = 251.481896
+  0: The maximum resident set size (KB)                   = 768888
 
 Test 034 control_restart_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_qr_p8
-Checking test 018 control_qr_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_qr_p8
+Checking test 035 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1475,15 +1707,15 @@ Checking test 018 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 238.399766
-  0: The maximum resident set size (KB)                   = 1549848
+  0: The total amount of wall time                        = 425.992683
+  0: The maximum resident set size (KB)                   = 1540936
 
 Test 035 control_qr_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_restart_qr_p8
-Checking test 019 control_restart_qr_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_restart_qr_p8
+Checking test 036 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -1521,15 +1753,15 @@ Checking test 019 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 135.521741
-  0: The maximum resident set size (KB)                   = 786796
+  0: The total amount of wall time                        = 316.047884
+  0: The maximum resident set size (KB)                   = 782812
 
 Test 036 control_restart_qr_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_decomp_p8
-Checking test 020 control_decomp_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_decomp_p8
+Checking test 037 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1571,15 +1803,15 @@ Checking test 020 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 263.491154
-  0: The maximum resident set size (KB)                   = 1537276
+  0: The total amount of wall time                        = 355.275471
+  0: The maximum resident set size (KB)                   = 1526360
 
 Test 037 control_decomp_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_2threads_p8
-Checking test 021 control_2threads_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_2threads_p8
+Checking test 038 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1621,15 +1853,15 @@ Checking test 021 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.896138
-  0: The maximum resident set size (KB)                   = 1622388
+  0: The total amount of wall time                        = 338.266716
+  0: The maximum resident set size (KB)                   = 1616104
 
 Test 038 control_2threads_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_p8_lndp
-Checking test 022 control_p8_lndp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_p8_lndp
+Checking test 039 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1647,15 +1879,15 @@ Checking test 022 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 484.593778
-  0: The maximum resident set size (KB)                   = 1540220
+  0: The total amount of wall time                        = 728.032402
+  0: The maximum resident set size (KB)                   = 1548256
 
 Test 039 control_p8_lndp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_p8_rrtmgp
-Checking test 023 control_p8_rrtmgp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_p8_rrtmgp
+Checking test 040 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1701,15 +1933,15 @@ Checking test 023 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 337.428154
-  0: The maximum resident set size (KB)                   = 1600600
+  0: The total amount of wall time                        = 496.377064
+  0: The maximum resident set size (KB)                   = 1611220
 
 Test 040 control_p8_rrtmgp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_p8_mynn
-Checking test 024 control_p8_mynn results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_p8_mynn
+Checking test 041 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1755,15 +1987,15 @@ Checking test 024 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 251.577176
-  0: The maximum resident set size (KB)                   = 1541628
+  0: The total amount of wall time                        = 434.159855
+  0: The maximum resident set size (KB)                   = 1541684
 
 Test 041 control_p8_mynn PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/merra2_thompson
-Checking test 025 merra2_thompson results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/merra2_thompson
+Checking test 042 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1809,15 +2041,15 @@ Checking test 025 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 280.577029
-  0: The maximum resident set size (KB)                   = 1546412
+  0: The total amount of wall time                        = 464.032666
+  0: The maximum resident set size (KB)                   = 1546392
 
 Test 042 merra2_thompson PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_control
-Checking test 026 regional_control results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_control
+Checking test 043 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1827,29 +2059,29 @@ Checking test 026 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 453.843403
-  0: The maximum resident set size (KB)                   = 788828
+  0: The total amount of wall time                        = 815.399253
+  0: The maximum resident set size (KB)                   = 806372
 
 Test 043 regional_control PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_restart
-Checking test 027 regional_restart results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_restart
+Checking test 044 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 323.690033
-  0: The maximum resident set size (KB)                   = 780308
+  0: The total amount of wall time                        = 512.664229
+  0: The maximum resident set size (KB)                   = 778412
 
 Test 044 regional_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_control_qr
-Checking test 028 regional_control_qr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_control_qr
+Checking test 045 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1859,29 +2091,29 @@ Checking test 028 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 442.062738
-  0: The maximum resident set size (KB)                   = 786028
+  0: The total amount of wall time                        = 771.457145
+  0: The maximum resident set size (KB)                   = 787240
 
 Test 045 regional_control_qr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_restart_qr
-Checking test 029 regional_restart_qr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_restart_qr
+Checking test 046 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 310.400858
-  0: The maximum resident set size (KB)                   = 777676
+  0: The total amount of wall time                        = 397.328340
+  0: The maximum resident set size (KB)                   = 780692
 
 Test 046 regional_restart_qr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_decomp
-Checking test 030 regional_decomp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_decomp
+Checking test 047 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1891,15 +2123,15 @@ Checking test 030 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 455.664970
-  0: The maximum resident set size (KB)                   = 788656
+  0: The total amount of wall time                        = 837.775049
+  0: The maximum resident set size (KB)                   = 779828
 
 Test 047 regional_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_2threads
-Checking test 031 regional_2threads results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_2threads
+Checking test 048 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1909,44 +2141,44 @@ Checking test 031 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 305.136345
-  0: The maximum resident set size (KB)                   = 769228
+  0: The total amount of wall time                        = 666.038379
+  0: The maximum resident set size (KB)                   = 768460
 
 Test 048 regional_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_noquilt
-Checking test 032 regional_noquilt results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing fv3_history2d.nc .........OK
- Comparing fv3_history.nc .........OK
- Comparing RESTART/fv_core.res.tile1_new.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_noquilt
+Checking test 049 regional_noquilt results ....
+ Comparing atmos_4xdaily.nc ............MISSING baseline
+ Comparing fv3_history2d.nc ............MISSING baseline
+ Comparing fv3_history.nc ............MISSING baseline
+ Comparing RESTART/fv_core.res.tile1_new.nc ............MISSING baseline
+ Comparing RESTART/fv_tracer.res.tile1_new.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 472.639644
-  0: The maximum resident set size (KB)                   = 770096
+  0: The total amount of wall time                        = 969.146288
+  0: The maximum resident set size (KB)                   = 771376
 
-Test 049 regional_noquilt PASS
+Test 049 regional_noquilt FAIL Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_netcdf_parallel
-Checking test 033 regional_netcdf_parallel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_netcdf_parallel
+Checking test 050 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 437.654363
-  0: The maximum resident set size (KB)                   = 789036
+  0: The total amount of wall time                        = 836.130643
+  0: The maximum resident set size (KB)                   = 784280
 
 Test 050 regional_netcdf_parallel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_2dwrtdecomp
-Checking test 034 regional_2dwrtdecomp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_2dwrtdecomp
+Checking test 051 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1956,33 +2188,17 @@ Checking test 034 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 439.266588
-  0: The maximum resident set size (KB)                   = 789708
+  0: The total amount of wall time                        = 772.632845
+  0: The maximum resident set size (KB)                   = 788356
 
 Test 051 regional_2dwrtdecomp PASS
 
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_wofs
-Checking test 035 regional_wofs results ....
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF06 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF06 .........OK
-
-  0: The total amount of wall time                        = 612.688663
-  0: The maximum resident set size (KB)                   = 526352
-
-Test 052 regional_wofs PASS
+Test 052 regional_wofs FAIL
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_control
-Checking test 036 rap_control results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_control
+Checking test 053 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2028,15 +2244,15 @@ Checking test 036 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 674.206119
-  0: The maximum resident set size (KB)                   = 943820
+  0: The total amount of wall time                        = 1147.258431
+  0: The maximum resident set size (KB)                   = 945768
 
 Test 053 rap_control PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_spp_sppt_shum_skeb
-Checking test 037 regional_spp_sppt_shum_skeb results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_spp_sppt_shum_skeb
+Checking test 054 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2046,15 +2262,15 @@ Checking test 037 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 348.096794
-  0: The maximum resident set size (KB)                   = 1086980
+  0: The total amount of wall time                        = 694.206527
+  0: The maximum resident set size (KB)                   = 1088424
 
 Test 054 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_decomp
-Checking test 038 rap_decomp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_decomp
+Checking test 055 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2100,15 +2316,15 @@ Checking test 038 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 710.595181
-  0: The maximum resident set size (KB)                   = 939032
+  0: The total amount of wall time                        = 1239.675469
+  0: The maximum resident set size (KB)                   = 948828
 
 Test 055 rap_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_2threads
-Checking test 039 rap_2threads results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_2threads
+Checking test 056 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2154,15 +2370,15 @@ Checking test 039 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 663.631215
-  0: The maximum resident set size (KB)                   = 1018376
+  0: The total amount of wall time                        = 1399.832807
+  0: The maximum resident set size (KB)                   = 1019712
 
 Test 056 rap_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_restart
-Checking test 040 rap_restart results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_restart
+Checking test 057 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -2200,15 +2416,15 @@ Checking test 040 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 337.623719
-  0: The maximum resident set size (KB)                   = 829068
+  0: The total amount of wall time                        = 496.660531
+  0: The maximum resident set size (KB)                   = 824788
 
 Test 057 rap_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_sfcdiff
-Checking test 041 rap_sfcdiff results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_sfcdiff
+Checking test 058 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2254,15 +2470,15 @@ Checking test 041 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 782.869251
-  0: The maximum resident set size (KB)                   = 944636
+  0: The total amount of wall time                        = 1219.294640
+  0: The maximum resident set size (KB)                   = 940680
 
 Test 058 rap_sfcdiff PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_sfcdiff_decomp
-Checking test 042 rap_sfcdiff_decomp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_sfcdiff_decomp
+Checking test 059 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2308,15 +2524,15 @@ Checking test 042 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 847.825960
-  0: The maximum resident set size (KB)                   = 952680
+  0: The total amount of wall time                        = 1384.574240
+  0: The maximum resident set size (KB)                   = 931988
 
 Test 059 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_sfcdiff_restart
-Checking test 043 rap_sfcdiff_restart results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_sfcdiff_restart
+Checking test 060 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -2354,15 +2570,15 @@ Checking test 043 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 535.410987
-  0: The maximum resident set size (KB)                   = 831044
+  0: The total amount of wall time                        = 702.281542
+  0: The maximum resident set size (KB)                   = 838212
 
 Test 060 rap_sfcdiff_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control
-Checking test 044 hrrr_control results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control
+Checking test 061 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2408,15 +2624,15 @@ Checking test 044 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 771.939269
-  0: The maximum resident set size (KB)                   = 942156
+  0: The total amount of wall time                        = 1290.228603
+  0: The maximum resident set size (KB)                   = 941880
 
 Test 061 hrrr_control PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_decomp
-Checking test 045 hrrr_control_decomp results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_decomp
+Checking test 062 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2462,15 +2678,15 @@ Checking test 045 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 794.701459
-  0: The maximum resident set size (KB)                   = 938788
+  0: The total amount of wall time                        = 1266.546916
+  0: The maximum resident set size (KB)                   = 935644
 
 Test 062 hrrr_control_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_2threads
-Checking test 046 hrrr_control_2threads results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_2threads
+Checking test 063 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2516,15 +2732,15 @@ Checking test 046 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 763.113719
-  0: The maximum resident set size (KB)                   = 1012764
+  0: The total amount of wall time                        = 1248.876726
+  0: The maximum resident set size (KB)                   = 1021552
 
 Test 063 hrrr_control_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_restart
-Checking test 047 hrrr_control_restart results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_restart
+Checking test 064 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -2562,15 +2778,15 @@ Checking test 047 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 486.019593
-  0: The maximum resident set size (KB)                   = 828660
+  0: The total amount of wall time                        = 784.830135
+  0: The maximum resident set size (KB)                   = 830188
 
 Test 064 hrrr_control_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_v1beta
-Checking test 048 rrfs_v1beta results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_v1beta
+Checking test 065 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2616,15 +2832,15 @@ Checking test 048 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 772.333615
-  0: The maximum resident set size (KB)                   = 949860
+  0: The total amount of wall time                        = 1267.088003
+  0: The maximum resident set size (KB)                   = 941044
 
 Test 065 rrfs_v1beta PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_v1nssl
-Checking test 049 rrfs_v1nssl results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_v1nssl
+Checking test 066 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2638,15 +2854,15 @@ Checking test 049 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 953.481284
-  0: The maximum resident set size (KB)                   = 630440
+  0: The total amount of wall time                        = 1440.616517
+  0: The maximum resident set size (KB)                   = 625808
 
 Test 066 rrfs_v1nssl PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_v1nssl_nohailnoccn
-Checking test 050 rrfs_v1nssl_nohailnoccn results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_v1nssl_nohailnoccn
+Checking test 067 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2660,15 +2876,15 @@ Checking test 050 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 985.234534
-  0: The maximum resident set size (KB)                   = 625780
+  0: The total amount of wall time                        = 1278.020603
+  0: The maximum resident set size (KB)                   = 633984
 
 Test 067 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_smoke_conus13km_hrrr_warm
-Checking test 051 rrfs_smoke_conus13km_hrrr_warm results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_smoke_conus13km_hrrr_warm
+Checking test 068 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2676,15 +2892,15 @@ Checking test 051 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 297.429291
-  0: The maximum resident set size (KB)                   = 899756
+  0: The total amount of wall time                        = 385.359667
+  0: The maximum resident set size (KB)                   = 903080
 
 Test 068 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_smoke_conus13km_hrrr_warm_2threads
-Checking test 052 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_smoke_conus13km_hrrr_warm_2threads
+Checking test 069 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2692,15 +2908,15 @@ Checking test 052 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 254.038838
-  0: The maximum resident set size (KB)                   = 870412
+  0: The total amount of wall time                        = 319.775353
+  0: The maximum resident set size (KB)                   = 866440
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_conus13km_hrrr_warm
-Checking test 053 rrfs_conus13km_hrrr_warm results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_conus13km_hrrr_warm
+Checking test 070 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2708,15 +2924,15 @@ Checking test 053 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 291.492792
-  0: The maximum resident set size (KB)                   = 865052
+  0: The total amount of wall time                        = 326.459549
+  0: The maximum resident set size (KB)                   = 857652
 
 Test 070 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_smoke_conus13km_radar_tten_warm
-Checking test 054 rrfs_smoke_conus13km_radar_tten_warm results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_smoke_conus13km_radar_tten_warm
+Checking test 071 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2724,27 +2940,27 @@ Checking test 054 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 289.137292
-  0: The maximum resident set size (KB)                   = 912136
+  0: The total amount of wall time                        = 349.970597
+  0: The maximum resident set size (KB)                   = 918088
 
 Test 071 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_conus13km_hrrr_warm_restart_mismatch
-Checking test 055 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_conus13km_hrrr_warm_restart_mismatch
+Checking test 072 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 124.872140
-  0: The maximum resident set size (KB)                   = 843044
+  0: The total amount of wall time                        = 230.868162
+  0: The maximum resident set size (KB)                   = 853160
 
 Test 072 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_csawmg
-Checking test 056 control_csawmg results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_csawmg
+Checking test 073 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2754,15 +2970,15 @@ Checking test 056 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 487.689636
-  0: The maximum resident set size (KB)                   = 660308
+  0: The total amount of wall time                        = 919.755923
+  0: The maximum resident set size (KB)                   = 669088
 
 Test 073 control_csawmg PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_csawmgt
-Checking test 057 control_csawmgt results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_csawmgt
+Checking test 074 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2772,15 +2988,15 @@ Checking test 057 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 474.506048
-  0: The maximum resident set size (KB)                   = 665268
+  0: The total amount of wall time                        = 943.676734
+  0: The maximum resident set size (KB)                   = 665792
 
 Test 074 control_csawmgt PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_ras
-Checking test 058 control_ras results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_ras
+Checking test 075 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2790,27 +3006,27 @@ Checking test 058 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 254.807989
-  0: The maximum resident set size (KB)                   = 627752
+  0: The total amount of wall time                        = 559.926139
+  0: The maximum resident set size (KB)                   = 632572
 
 Test 075 control_ras PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_wam
-Checking test 059 control_wam results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_wam
+Checking test 076 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 152.306931
-  0: The maximum resident set size (KB)                   = 481136
+  0: The total amount of wall time                        = 353.615537
+  0: The maximum resident set size (KB)                   = 481728
 
 Test 076 control_wam PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_p8_faster
-Checking test 060 control_p8_faster results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_p8_faster
+Checking test 077 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2856,15 +3072,15 @@ Checking test 060 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 322.012246
-  0: The maximum resident set size (KB)                   = 1542572
+  0: The total amount of wall time                        = 353.895378
+  0: The maximum resident set size (KB)                   = 1540888
 
 Test 077 control_p8_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_control_faster
-Checking test 061 regional_control_faster results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_control_faster
+Checking test 078 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2874,57 +3090,57 @@ Checking test 061 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 472.937859
-  0: The maximum resident set size (KB)                   = 784712
+  0: The total amount of wall time                        = 733.980959
+  0: The maximum resident set size (KB)                   = 787152
 
 Test 078 regional_control_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_smoke_conus13km_hrrr_warm_debug
-Checking test 062 rrfs_smoke_conus13km_hrrr_warm_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_smoke_conus13km_hrrr_warm_debug
+Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 1106.244782
-  0: The maximum resident set size (KB)                   = 938764
+  0: The total amount of wall time                        = 1223.809276
+  0: The maximum resident set size (KB)                   = 932000
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
-Checking test 063 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 654.563884
-  0: The maximum resident set size (KB)                   = 896976
+  0: The total amount of wall time                        = 822.204000
+  0: The maximum resident set size (KB)                   = 896580
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_conus13km_hrrr_warm_debug
-Checking test 064 rrfs_conus13km_hrrr_warm_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_conus13km_hrrr_warm_debug
+Checking test 081 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 990.969474
-  0: The maximum resident set size (KB)                   = 894652
+  0: The total amount of wall time                        = 1218.188553
+  0: The maximum resident set size (KB)                   = 894512
 
 Test 081 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_CubedSphereGrid_debug
-Checking test 065 control_CubedSphereGrid_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_CubedSphereGrid_debug
+Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2950,335 +3166,335 @@ Checking test 065 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.780816
-  0: The maximum resident set size (KB)                   = 741648
+  0: The total amount of wall time                        = 263.679241
+  0: The maximum resident set size (KB)                   = 740132
 
 Test 082 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_wrtGauss_netcdf_parallel_debug
-Checking test 066 control_wrtGauss_netcdf_parallel_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_wrtGauss_netcdf_parallel_debug
+Checking test 083 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 212.911012
-  0: The maximum resident set size (KB)                   = 735336
+  0: The total amount of wall time                        = 279.001757
+  0: The maximum resident set size (KB)                   = 732076
 
 Test 083 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_stochy_debug
-Checking test 067 control_stochy_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_stochy_debug
+Checking test 084 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.092064
-  0: The maximum resident set size (KB)                   = 744480
+  0: The total amount of wall time                        = 288.711306
+  0: The maximum resident set size (KB)                   = 741596
 
 Test 084 control_stochy_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_lndp_debug
-Checking test 068 control_lndp_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_lndp_debug
+Checking test 085 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 208.596316
-  0: The maximum resident set size (KB)                   = 741648
+  0: The total amount of wall time                        = 268.417731
+  0: The maximum resident set size (KB)                   = 744640
 
 Test 085 control_lndp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_csawmg_debug
-Checking test 069 control_csawmg_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_csawmg_debug
+Checking test 086 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 315.374329
-  0: The maximum resident set size (KB)                   = 790804
+  0: The total amount of wall time                        = 388.751142
+  0: The maximum resident set size (KB)                   = 791476
 
 Test 086 control_csawmg_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_csawmgt_debug
-Checking test 070 control_csawmgt_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_csawmgt_debug
+Checking test 087 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 318.761519
-  0: The maximum resident set size (KB)                   = 783196
+  0: The total amount of wall time                        = 349.195919
+  0: The maximum resident set size (KB)                   = 785704
 
 Test 087 control_csawmgt_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_ras_debug
-Checking test 071 control_ras_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_ras_debug
+Checking test 088 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 206.356663
-  0: The maximum resident set size (KB)                   = 754452
+  0: The total amount of wall time                        = 297.946826
+  0: The maximum resident set size (KB)                   = 749172
 
 Test 088 control_ras_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_diag_debug
-Checking test 072 control_diag_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_diag_debug
+Checking test 089 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.093528
-  0: The maximum resident set size (KB)                   = 798296
+  0: The total amount of wall time                        = 345.575984
+  0: The maximum resident set size (KB)                   = 802508
 
 Test 089 control_diag_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_debug_p8
-Checking test 073 control_debug_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_debug_p8
+Checking test 090 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 239.557208
-  0: The maximum resident set size (KB)                   = 1557448
+  0: The total amount of wall time                        = 284.477699
+  0: The maximum resident set size (KB)                   = 1557652
 
 Test 090 control_debug_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_debug
-Checking test 074 regional_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_debug
+Checking test 091 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1395.561652
-  0: The maximum resident set size (KB)                   = 808548
+  0: The total amount of wall time                        = 1723.962942
+  0: The maximum resident set size (KB)                   = 810888
 
 Test 091 regional_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_control_debug
-Checking test 075 rap_control_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_control_debug
+Checking test 092 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 409.893690
-  0: The maximum resident set size (KB)                   = 1117312
+  0: The total amount of wall time                        = 426.554602
+  0: The maximum resident set size (KB)                   = 1119588
 
 Test 092 rap_control_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_debug
-Checking test 076 hrrr_control_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_debug
+Checking test 093 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 370.160576
-  0: The maximum resident set size (KB)                   = 1110020
+  0: The total amount of wall time                        = 426.838689
+  0: The maximum resident set size (KB)                   = 1109180
 
 Test 093 hrrr_control_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_unified_drag_suite_debug
-Checking test 077 rap_unified_drag_suite_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_unified_drag_suite_debug
+Checking test 094 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 370.346998
-  0: The maximum resident set size (KB)                   = 1112492
+  0: The total amount of wall time                        = 438.384023
+  0: The maximum resident set size (KB)                   = 1113748
 
 Test 094 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_diag_debug
-Checking test 078 rap_diag_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_diag_debug
+Checking test 095 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 427.042402
-  0: The maximum resident set size (KB)                   = 1194600
+  0: The total amount of wall time                        = 508.243580
+  0: The maximum resident set size (KB)                   = 1197080
 
 Test 095 rap_diag_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_cires_ugwp_debug
-Checking test 079 rap_cires_ugwp_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_cires_ugwp_debug
+Checking test 096 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 402.923778
-  0: The maximum resident set size (KB)                   = 1112208
+  0: The total amount of wall time                        = 434.896535
+  0: The maximum resident set size (KB)                   = 1111720
 
 Test 096 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_unified_ugwp_debug
-Checking test 080 rap_unified_ugwp_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_unified_ugwp_debug
+Checking test 097 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 384.977416
-  0: The maximum resident set size (KB)                   = 1118748
+  0: The total amount of wall time                        = 479.391513
+  0: The maximum resident set size (KB)                   = 1118896
 
 Test 097 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_lndp_debug
-Checking test 081 rap_lndp_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_lndp_debug
+Checking test 098 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 393.563130
-  0: The maximum resident set size (KB)                   = 1121284
+  0: The total amount of wall time                        = 452.839547
+  0: The maximum resident set size (KB)                   = 1113888
 
 Test 098 rap_lndp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_flake_debug
-Checking test 082 rap_flake_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_flake_debug
+Checking test 099 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 399.128186
-  0: The maximum resident set size (KB)                   = 1118912
+  0: The total amount of wall time                        = 498.620731
+  0: The maximum resident set size (KB)                   = 1114684
 
 Test 099 rap_flake_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_progcld_thompson_debug
-Checking test 083 rap_progcld_thompson_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_progcld_thompson_debug
+Checking test 100 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 429.224485
-  0: The maximum resident set size (KB)                   = 1112872
+  0: The total amount of wall time                        = 448.195066
+  0: The maximum resident set size (KB)                   = 1112716
 
 Test 100 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_noah_debug
-Checking test 084 rap_noah_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_noah_debug
+Checking test 101 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 433.896558
-  0: The maximum resident set size (KB)                   = 1107452
+  0: The total amount of wall time                        = 444.634780
+  0: The maximum resident set size (KB)                   = 1111204
 
 Test 101 rap_noah_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_sfcdiff_debug
-Checking test 085 rap_sfcdiff_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_sfcdiff_debug
+Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 448.253582
-  0: The maximum resident set size (KB)                   = 1109228
+  0: The total amount of wall time                        = 428.477888
+  0: The maximum resident set size (KB)                   = 1112556
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_noah_sfcdiff_cires_ugwp_debug
-Checking test 086 rap_noah_sfcdiff_cires_ugwp_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 601.437319
-  0: The maximum resident set size (KB)                   = 1113764
+  0: The total amount of wall time                        = 678.303145
+  0: The maximum resident set size (KB)                   = 1113228
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rrfs_v1beta_debug
-Checking test 087 rrfs_v1beta_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rrfs_v1beta_debug
+Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 389.641040
-  0: The maximum resident set size (KB)                   = 1105232
+  0: The total amount of wall time                        = 404.050784
+  0: The maximum resident set size (KB)                   = 1109320
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_wam_debug
-Checking test 088 control_wam_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_wam_debug
+Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 371.894090
-  0: The maximum resident set size (KB)                   = 436172
+  0: The total amount of wall time                        = 443.809283
+  0: The maximum resident set size (KB)                   = 443340
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_spp_sppt_shum_skeb_dyn32_phy32
-Checking test 089 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/regional_spp_sppt_shum_skeb_dyn32_phy32
+Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3288,15 +3504,15 @@ Checking test 089 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 335.049861
-  0: The maximum resident set size (KB)                   = 992664
+  0: The total amount of wall time                        = 709.139162
+  0: The maximum resident set size (KB)                   = 991500
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_control_dyn32_phy32
-Checking test 090 rap_control_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_control_dyn32_phy32
+Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3342,15 +3558,15 @@ Checking test 090 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 642.664683
-  0: The maximum resident set size (KB)                   = 845316
+  0: The total amount of wall time                        = 1430.815863
+  0: The maximum resident set size (KB)                   = 850584
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_dyn32_phy32
-Checking test 091 hrrr_control_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_dyn32_phy32
+Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3396,15 +3612,15 @@ Checking test 091 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 324.263144
-  0: The maximum resident set size (KB)                   = 830640
+  0: The total amount of wall time                        = 632.385094
+  0: The maximum resident set size (KB)                   = 827652
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_2threads_dyn32_phy32
-Checking test 092 rap_2threads_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_2threads_dyn32_phy32
+Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3450,15 +3666,15 @@ Checking test 092 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 650.925010
-  0: The maximum resident set size (KB)                   = 884556
+  0: The total amount of wall time                        = 1497.974004
+  0: The maximum resident set size (KB)                   = 888892
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_2threads_dyn32_phy32
-Checking test 093 hrrr_control_2threads_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_2threads_dyn32_phy32
+Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3504,15 +3720,15 @@ Checking test 093 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 364.918643
-  0: The maximum resident set size (KB)                   = 885492
+  0: The total amount of wall time                        = 684.806861
+  0: The maximum resident set size (KB)                   = 884192
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_decomp_dyn32_phy32
-Checking test 094 hrrr_control_decomp_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_decomp_dyn32_phy32
+Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3558,15 +3774,15 @@ Checking test 094 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 381.878723
-  0: The maximum resident set size (KB)                   = 819844
+  0: The total amount of wall time                        = 665.332308
+  0: The maximum resident set size (KB)                   = 832060
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_restart_dyn32_phy32
-Checking test 095 rap_restart_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_restart_dyn32_phy32
+Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3604,15 +3820,15 @@ Checking test 095 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 643.966373
-  0: The maximum resident set size (KB)                   = 807828
+  0: The total amount of wall time                        = 753.953657
+  0: The maximum resident set size (KB)                   = 807432
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_restart_dyn32_phy32
-Checking test 096 hrrr_control_restart_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_restart_dyn32_phy32
+Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3650,15 +3866,15 @@ Checking test 096 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.139193
-  0: The maximum resident set size (KB)                   = 769128
+  0: The total amount of wall time                        = 614.031185
+  0: The maximum resident set size (KB)                   = 758120
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_control_dyn64_phy32
-Checking test 097 rap_control_dyn64_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_control_dyn64_phy32
+Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3704,69 +3920,72 @@ Checking test 097 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 481.806284
-  0: The maximum resident set size (KB)                   = 868160
+  0: The total amount of wall time                        = 878.822766
+  0: The maximum resident set size (KB)                   = 864684
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_control_debug_dyn32_phy32
-Checking test 098 rap_control_debug_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_control_debug_dyn32_phy32
+Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 367.854497
-  0: The maximum resident set size (KB)                   = 1001660
+  0: The total amount of wall time                        = 462.834700
+  0: The maximum resident set size (KB)                   = 1003668
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hrrr_control_debug_dyn32_phy32
-Checking test 099 hrrr_control_debug_dyn32_phy32 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hrrr_control_debug_dyn32_phy32
+Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 362.782037
-  0: The maximum resident set size (KB)                   = 996488
+  0: The total amount of wall time                        = 536.887410
+  0: The maximum resident set size (KB)                   = 998896
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/rap_control_dyn64_phy32_debug
-Checking test 100 rap_control_dyn64_phy32_debug results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/rap_control_dyn64_phy32_debug
+Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 451.959167
-  0: The maximum resident set size (KB)                   = 1030856
+  0: The total amount of wall time                        = 594.911765
+  0: The maximum resident set size (KB)                   = 1033816
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hafs_regional_atm_thompson_gfdlsf
-Checking test 102 hafs_regional_atm_thompson_gfdlsf results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hafs_regional_atm
+Checking test 118 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
+ Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 846.696857
-  0: The maximum resident set size (KB)                   = 1575664
+  0: The total amount of wall time                        = 1342.548847
+  0: The maximum resident set size (KB)                   = 1218956
 
-Test 118 hafs_regional_atm_thompson_gfdlsf PASS
+Test 118 hafs_regional_atm PASS
+
+Test 119 hafs_regional_atm_thompson_gfdlsf FAIL
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hafs_regional_atm_ocn
-Checking test 103 hafs_regional_atm_ocn results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hafs_regional_atm_ocn
+Checking test 120 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -3774,202 +3993,169 @@ Checking test 103 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 699.730398
-  0: The maximum resident set size (KB)                   = 1260508
+  0: The total amount of wall time                        = 1165.605709
+  0: The maximum resident set size (KB)                   = 1298968
 
-Test 119 hafs_regional_atm_ocn PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_iovr4
-Checking test 014 control_iovr4 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 206.800471
-  0: The maximum resident set size (KB)                   = 573676
-
-Test 120 control_iovr4 PASS
+Test 120 hafs_regional_atm_ocn PASS Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hafs_regional_atm_ocn_wav
-Checking test 105 hafs_regional_atm_ocn_wav results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hafs_regional_atm_wav
+Checking test 121 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing archv.2019_241_06.a .........OK
- Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1204.761276
-  0: The maximum resident set size (KB)                   = 1313620
+  0: The total amount of wall time                        = 1713.539486
+  0: The maximum resident set size (KB)                   = 1325076
 
-Test 121 hafs_regional_atm_ocn_wav PASS
+Test 121 hafs_regional_atm_wav PASS Tries: 2
+
+Test 122 hafs_regional_atm_ocn_wav FAIL
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hafs_regional_docn
-Checking test 106 hafs_regional_docn results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hafs_regional_docn
+Checking test 123 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 809.648488
-  0: The maximum resident set size (KB)                   = 1279144
+  0: The total amount of wall time                        = 1050.848072
+  0: The maximum resident set size (KB)                   = 1307152
 
-Test 122 hafs_regional_docn PASS
+Test 123 hafs_regional_docn PASS Tries: 2
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hafs_regional_docn_oisst
-Checking test 107 hafs_regional_docn_oisst results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/hafs_regional_docn_oisst
+Checking test 124 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 674.633126
-  0: The maximum resident set size (KB)                   = 1280272
+  0: The total amount of wall time                        = 1032.964522
+  0: The maximum resident set size (KB)                   = 1292868
 
-Test 123 hafs_regional_docn_oisst PASS
+Test 124 hafs_regional_docn_oisst PASS Tries: 2
 
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/hafs_regional_datm_cdeps
-Checking test 108 hafs_regional_datm_cdeps results ....
- Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
- Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
- Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
-
-  0: The total amount of wall time                        = 1429.212467
-  0: The maximum resident set size (KB)                   = 976204
-
-Test 124 hafs_regional_datm_cdeps PASS
+Test 125 hafs_regional_datm_cdeps FAIL
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_control_cfsr
-Checking test 109 datm_cdeps_control_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_control_cfsr
+Checking test 126 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 287.154671
- 0: The maximum resident set size (KB)                   = 963512
+ 0: The total amount of wall time                        = 603.831120
+ 0: The maximum resident set size (KB)                   = 967264
 
-Test 125 datm_cdeps_control_cfsr PASS
+Test 126 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_restart_cfsr
-Checking test 110 datm_cdeps_restart_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_restart_cfsr
+Checking test 127 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 172.911956
- 0: The maximum resident set size (KB)                   = 938552
+ 0: The total amount of wall time                        = 472.222421
+ 0: The maximum resident set size (KB)                   = 939044
 
-Test 126 datm_cdeps_restart_cfsr PASS
+Test 127 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_control_gefs
-Checking test 111 datm_cdeps_control_gefs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_control_gefs
+Checking test 128 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 278.839390
- 0: The maximum resident set size (KB)                   = 871192
+ 0: The total amount of wall time                        = 731.988749
+ 0: The maximum resident set size (KB)                   = 866976
 
-Test 127 datm_cdeps_control_gefs PASS
+Test 128 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_iau_gefs
-Checking test 112 datm_cdeps_iau_gefs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_iau_gefs
+Checking test 129 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 294.204034
- 0: The maximum resident set size (KB)                   = 862168
+ 0: The total amount of wall time                        = 633.913442
+ 0: The maximum resident set size (KB)                   = 863372
 
-Test 128 datm_cdeps_iau_gefs PASS
+Test 129 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_stochy_gefs
-Checking test 113 datm_cdeps_stochy_gefs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_stochy_gefs
+Checking test 130 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 274.005004
- 0: The maximum resident set size (KB)                   = 863956
+ 0: The total amount of wall time                        = 744.561946
+ 0: The maximum resident set size (KB)                   = 864148
 
-Test 129 datm_cdeps_stochy_gefs PASS
+Test 130 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_ciceC_cfsr
-Checking test 114 datm_cdeps_ciceC_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_ciceC_cfsr
+Checking test 131 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 293.466241
- 0: The maximum resident set size (KB)                   = 967576
+ 0: The total amount of wall time                        = 746.131084
+ 0: The maximum resident set size (KB)                   = 969796
 
-Test 130 datm_cdeps_ciceC_cfsr PASS
+Test 131 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_bulk_cfsr
-Checking test 115 datm_cdeps_bulk_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_bulk_cfsr
+Checking test 132 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 266.816228
- 0: The maximum resident set size (KB)                   = 964536
+ 0: The total amount of wall time                        = 818.385175
+ 0: The maximum resident set size (KB)                   = 961452
 
-Test 131 datm_cdeps_bulk_cfsr PASS
+Test 132 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_bulk_gefs
-Checking test 116 datm_cdeps_bulk_gefs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_bulk_gefs
+Checking test 133 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 312.326680
- 0: The maximum resident set size (KB)                   = 864496
+ 0: The total amount of wall time                        = 841.510874
+ 0: The maximum resident set size (KB)                   = 865468
 
-Test 132 datm_cdeps_bulk_gefs PASS
+Test 133 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_mx025_cfsr
-Checking test 117 datm_cdeps_mx025_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_mx025_cfsr
+Checking test 134 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -3977,15 +4163,15 @@ Checking test 117 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 751.487117
-  0: The maximum resident set size (KB)                   = 775928
+  0: The total amount of wall time                        = 1106.973467
+  0: The maximum resident set size (KB)                   = 767748
 
-Test 133 datm_cdeps_mx025_cfsr PASS
+Test 134 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_mx025_gefs
-Checking test 118 datm_cdeps_mx025_gefs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_mx025_gefs
+Checking test 135 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -3993,78 +4179,78 @@ Checking test 118 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 723.873950
-  0: The maximum resident set size (KB)                   = 738848
+  0: The total amount of wall time                        = 1468.397514
+  0: The maximum resident set size (KB)                   = 748680
 
-Test 134 datm_cdeps_mx025_gefs PASS
+Test 135 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_multiple_files_cfsr
-Checking test 119 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_multiple_files_cfsr
+Checking test 136 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 248.311028
- 0: The maximum resident set size (KB)                   = 976544
+ 0: The total amount of wall time                        = 691.168807
+ 0: The maximum resident set size (KB)                   = 964456
 
-Test 135 datm_cdeps_multiple_files_cfsr PASS
+Test 136 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_3072x1536_cfsr
-Checking test 120 datm_cdeps_3072x1536_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_3072x1536_cfsr
+Checking test 137 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 423.035693
- 0: The maximum resident set size (KB)                   = 2256384
+ 0: The total amount of wall time                        = 737.249033
+ 0: The maximum resident set size (KB)                   = 2270996
 
-Test 136 datm_cdeps_3072x1536_cfsr PASS
+Test 137 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_gfs
-Checking test 121 datm_cdeps_gfs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_gfs
+Checking test 138 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 456.769022
- 0: The maximum resident set size (KB)                   = 2249744
+ 0: The total amount of wall time                        = 1182.186169
+ 0: The maximum resident set size (KB)                   = 2255420
 
-Test 137 datm_cdeps_gfs PASS
+Test 138 datm_cdeps_gfs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_debug_cfsr
-Checking test 122 datm_cdeps_debug_cfsr results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_debug_cfsr
+Checking test 139 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 636.258182
- 0: The maximum resident set size (KB)                   = 932928
+ 0: The total amount of wall time                        = 819.698358
+ 0: The maximum resident set size (KB)                   = 930492
 
-Test 138 datm_cdeps_debug_cfsr PASS
+Test 139 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_control_cfsr_faster
-Checking test 123 datm_cdeps_control_cfsr_faster results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_control_cfsr_faster
+Checking test 140 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 298.916008
- 0: The maximum resident set size (KB)                   = 972452
+ 0: The total amount of wall time                        = 721.106849
+ 0: The maximum resident set size (KB)                   = 965352
 
-Test 139 datm_cdeps_control_cfsr_faster PASS
+Test 140 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/datm_cdeps_lnd_gswp3
-Checking test 124 datm_cdeps_lnd_gswp3 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_lnd_gswp3
+Checking test 141 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4072,15 +4258,31 @@ Checking test 124 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 19.838935
-  0: The maximum resident set size (KB)                   = 246596
+  0: The total amount of wall time                        = 507.770898
+  0: The maximum resident set size (KB)                   = 253032
 
-Test 140 datm_cdeps_lnd_gswp3 PASS
+Test 141 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_p8_atmlnd_sbs
-Checking test 126 control_p8_atmlnd_sbs results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/datm_cdeps_lnd_gswp3_rst
+Checking test 142 datm_cdeps_lnd_gswp3_rst results ....
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 253.222300
+  0: The maximum resident set size (KB)                   = 253128
+
+Test 142 datm_cdeps_lnd_gswp3_rst PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_p8_atmlnd_sbs
+Checking test 143 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4164,15 +4366,15 @@ Checking test 126 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 448.642660
-  0: The maximum resident set size (KB)                   = 1589012
+  0: The total amount of wall time                        = 886.877469
+  0: The maximum resident set size (KB)                   = 1582200
 
-Test 141 control_p8_atmlnd_sbs PASS
+Test 143 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/control_atmwav
-Checking test 127 control_atmwav results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/control_atmwav
+Checking test 144 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4215,15 +4417,15 @@ Checking test 127 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 145.089799
-  0: The maximum resident set size (KB)                   = 594720
+  0: The total amount of wall time                        = 740.435352
+  0: The maximum resident set size (KB)                   = 593960
 
-Test 142 control_atmwav PASS
+Test 144 control_atmwav PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/atmaero_control_p8
-Checking test 128 atmaero_control_p8 results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/atmaero_control_p8
+Checking test 145 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4266,15 +4468,15 @@ Checking test 128 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 331.368146
-  0: The maximum resident set size (KB)                   = 1632208
+  0: The total amount of wall time                        = 676.667086
+  0: The maximum resident set size (KB)                   = 1630980
 
-Test 143 atmaero_control_p8 PASS
+Test 145 atmaero_control_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/atmaero_control_p8_rad
-Checking test 129 atmaero_control_p8_rad results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/atmaero_control_p8_rad
+Checking test 146 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4317,15 +4519,15 @@ Checking test 129 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 475.502210
-  0: The maximum resident set size (KB)                   = 1658316
+  0: The total amount of wall time                        = 690.978175
+  0: The maximum resident set size (KB)                   = 1656968
 
-Test 144 atmaero_control_p8_rad PASS
+Test 146 atmaero_control_p8_rad PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/atmaero_control_p8_rad_micro
-Checking test 130 atmaero_control_p8_rad_micro results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_303681/atmaero_control_p8_rad_micro
+Checking test 147 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4368,54 +4570,122 @@ Checking test 130 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 470.278130
-  0: The maximum resident set size (KB)                   = 1680844
+  0: The total amount of wall time                        = 1077.640635
+  0: The maximum resident set size (KB)                   = 1667260
 
-Test 145 atmaero_control_p8_rad_micro PASS
+Test 147 atmaero_control_p8_rad_micro PASS
+
+Test 148 regional_atmaq FAIL
+
+Test 149 regional_atmaq_faster FAIL
+
+FAILED TESTS: 
+Test control_c384 026 failed in run_test failed 
+Test regional_noquilt 049 failed in check_result failed 
+Test regional_noquilt 049 failed in run_test failed 
+Test regional_wofs 052 failed in run_test failed 
+Test hafs_regional_atm_thompson_gfdlsf 119 failed in run_test failed 
+Test hafs_regional_atm_ocn_wav 122 failed in run_test failed 
+Test hafs_regional_datm_cdeps 125 failed in run_test failed 
+Test regional_atmaq 148 failed in run_test failed 
+Test regional_atmaq_faster 149 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Mon Apr  3 05:57:35 UTC 2023
+Elapsed time: 04h:57m:10s. Have a nice day!
+Mon Apr  3 13:34:54 UTC 2023
+Start Regression test
+
+Compile 001 elapsed time 1824 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 002 elapsed time 1783 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 003 elapsed time 1585 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 2102 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Test 001 control_c384 FAIL
+
+Test 002 regional_wofs FAIL
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_atmaq
-Checking test 131 regional_atmaq results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf003.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf003.nc .........OK
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_178965/hafs_regional_atm_thompson_gfdlsf
+Checking test 003 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
- Comparing RESTART/20190801.180000.coupler.res .........OK
- Comparing RESTART/20190801.180000.fv_core.res.nc .........OK
- Comparing RESTART/20190801.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.phy_data.nc .........OK
- Comparing RESTART/20190801.180000.sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 1261.303804
-  0: The maximum resident set size (KB)                   = 1156936
-
-Test 146 regional_atmaq PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_300047/regional_atmaq_faster
-Checking test 132 regional_atmaq_faster results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
+
+  0: The total amount of wall time                        = 938.702669
+  0: The maximum resident set size (KB)                   = 1561924
+
+Test 003 hafs_regional_atm_thompson_gfdlsf PASS
+
+Test 004 hafs_regional_atm_ocn_wav FAIL
+
+Test 005 regional_atmaq FAIL
+
+Test 006 regional_atmaq_faster FAIL
+
+FAILED TESTS: 
+Test control_c384 001 failed in run_test failed 
+Test regional_wofs 002 failed in run_test failed 
+Test hafs_regional_atm_ocn_wav 004 failed in run_test failed 
+Test regional_atmaq 005 failed in run_test failed 
+Test regional_atmaq_faster 006 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Mon Apr  3 15:40:06 UTC 2023
+Elapsed time: 02h:05m:14s. Have a nice day!
+Mon Apr  3 16:24:08 UTC 2023
+Start Regression test
+
+Compile 001 elapsed time 1900 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 002 elapsed time 1842 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 003 elapsed time 1657 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 2206 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_272954/control_c384
+Checking test 001 control_c384 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf003.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 1561.253900
+  0: The maximum resident set size (KB)                   = 1061804
+
+Test 001 control_c384 PASS
+
+Test 002 regional_wofs FAIL
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_272954/hafs_regional_atm_ocn_wav
+Checking test 003 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
- Comparing RESTART/20190801.180000.coupler.res .........OK
- Comparing RESTART/20190801.180000.fv_core.res.nc .........OK
- Comparing RESTART/20190801.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.phy_data.nc .........OK
- Comparing RESTART/20190801.180000.sfc_data.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing archv.2019_241_06.a .........OK
+ Comparing archs.2019_241_06.a .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1088.503938
-  0: The maximum resident set size (KB)                   = 1162296
+  0: The total amount of wall time                        = 1740.569251
+  0: The maximum resident set size (KB)                   = 1338868
 
-Test 147 regional_atmaq_faster PASS
+Test 003 hafs_regional_atm_ocn_wav PASS
 
+Test 004 regional_atmaq FAIL
+
+Test 005 regional_atmaq_faster FAIL
+
+FAILED TESTS: 
+Test regional_wofs 002 failed in run_test failed 
+Test regional_atmaq 004 failed in run_test failed 
+Test regional_atmaq_faster 005 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Mon Apr  3 18:24:15 UTC 2023
+Elapsed time: 02h:00m:09s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,42 +1,42 @@
-Thu Mar 30 09:10:58 CDT 2023
+Sun Apr  2 08:17:03 CDT 2023
 Start Regression test
 
-Compile 001 elapsed time 783 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 795 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 690 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 283 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 266 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 637 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 636 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 852 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 642 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 612 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 566 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 496 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 764 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 341 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 272 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 546 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 554 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 265 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 265 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 721 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 198 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 729 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 684 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 211 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 124 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 227 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 81 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 634 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 591 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 594 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 586 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 226 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 033 elapsed time 611 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 842 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 856 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 746 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 431 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 368 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 708 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 756 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 923 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 715 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 690 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 538 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 510 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 804 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 256 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 215 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 556 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 560 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 177 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 356 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 644 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 306 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 795 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 696 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 279 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 238 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 216 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 59 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 569 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 589 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 554 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 533 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 187 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 033 elapsed time 621 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_p8_mixedmode
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -101,14 +101,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 311.058532
-  0: The maximum resident set size (KB)                   = 3150964
+  0: The total amount of wall time                        = 360.025994
+  0: The maximum resident set size (KB)                   = 3151220
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_gfsv17
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_gfsv17
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_gfsv17
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -172,14 +172,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 234.852672
-  0: The maximum resident set size (KB)                   = 1736616
+  0: The total amount of wall time                        = 264.088721
+  0: The maximum resident set size (KB)                   = 1718896
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -244,14 +244,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 356.462745
-  0: The maximum resident set size (KB)                   = 3112304
+  0: The total amount of wall time                        = 464.320466
+  0: The maximum resident set size (KB)                   = 3180704
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -304,14 +304,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 202.075789
-  0: The maximum resident set size (KB)                   = 3050588
+  0: The total amount of wall time                        = 204.981151
+  0: The maximum resident set size (KB)                   = 3053592
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -376,14 +376,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 351.597487
-  0: The maximum resident set size (KB)                   = 3188192
+  0: The total amount of wall time                        = 463.872271
+  0: The maximum resident set size (KB)                   = 3191672
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_restart_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -436,14 +436,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 219.445944
-  0: The maximum resident set size (KB)                   = 3064820
+  0: The total amount of wall time                        = 204.302325
+  0: The maximum resident set size (KB)                   = 3066152
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -496,14 +496,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 409.558236
-  0: The maximum resident set size (KB)                   = 3518632
+  0: The total amount of wall time                        = 502.710576
+  0: The maximum resident set size (KB)                   = 3512160
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -556,14 +556,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.961624
-  0: The maximum resident set size (KB)                   = 3180936
+  0: The total amount of wall time                        = 469.994356
+  0: The maximum resident set size (KB)                   = 3175556
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -616,14 +616,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 287.944218
-  0: The maximum resident set size (KB)                   = 3037828
+  0: The total amount of wall time                        = 437.120723
+  0: The maximum resident set size (KB)                   = 3030824
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_ciceC_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_ciceC_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_ciceC_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -688,14 +688,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 348.029728
-  0: The maximum resident set size (KB)                   = 3176388
+  0: The total amount of wall time                        = 435.295417
+  0: The maximum resident set size (KB)                   = 3188104
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -748,14 +748,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 655.659299
-  0: The maximum resident set size (KB)                   = 3268512
+  0: The total amount of wall time                        = 682.094174
+  0: The maximum resident set size (KB)                   = 3264132
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -808,14 +808,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 439.966021
-  0: The maximum resident set size (KB)                   = 3165124
+  0: The total amount of wall time                        = 441.389530
+  0: The maximum resident set size (KB)                   = 3164976
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_bmark_p8
 Checking test 013 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -863,14 +863,14 @@ Checking test 013 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 878.945090
-   0: The maximum resident set size (KB)                   = 4030216
+   0: The total amount of wall time                        = 910.235389
+   0: The maximum resident set size (KB)                   = 3969812
 
 Test 013 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_restart_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_restart_bmark_p8
 Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -918,14 +918,14 @@ Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 545.560317
-   0: The maximum resident set size (KB)                   = 3933396
+   0: The total amount of wall time                        = 537.637430
+   0: The maximum resident set size (KB)                   = 3978480
 
 Test 014 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_noaero_p8
 Checking test 015 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -989,14 +989,14 @@ Checking test 015 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 260.156320
-  0: The maximum resident set size (KB)                   = 1721384
+  0: The total amount of wall time                        = 348.570885
+  0: The maximum resident set size (KB)                   = 1724168
 
 Test 015 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_nowave_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_nowave_noaero_p8
 Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1058,14 +1058,14 @@ Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 262.240612
-  0: The maximum resident set size (KB)                   = 1755680
+  0: The total amount of wall time                        = 312.143126
+  0: The maximum resident set size (KB)                   = 1759904
 
 Test 016 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_debug_p8
 Checking test 017 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1118,14 +1118,14 @@ Checking test 017 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 675.012589
-  0: The maximum resident set size (KB)                   = 3247544
+  0: The total amount of wall time                        = 737.837094
+  0: The maximum resident set size (KB)                   = 3255196
 
 Test 017 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_debug_noaero_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_debug_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_debug_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_debug_noaero_p8
 Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1177,14 +1177,14 @@ Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 439.442341
-  0: The maximum resident set size (KB)                   = 1739272
+  0: The total amount of wall time                        = 424.931717
+  0: The maximum resident set size (KB)                   = 1744160
 
 Test 018 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_noaero_p8_agrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_noaero_p8_agrid
 Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1246,14 +1246,14 @@ Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 273.867236
-  0: The maximum resident set size (KB)                   = 1765068
+  0: The total amount of wall time                        = 274.027633
+  0: The maximum resident set size (KB)                   = 1769708
 
 Test 019 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_c48
 Checking test 020 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1303,14 +1303,14 @@ Checking test 020 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 497.192344
- 0: The maximum resident set size (KB)                   = 2795480
+ 0: The total amount of wall time                        = 496.558939
+ 0: The maximum resident set size (KB)                   = 2812532
 
 Test 020 cpld_control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_warmstart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_warmstart_c48
 Checking test 021 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1360,14 +1360,14 @@ Checking test 021 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 135.919974
- 0: The maximum resident set size (KB)                   = 2802716
+ 0: The total amount of wall time                        = 147.660447
+ 0: The maximum resident set size (KB)                   = 2804684
 
 Test 021 cpld_warmstart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_restart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_restart_c48
 Checking test 022 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1417,14 +1417,14 @@ Checking test 022 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 77.298121
- 0: The maximum resident set size (KB)                   = 2244784
+ 0: The total amount of wall time                        = 72.282015
+ 0: The maximum resident set size (KB)                   = 2228108
 
 Test 022 cpld_restart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_faster
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/cpld_control_p8_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/cpld_control_p8_faster
 Checking test 023 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 023 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 326.859879
-  0: The maximum resident set size (KB)                   = 3177672
+  0: The total amount of wall time                        = 335.157784
+  0: The maximum resident set size (KB)                   = 3176720
 
 Test 023 cpld_control_p8_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_CubedSphereGrid
 Checking test 024 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1523,28 +1523,28 @@ Checking test 024 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 131.676440
-  0: The maximum resident set size (KB)                   = 581572
+  0: The total amount of wall time                        = 130.250790
+  0: The maximum resident set size (KB)                   = 638552
 
 Test 024 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_parallel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_CubedSphereGrid_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_CubedSphereGrid_parallel
 Checking test 025 control_CubedSphereGrid_parallel results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 129.507537
-  0: The maximum resident set size (KB)                   = 635440
+  0: The total amount of wall time                        = 128.740995
+  0: The maximum resident set size (KB)                   = 637408
 
 Test 025 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_latlon
 Checking test 026 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1555,32 +1555,32 @@ Checking test 026 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.990428
-  0: The maximum resident set size (KB)                   = 632236
+  0: The total amount of wall time                        = 133.381130
+  0: The maximum resident set size (KB)                   = 640504
 
 Test 026 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_wrtGauss_netcdf_parallel
 Checking test 027 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.998859
-  0: The maximum resident set size (KB)                   = 634844
+  0: The total amount of wall time                        = 136.274915
+  0: The maximum resident set size (KB)                   = 634564
 
 Test 027 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_c48
 Checking test 028 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1619,14 +1619,14 @@ Checking test 028 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 345.434925
-0: The maximum resident set size (KB)                   = 822216
+0: The total amount of wall time                        = 349.987469
+0: The maximum resident set size (KB)                   = 808992
 
 Test 028 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_c192
 Checking test 029 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1637,14 +1637,14 @@ Checking test 029 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 526.277321
-  0: The maximum resident set size (KB)                   = 772480
+  0: The total amount of wall time                        = 547.134382
+  0: The maximum resident set size (KB)                   = 772468
 
 Test 029 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_c384
 Checking test 030 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1655,14 +1655,14 @@ Checking test 030 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 581.052564
-  0: The maximum resident set size (KB)                   = 1223468
+  0: The total amount of wall time                        = 623.780968
+  0: The maximum resident set size (KB)                   = 1235584
 
 Test 030 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_c384gdas
 Checking test 031 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1705,14 +1705,14 @@ Checking test 031 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 512.061297
-  0: The maximum resident set size (KB)                   = 1286604
+  0: The total amount of wall time                        = 550.269241
+  0: The maximum resident set size (KB)                   = 1339984
 
 Test 031 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_stochy
 Checking test 032 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1723,28 +1723,28 @@ Checking test 032 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 86.711852
-  0: The maximum resident set size (KB)                   = 641572
+  0: The total amount of wall time                        = 87.358989
+  0: The maximum resident set size (KB)                   = 641244
 
 Test 032 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_stochy_restart
 Checking test 033 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 47.544164
-  0: The maximum resident set size (KB)                   = 489272
+  0: The total amount of wall time                        = 73.630983
+  0: The maximum resident set size (KB)                   = 452152
 
 Test 033 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_lndp
 Checking test 034 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1755,14 +1755,14 @@ Checking test 034 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 84.081561
-  0: The maximum resident set size (KB)                   = 634968
+  0: The total amount of wall time                        = 82.949255
+  0: The maximum resident set size (KB)                   = 637848
 
 Test 034 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_iovr4
 Checking test 035 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1777,14 +1777,14 @@ Checking test 035 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.557634
-  0: The maximum resident set size (KB)                   = 636208
+  0: The total amount of wall time                        = 134.968310
+  0: The maximum resident set size (KB)                   = 631104
 
 Test 035 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_iovr5
 Checking test 036 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 036 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 138.735804
-  0: The maximum resident set size (KB)                   = 637784
+  0: The total amount of wall time                        = 135.743425
+  0: The maximum resident set size (KB)                   = 632612
 
 Test 036 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_p8
 Checking test 037 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1853,14 +1853,14 @@ Checking test 037 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.930710
-  0: The maximum resident set size (KB)                   = 1606212
+  0: The total amount of wall time                        = 166.672191
+  0: The maximum resident set size (KB)                   = 1606336
 
 Test 037 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_restart_p8
 Checking test 038 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1899,14 +1899,14 @@ Checking test 038 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.423530
-  0: The maximum resident set size (KB)                   = 873116
+  0: The total amount of wall time                        = 102.756309
+  0: The maximum resident set size (KB)                   = 874064
 
 Test 038 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_qr_p8
 Checking test 039 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1953,14 +1953,14 @@ Checking test 039 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 170.198703
-  0: The maximum resident set size (KB)                   = 1611696
+  0: The total amount of wall time                        = 168.462476
+  0: The maximum resident set size (KB)                   = 1606056
 
 Test 039 control_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_restart_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_restart_qr_p8
 Checking test 040 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1999,14 +1999,14 @@ Checking test 040 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 91.590195
-  0: The maximum resident set size (KB)                   = 865288
+  0: The total amount of wall time                        = 92.528934
+  0: The maximum resident set size (KB)                   = 871924
 
 Test 040 control_restart_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_decomp_p8
 Checking test 041 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2049,14 +2049,14 @@ Checking test 041 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.360028
-  0: The maximum resident set size (KB)                   = 1587696
+  0: The total amount of wall time                        = 173.626129
+  0: The maximum resident set size (KB)                   = 1590812
 
 Test 041 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_2threads_p8
 Checking test 042 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 042 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 181.370958
-  0: The maximum resident set size (KB)                   = 1689164
+  0: The total amount of wall time                        = 174.332877
+  0: The maximum resident set size (KB)                   = 1695544
 
 Test 042 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_p8_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_p8_lndp
 Checking test 043 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 043 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 317.457693
-  0: The maximum resident set size (KB)                   = 1608708
+  0: The total amount of wall time                        = 322.781381
+  0: The maximum resident set size (KB)                   = 1613576
 
 Test 043 control_p8_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_p8_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_p8_rrtmgp
 Checking test 044 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 044 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.258423
-  0: The maximum resident set size (KB)                   = 1669684
+  0: The total amount of wall time                        = 226.095187
+  0: The maximum resident set size (KB)                   = 1675292
 
 Test 044 control_p8_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_p8_mynn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_p8_mynn
 Checking test 045 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2233,14 +2233,14 @@ Checking test 045 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.670271
-  0: The maximum resident set size (KB)                   = 1615080
+  0: The total amount of wall time                        = 169.857445
+  0: The maximum resident set size (KB)                   = 1614452
 
 Test 045 control_p8_mynn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/merra2_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/merra2_thompson
 Checking test 046 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2287,14 +2287,14 @@ Checking test 046 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.860995
-  0: The maximum resident set size (KB)                   = 1615560
+  0: The total amount of wall time                        = 189.976241
+  0: The maximum resident set size (KB)                   = 1611972
 
 Test 046 merra2_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_control
 Checking test 047 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2305,28 +2305,28 @@ Checking test 047 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 297.837700
-  0: The maximum resident set size (KB)                   = 877316
+  0: The total amount of wall time                        = 317.967460
+  0: The maximum resident set size (KB)                   = 871500
 
 Test 047 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_restart
 Checking test 048 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 154.878157
-  0: The maximum resident set size (KB)                   = 871168
+  0: The total amount of wall time                        = 160.443772
+  0: The maximum resident set size (KB)                   = 865628
 
 Test 048 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_control_qr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_control_qr
 Checking test 049 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2337,28 +2337,28 @@ Checking test 049 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 296.657407
-  0: The maximum resident set size (KB)                   = 872100
+  0: The total amount of wall time                        = 317.147438
+  0: The maximum resident set size (KB)                   = 869272
 
 Test 049 regional_control_qr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_restart_qr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_restart_qr
 Checking test 050 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 153.963477
-  0: The maximum resident set size (KB)                   = 865756
+  0: The total amount of wall time                        = 156.573514
+  0: The maximum resident set size (KB)                   = 864488
 
 Test 050 regional_restart_qr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_decomp
 Checking test 051 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2369,14 +2369,14 @@ Checking test 051 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 313.546564
-  0: The maximum resident set size (KB)                   = 866236
+  0: The total amount of wall time                        = 322.632273
+  0: The maximum resident set size (KB)                   = 867232
 
 Test 051 regional_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_2threads
 Checking test 052 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2387,14 +2387,14 @@ Checking test 052 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 207.639312
-  0: The maximum resident set size (KB)                   = 848308
+  0: The total amount of wall time                        = 204.198133
+  0: The maximum resident set size (KB)                   = 857052
 
 Test 052 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_noquilt
 Checking test 053 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2402,28 +2402,28 @@ Checking test 053 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 317.695845
-  0: The maximum resident set size (KB)                   = 862128
+  0: The total amount of wall time                        = 321.247920
+  0: The maximum resident set size (KB)                   = 863532
 
 Test 053 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_netcdf_parallel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_netcdf_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_netcdf_parallel
 Checking test 054 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 292.401743
-  0: The maximum resident set size (KB)                   = 869560
+  0: The total amount of wall time                        = 320.120896
+  0: The maximum resident set size (KB)                   = 864164
 
 Test 054 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_2dwrtdecomp
 Checking test 055 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2434,14 +2434,14 @@ Checking test 055 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 297.138677
-  0: The maximum resident set size (KB)                   = 818008
+  0: The total amount of wall time                        = 314.839237
+  0: The maximum resident set size (KB)                   = 875208
 
 Test 055 regional_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_wofs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/fv3_regional_wofs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_wofs
 Checking test 056 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2452,14 +2452,14 @@ Checking test 056 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 375.544969
-  0: The maximum resident set size (KB)                   = 633956
+  0: The total amount of wall time                        = 376.170909
+  0: The maximum resident set size (KB)                   = 630060
 
 Test 056 regional_wofs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_control
 Checking test 057 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2506,14 +2506,14 @@ Checking test 057 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.536248
-  0: The maximum resident set size (KB)                   = 1062940
+  0: The total amount of wall time                        = 459.666292
+  0: The maximum resident set size (KB)                   = 1066948
 
 Test 057 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_spp_sppt_shum_skeb
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_spp_sppt_shum_skeb
 Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2524,14 +2524,14 @@ Checking test 058 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 267.255093
-  0: The maximum resident set size (KB)                   = 1143588
+  0: The total amount of wall time                        = 267.680083
+  0: The maximum resident set size (KB)                   = 1193752
 
 Test 058 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_decomp
 Checking test 059 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2578,14 +2578,14 @@ Checking test 059 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 477.164388
-  0: The maximum resident set size (KB)                   = 1014196
+  0: The total amount of wall time                        = 481.253860
+  0: The maximum resident set size (KB)                   = 997008
 
 Test 059 rap_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_2threads
 Checking test 060 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2632,14 +2632,14 @@ Checking test 060 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 470.356117
-  0: The maximum resident set size (KB)                   = 1136148
+  0: The total amount of wall time                        = 472.567070
+  0: The maximum resident set size (KB)                   = 1144472
 
 Test 060 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_restart
 Checking test 061 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2678,14 +2678,14 @@ Checking test 061 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 230.430299
-  0: The maximum resident set size (KB)                   = 962300
+  0: The total amount of wall time                        = 231.168381
+  0: The maximum resident set size (KB)                   = 969516
 
 Test 061 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_sfcdiff
 Checking test 062 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2732,14 +2732,14 @@ Checking test 062 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 457.495147
-  0: The maximum resident set size (KB)                   = 1060812
+  0: The total amount of wall time                        = 456.847308
+  0: The maximum resident set size (KB)                   = 1055312
 
 Test 062 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_sfcdiff_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_sfcdiff_decomp
 Checking test 063 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2786,14 +2786,14 @@ Checking test 063 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 480.828855
-  0: The maximum resident set size (KB)                   = 1010676
+  0: The total amount of wall time                        = 480.615927
+  0: The maximum resident set size (KB)                   = 963220
 
 Test 063 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_sfcdiff_restart
 Checking test 064 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2832,14 +2832,14 @@ Checking test 064 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 343.817476
-  0: The maximum resident set size (KB)                   = 981208
+  0: The total amount of wall time                        = 339.957078
+  0: The maximum resident set size (KB)                   = 984228
 
 Test 064 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control
 Checking test 065 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2886,14 +2886,14 @@ Checking test 065 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 443.573346
-  0: The maximum resident set size (KB)                   = 1001316
+  0: The total amount of wall time                        = 446.154843
+  0: The maximum resident set size (KB)                   = 1063232
 
 Test 065 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_decomp
 Checking test 066 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2940,14 +2940,14 @@ Checking test 066 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 462.419557
-  0: The maximum resident set size (KB)                   = 1002592
+  0: The total amount of wall time                        = 462.373051
+  0: The maximum resident set size (KB)                   = 1000404
 
 Test 066 hrrr_control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_2threads
 Checking test 067 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2994,14 +2994,14 @@ Checking test 067 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 455.277457
-  0: The maximum resident set size (KB)                   = 1140172
+  0: The total amount of wall time                        = 453.749351
+  0: The maximum resident set size (KB)                   = 1141144
 
 Test 067 hrrr_control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_restart
 Checking test 068 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3040,14 +3040,14 @@ Checking test 068 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.367109
-  0: The maximum resident set size (KB)                   = 977844
+  0: The total amount of wall time                        = 329.521139
+  0: The maximum resident set size (KB)                   = 987624
 
 Test 068 hrrr_control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_v1beta
 Checking test 069 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3094,14 +3094,14 @@ Checking test 069 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 452.644843
-  0: The maximum resident set size (KB)                   = 1067040
+  0: The total amount of wall time                        = 455.329131
+  0: The maximum resident set size (KB)                   = 1060724
 
 Test 069 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_v1nssl
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_v1nssl
 Checking test 070 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3116,14 +3116,14 @@ Checking test 070 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 538.464294
-  0: The maximum resident set size (KB)                   = 693116
+  0: The total amount of wall time                        = 540.267869
+  0: The maximum resident set size (KB)                   = 702696
 
 Test 070 rrfs_v1nssl PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_v1nssl_nohailnoccn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_v1nssl_nohailnoccn
 Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3138,14 +3138,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 523.039355
-  0: The maximum resident set size (KB)                   = 758644
+  0: The total amount of wall time                        = 526.890775
+  0: The maximum resident set size (KB)                   = 760748
 
 Test 071 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_smoke_conus13km_hrrr_warm
 Checking test 072 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3154,14 +3154,14 @@ Checking test 072 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 144.632846
-  0: The maximum resident set size (KB)                   = 1032260
+  0: The total amount of wall time                        = 145.122186
+  0: The maximum resident set size (KB)                   = 1031784
 
 Test 072 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3170,14 +3170,14 @@ Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 97.934376
-  0: The maximum resident set size (KB)                   = 944520
+  0: The total amount of wall time                        = 96.507285
+  0: The maximum resident set size (KB)                   = 947092
 
 Test 073 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_conus13km_hrrr_warm
 Checking test 074 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3186,14 +3186,14 @@ Checking test 074 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 130.802221
-  0: The maximum resident set size (KB)                   = 901436
+  0: The total amount of wall time                        = 130.138969
+  0: The maximum resident set size (KB)                   = 943088
 
 Test 074 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 075 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3202,26 +3202,26 @@ Checking test 075 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 147.981714
-  0: The maximum resident set size (KB)                   = 977504
+  0: The total amount of wall time                        = 148.608193
+  0: The maximum resident set size (KB)                   = 1040332
 
 Test 075 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 076 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 68.583903
-  0: The maximum resident set size (KB)                   = 935968
+  0: The total amount of wall time                        = 70.893843
+  0: The maximum resident set size (KB)                   = 931408
 
 Test 076 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_csawmg
 Checking test 077 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3232,14 +3232,14 @@ Checking test 077 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 342.955175
-  0: The maximum resident set size (KB)                   = 726756
+  0: The total amount of wall time                        = 345.217996
+  0: The maximum resident set size (KB)                   = 724976
 
 Test 077 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_csawmgt
 Checking test 078 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3250,14 +3250,14 @@ Checking test 078 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 339.668096
-  0: The maximum resident set size (KB)                   = 672928
+  0: The total amount of wall time                        = 339.571495
+  0: The maximum resident set size (KB)                   = 725844
 
 Test 078 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_ras
 Checking test 079 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3268,26 +3268,26 @@ Checking test 079 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 182.184838
-  0: The maximum resident set size (KB)                   = 715400
+  0: The total amount of wall time                        = 181.641932
+  0: The maximum resident set size (KB)                   = 716588
 
 Test 079 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_wam
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_wam
 Checking test 080 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 112.572405
-  0: The maximum resident set size (KB)                   = 644644
+  0: The total amount of wall time                        = 112.250638
+  0: The maximum resident set size (KB)                   = 640204
 
 Test 080 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_p8_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_p8_faster
 Checking test 081 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3334,14 +3334,14 @@ Checking test 081 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.807982
-  0: The maximum resident set size (KB)                   = 1603052
+  0: The total amount of wall time                        = 153.674685
+  0: The maximum resident set size (KB)                   = 1608392
 
 Test 081 control_p8_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_control_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_control_faster
 Checking test 082 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3352,56 +3352,56 @@ Checking test 082 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 271.168758
-  0: The maximum resident set size (KB)                   = 875056
+  0: The total amount of wall time                        = 270.792263
+  0: The maximum resident set size (KB)                   = 867896
 
 Test 082 regional_control_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 886.561081
-  0: The maximum resident set size (KB)                   = 1026564
+  0: The total amount of wall time                        = 868.817926
+  0: The maximum resident set size (KB)                   = 1023576
 
 Test 083 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 495.909023
-  0: The maximum resident set size (KB)                   = 943756
+  0: The total amount of wall time                        = 494.594011
+  0: The maximum resident set size (KB)                   = 940592
 
 Test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_conus13km_hrrr_warm_debug
 Checking test 085 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 768.534309
-  0: The maximum resident set size (KB)                   = 970984
+  0: The total amount of wall time                        = 764.497690
+  0: The maximum resident set size (KB)                   = 976492
 
 Test 085 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_CubedSphereGrid_debug
 Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3428,334 +3428,334 @@ Checking test 086 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.536277
-  0: The maximum resident set size (KB)                   = 800620
+  0: The total amount of wall time                        = 175.839748
+  0: The maximum resident set size (KB)                   = 798184
 
 Test 086 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_wrtGauss_netcdf_parallel_debug
 Checking test 087 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 165.964688
-  0: The maximum resident set size (KB)                   = 799104
+  0: The total amount of wall time                        = 159.079318
+  0: The maximum resident set size (KB)                   = 794920
 
 Test 087 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_stochy_debug
 Checking test 088 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.762073
-  0: The maximum resident set size (KB)                   = 803416
+  0: The total amount of wall time                        = 181.392188
+  0: The maximum resident set size (KB)                   = 803204
 
 Test 088 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_lndp_debug
 Checking test 089 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.054328
-  0: The maximum resident set size (KB)                   = 806188
+  0: The total amount of wall time                        = 160.108254
+  0: The maximum resident set size (KB)                   = 794748
 
 Test 089 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_csawmg_debug
 Checking test 090 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 248.190782
-  0: The maximum resident set size (KB)                   = 846456
+  0: The total amount of wall time                        = 246.145341
+  0: The maximum resident set size (KB)                   = 847676
 
 Test 090 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_csawmgt_debug
 Checking test 091 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.648645
-  0: The maximum resident set size (KB)                   = 845884
+  0: The total amount of wall time                        = 239.760912
+  0: The maximum resident set size (KB)                   = 847160
 
 Test 091 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_ras_debug
 Checking test 092 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.843301
-  0: The maximum resident set size (KB)                   = 809756
+  0: The total amount of wall time                        = 162.611085
+  0: The maximum resident set size (KB)                   = 810212
 
 Test 092 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_diag_debug
 Checking test 093 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.554328
-  0: The maximum resident set size (KB)                   = 859704
+  0: The total amount of wall time                        = 172.235508
+  0: The maximum resident set size (KB)                   = 823460
 
 Test 093 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_debug_p8
 Checking test 094 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.630132
-  0: The maximum resident set size (KB)                   = 1620212
+  0: The total amount of wall time                        = 178.325941
+  0: The maximum resident set size (KB)                   = 1623616
 
 Test 094 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_debug
 Checking test 095 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 995.208995
-  0: The maximum resident set size (KB)                   = 889752
+  0: The total amount of wall time                        = 988.536634
+  0: The maximum resident set size (KB)                   = 889276
 
 Test 095 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_control_debug
 Checking test 096 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.171433
-  0: The maximum resident set size (KB)                   = 1177184
+  0: The total amount of wall time                        = 285.557542
+  0: The maximum resident set size (KB)                   = 1180944
 
 Test 096 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_debug
 Checking test 097 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.730572
-  0: The maximum resident set size (KB)                   = 1178584
+  0: The total amount of wall time                        = 284.904559
+  0: The maximum resident set size (KB)                   = 1177316
 
 Test 097 hrrr_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_unified_drag_suite_debug
 Checking test 098 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.277386
-  0: The maximum resident set size (KB)                   = 1174608
+  0: The total amount of wall time                        = 280.156018
+  0: The maximum resident set size (KB)                   = 1173000
 
 Test 098 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_diag_debug
 Checking test 099 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 307.733998
-  0: The maximum resident set size (KB)                   = 1267252
+  0: The total amount of wall time                        = 306.333450
+  0: The maximum resident set size (KB)                   = 1257848
 
 Test 099 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_cires_ugwp_debug
 Checking test 100 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 299.548825
-  0: The maximum resident set size (KB)                   = 1171588
+  0: The total amount of wall time                        = 289.768713
+  0: The maximum resident set size (KB)                   = 1178548
 
 Test 100 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_unified_ugwp_debug
 Checking test 101 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.797830
-  0: The maximum resident set size (KB)                   = 1175496
+  0: The total amount of wall time                        = 288.965274
+  0: The maximum resident set size (KB)                   = 1175864
 
 Test 101 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_lndp_debug
 Checking test 102 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.669245
-  0: The maximum resident set size (KB)                   = 1179372
+  0: The total amount of wall time                        = 292.433463
+  0: The maximum resident set size (KB)                   = 1181212
 
 Test 102 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_flake_debug
 Checking test 103 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.218847
-  0: The maximum resident set size (KB)                   = 1173688
+  0: The total amount of wall time                        = 282.444418
+  0: The maximum resident set size (KB)                   = 1175932
 
 Test 103 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_progcld_thompson_debug
 Checking test 104 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.165400
-  0: The maximum resident set size (KB)                   = 1180028
+  0: The total amount of wall time                        = 285.270191
+  0: The maximum resident set size (KB)                   = 1175608
 
 Test 104 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_noah_debug
 Checking test 105 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.869479
-  0: The maximum resident set size (KB)                   = 1182124
+  0: The total amount of wall time                        = 287.064123
+  0: The maximum resident set size (KB)                   = 1142136
 
 Test 105 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_sfcdiff_debug
 Checking test 106 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.749184
-  0: The maximum resident set size (KB)                   = 1180912
+  0: The total amount of wall time                        = 284.720790
+  0: The maximum resident set size (KB)                   = 1171736
 
 Test 106 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 107 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 470.374684
-  0: The maximum resident set size (KB)                   = 1180816
+  0: The total amount of wall time                        = 476.655544
+  0: The maximum resident set size (KB)                   = 1178444
 
 Test 107 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rrfs_v1beta_debug
 Checking test 108 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.696820
-  0: The maximum resident set size (KB)                   = 1167048
+  0: The total amount of wall time                        = 281.983163
+  0: The maximum resident set size (KB)                   = 1176184
 
 Test 108 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_wam_debug
 Checking test 109 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 295.541263
-  0: The maximum resident set size (KB)                   = 524740
+  0: The total amount of wall time                        = 290.777702
+  0: The maximum resident set size (KB)                   = 528672
 
 Test 109 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3766,14 +3766,14 @@ Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 251.779372
-  0: The maximum resident set size (KB)                   = 1086004
+  0: The total amount of wall time                        = 250.969519
+  0: The maximum resident set size (KB)                   = 1087632
 
 Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_control_dyn32_phy32
 Checking test 111 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3820,14 +3820,14 @@ Checking test 111 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 380.722583
-  0: The maximum resident set size (KB)                   = 1003632
+  0: The total amount of wall time                        = 380.329200
+  0: The maximum resident set size (KB)                   = 1005060
 
 Test 111 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_dyn32_phy32
 Checking test 112 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3874,14 +3874,14 @@ Checking test 112 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.850631
-  0: The maximum resident set size (KB)                   = 950028
+  0: The total amount of wall time                        = 197.111988
+  0: The maximum resident set size (KB)                   = 957640
 
 Test 112 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_2threads_dyn32_phy32
 Checking test 113 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3928,14 +3928,14 @@ Checking test 113 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 398.957264
-  0: The maximum resident set size (KB)                   = 1024544
+  0: The total amount of wall time                        = 395.513768
+  0: The maximum resident set size (KB)                   = 1026572
 
 Test 113 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_2threads_dyn32_phy32
 Checking test 114 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3982,14 +3982,14 @@ Checking test 114 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 206.302524
-  0: The maximum resident set size (KB)                   = 1005344
+  0: The total amount of wall time                        = 204.261548
+  0: The maximum resident set size (KB)                   = 999728
 
 Test 114 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_decomp_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_decomp_dyn32_phy32
 Checking test 115 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4036,14 +4036,14 @@ Checking test 115 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 208.062340
-  0: The maximum resident set size (KB)                   = 897984
+  0: The total amount of wall time                        = 210.028117
+  0: The maximum resident set size (KB)                   = 901448
 
 Test 115 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_restart_dyn32_phy32
 Checking test 116 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4082,14 +4082,14 @@ Checking test 116 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 282.812693
-  0: The maximum resident set size (KB)                   = 951140
+  0: The total amount of wall time                        = 282.359329
+  0: The maximum resident set size (KB)                   = 916748
 
 Test 116 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_restart_dyn32_phy32
 Checking test 117 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4128,14 +4128,14 @@ Checking test 117 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 102.324227
-  0: The maximum resident set size (KB)                   = 870596
+  0: The total amount of wall time                        = 102.678007
+  0: The maximum resident set size (KB)                   = 831308
 
 Test 117 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_control_dyn64_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_control_dyn64_phy32
 Checking test 118 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4182,81 +4182,81 @@ Checking test 118 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 242.777655
-  0: The maximum resident set size (KB)                   = 941912
+  0: The total amount of wall time                        = 241.666500
+  0: The maximum resident set size (KB)                   = 966112
 
 Test 118 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_control_debug_dyn32_phy32
 Checking test 119 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.451552
-  0: The maximum resident set size (KB)                   = 1061992
+  0: The total amount of wall time                        = 277.608381
+  0: The maximum resident set size (KB)                   = 1066192
 
 Test 119 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hrrr_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hrrr_control_debug_dyn32_phy32
 Checking test 120 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.402705
-  0: The maximum resident set size (KB)                   = 1059872
+  0: The total amount of wall time                        = 281.186169
+  0: The maximum resident set size (KB)                   = 1066164
 
 Test 120 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/rap_control_dyn64_phy32_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/rap_control_dyn64_phy32_debug
 Checking test 121 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.428808
-  0: The maximum resident set size (KB)                   = 1107772
+  0: The total amount of wall time                        = 289.449805
+  0: The maximum resident set size (KB)                   = 1105960
 
 Test 121 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_atm
 Checking test 122 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 265.759015
-  0: The maximum resident set size (KB)                   = 1051304
+  0: The total amount of wall time                        = 263.467270
+  0: The maximum resident set size (KB)                   = 1060952
 
 Test 122 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_atm_thompson_gfdlsf
 Checking test 123 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 408.295196
-  0: The maximum resident set size (KB)                   = 1400320
+  0: The total amount of wall time                        = 398.461310
+  0: The maximum resident set size (KB)                   = 1428632
 
 Test 123 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_atm_ocn
 Checking test 124 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4265,30 +4265,30 @@ Checking test 124 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 377.556505
-  0: The maximum resident set size (KB)                   = 1236100
+  0: The total amount of wall time                        = 373.478730
+  0: The maximum resident set size (KB)                   = 1233468
 
 Test 124 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_atm_wav
 Checking test 125 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 726.919353
-  0: The maximum resident set size (KB)                   = 1266144
+  0: The total amount of wall time                        = 722.668913
+  0: The maximum resident set size (KB)                   = 1286524
 
 Test 125 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_atm_ocn_wav
 Checking test 126 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4296,31 +4296,31 @@ Checking test 126 hafs_regional_atm_ocn_wav results ....
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 830.398805
-  0: The maximum resident set size (KB)                   = 1225908
+  0: The total amount of wall time                        = 826.121638
+  0: The maximum resident set size (KB)                   = 1282832
 
 Test 126 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_1nest_atm
 Checking test 127 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 361.522534
-  0: The maximum resident set size (KB)                   = 507816
+  0: The total amount of wall time                        = 360.110703
+  0: The maximum resident set size (KB)                   = 509456
 
 Test 127 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_telescopic_2nests_atm
 Checking test 128 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4329,28 +4329,28 @@ Checking test 128 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 414.007574
-  0: The maximum resident set size (KB)                   = 519928
+  0: The total amount of wall time                        = 441.193403
+  0: The maximum resident set size (KB)                   = 514944
 
 Test 128 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_global_1nest_atm
 Checking test 129 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 172.194458
-  0: The maximum resident set size (KB)                   = 356904
+  0: The total amount of wall time                        = 174.097911
+  0: The maximum resident set size (KB)                   = 361456
 
 Test 129 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_global_multiple_4nests_atm
 Checking test 130 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4368,14 +4368,14 @@ Checking test 130 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 461.130139
-  0: The maximum resident set size (KB)                   = 428728
+  0: The total amount of wall time                        = 462.725770
+  0: The maximum resident set size (KB)                   = 433444
 
 Test 130 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_specified_moving_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_specified_moving_1nest_atm
 Checking test 131 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4384,28 +4384,28 @@ Checking test 131 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 228.211707
-  0: The maximum resident set size (KB)                   = 530644
+  0: The total amount of wall time                        = 229.710359
+  0: The maximum resident set size (KB)                   = 531524
 
 Test 131 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_storm_following_1nest_atm
 Checking test 132 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 217.402211
-  0: The maximum resident set size (KB)                   = 528952
+  0: The total amount of wall time                        = 217.700429
+  0: The maximum resident set size (KB)                   = 523572
 
 Test 132 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 133 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4414,42 +4414,42 @@ Checking test 133 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 288.741746
-  0: The maximum resident set size (KB)                   = 569016
+  0: The total amount of wall time                        = 287.810792
+  0: The maximum resident set size (KB)                   = 569428
 
 Test 133 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_global_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_global_storm_following_1nest_atm
 Checking test 134 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 68.092813
-  0: The maximum resident set size (KB)                   = 369032
+  0: The total amount of wall time                        = 68.720297
+  0: The maximum resident set size (KB)                   = 374512
 
 Test 134 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 789.952451
-  0: The maximum resident set size (KB)                   = 606168
+  0: The total amount of wall time                        = 796.680035
+  0: The maximum resident set size (KB)                   = 594928
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 136 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4460,14 +4460,14 @@ Checking test 136 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 535.841316
-  0: The maximum resident set size (KB)                   = 617380
+  0: The total amount of wall time                        = 538.006011
+  0: The maximum resident set size (KB)                   = 627856
 
 Test 136 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_docn
 Checking test 137 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4475,14 +4475,14 @@ Checking test 137 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 364.677356
-  0: The maximum resident set size (KB)                   = 1180356
+  0: The total amount of wall time                        = 357.840520
+  0: The maximum resident set size (KB)                   = 1243472
 
 Test 137 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_docn_oisst
 Checking test 138 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4490,131 +4490,131 @@ Checking test 138 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 359.203480
-  0: The maximum resident set size (KB)                   = 1219992
+  0: The total amount of wall time                        = 361.481893
+  0: The maximum resident set size (KB)                   = 1224160
 
 Test 138 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/hafs_regional_datm_cdeps
 Checking test 139 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 941.559831
-  0: The maximum resident set size (KB)                   = 1036744
+  0: The total amount of wall time                        = 933.787702
+  0: The maximum resident set size (KB)                   = 1046832
 
 Test 139 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_control_cfsr
 Checking test 140 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.645775
- 0: The maximum resident set size (KB)                   = 1048792
+ 0: The total amount of wall time                        = 146.406317
+ 0: The maximum resident set size (KB)                   = 1065976
 
 Test 140 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_restart_cfsr
 Checking test 141 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 94.093936
- 0: The maximum resident set size (KB)                   = 1010516
+ 0: The total amount of wall time                        = 88.071125
+ 0: The maximum resident set size (KB)                   = 1028032
 
 Test 141 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_control_gefs
 Checking test 142 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.334809
- 0: The maximum resident set size (KB)                   = 961896
+ 0: The total amount of wall time                        = 145.741395
+ 0: The maximum resident set size (KB)                   = 947476
 
 Test 142 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_iau_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_iau_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_iau_gefs
 Checking test 143 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.182718
- 0: The maximum resident set size (KB)                   = 953428
+ 0: The total amount of wall time                        = 145.261303
+ 0: The maximum resident set size (KB)                   = 975088
 
 Test 143 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_stochy_gefs
 Checking test 144 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.880993
- 0: The maximum resident set size (KB)                   = 961204
+ 0: The total amount of wall time                        = 145.185667
+ 0: The maximum resident set size (KB)                   = 967700
 
 Test 144 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_ciceC_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_ciceC_cfsr
 Checking test 145 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.383316
- 0: The maximum resident set size (KB)                   = 1059064
+ 0: The total amount of wall time                        = 146.756048
+ 0: The maximum resident set size (KB)                   = 1069664
 
 Test 145 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_bulk_cfsr
 Checking test 146 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.354040
- 0: The maximum resident set size (KB)                   = 1049092
+ 0: The total amount of wall time                        = 147.200393
+ 0: The maximum resident set size (KB)                   = 1064720
 
 Test 146 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_bulk_gefs
 Checking test 147 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.526539
- 0: The maximum resident set size (KB)                   = 964428
+ 0: The total amount of wall time                        = 140.620915
+ 0: The maximum resident set size (KB)                   = 966136
 
 Test 147 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_mx025_cfsr
 Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4623,14 +4623,14 @@ Checking test 148 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 432.848779
-  0: The maximum resident set size (KB)                   = 882564
+  0: The total amount of wall time                        = 436.112190
+  0: The maximum resident set size (KB)                   = 872016
 
 Test 148 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_mx025_gefs
 Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4639,77 +4639,77 @@ Checking test 149 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 433.732868
-  0: The maximum resident set size (KB)                   = 935376
+  0: The total amount of wall time                        = 438.317972
+  0: The maximum resident set size (KB)                   = 936840
 
 Test 149 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_multiple_files_cfsr
 Checking test 150 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.280865
- 0: The maximum resident set size (KB)                   = 1072052
+ 0: The total amount of wall time                        = 147.428317
+ 0: The maximum resident set size (KB)                   = 1074940
 
 Test 150 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_3072x1536_cfsr
 Checking test 151 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 204.727256
- 0: The maximum resident set size (KB)                   = 2365832
+ 0: The total amount of wall time                        = 199.653139
+ 0: The maximum resident set size (KB)                   = 2305960
 
 Test 151 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_gfs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_gfs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_gfs
 Checking test 152 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 205.332922
- 0: The maximum resident set size (KB)                   = 2351312
+ 0: The total amount of wall time                        = 200.199389
+ 0: The maximum resident set size (KB)                   = 2353672
 
 Test 152 datm_cdeps_gfs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_debug_cfsr
 Checking test 153 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 452.844463
- 0: The maximum resident set size (KB)                   = 976224
+ 0: The total amount of wall time                        = 433.731604
+ 0: The maximum resident set size (KB)                   = 1000132
 
 Test 153 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_control_cfsr_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_control_cfsr_faster
 Checking test 154 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.208315
- 0: The maximum resident set size (KB)                   = 1071196
+ 0: The total amount of wall time                        = 148.437846
+ 0: The maximum resident set size (KB)                   = 1077516
 
 Test 154 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_lnd_gswp3
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_lnd_gswp3
 Checking test 155 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4718,14 +4718,14 @@ Checking test 155 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.656714
-  0: The maximum resident set size (KB)                   = 260416
+  0: The total amount of wall time                        = 7.527640
+  0: The maximum resident set size (KB)                   = 266672
 
 Test 155 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/datm_cdeps_lnd_gswp3_rst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/datm_cdeps_lnd_gswp3_rst
 Checking test 156 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4734,14 +4734,14 @@ Checking test 156 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 13.153722
-  0: The maximum resident set size (KB)                   = 261336
+  0: The total amount of wall time                        = 13.254512
+  0: The maximum resident set size (KB)                   = 265172
 
 Test 156 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_p8_atmlnd_sbs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_p8_atmlnd_sbs
 Checking test 157 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4826,14 +4826,14 @@ Checking test 157 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.255672
-  0: The maximum resident set size (KB)                   = 1608012
+  0: The total amount of wall time                        = 203.298471
+  0: The maximum resident set size (KB)                   = 1606656
 
 Test 157 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/control_atmwav
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/control_atmwav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/control_atmwav
 Checking test 158 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4877,14 +4877,14 @@ Checking test 158 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 88.473338
-  0: The maximum resident set size (KB)                   = 663772
+  0: The total amount of wall time                        = 87.047530
+  0: The maximum resident set size (KB)                   = 670724
 
 Test 158 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/atmaero_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/atmaero_control_p8
 Checking test 159 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4928,14 +4928,14 @@ Checking test 159 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.887469
-  0: The maximum resident set size (KB)                   = 2975968
+  0: The total amount of wall time                        = 226.753447
+  0: The maximum resident set size (KB)                   = 2974084
 
 Test 159 atmaero_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/atmaero_control_p8_rad
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/atmaero_control_p8_rad
 Checking test 160 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4979,14 +4979,14 @@ Checking test 160 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 280.146878
-  0: The maximum resident set size (KB)                   = 3051440
+  0: The total amount of wall time                        = 281.119158
+  0: The maximum resident set size (KB)                   = 3045704
 
 Test 160 atmaero_control_p8_rad PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad_micro
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/atmaero_control_p8_rad_micro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/atmaero_control_p8_rad_micro
 Checking test 161 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5030,14 +5030,14 @@ Checking test 161 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 285.456283
-  0: The maximum resident set size (KB)                   = 3057716
+  0: The total amount of wall time                        = 285.167559
+  0: The maximum resident set size (KB)                   = 3063456
 
 Test 161 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_atmaq
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_atmaq
 Checking test 162 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5053,14 +5053,14 @@ Checking test 162 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 623.230267
-  0: The maximum resident set size (KB)                   = 1344252
+  0: The total amount of wall time                        = 618.876739
+  0: The maximum resident set size (KB)                   = 1475488
 
 Test 162 regional_atmaq PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_debug
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_atmaq_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_atmaq_debug
 Checking test 163 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5074,14 +5074,14 @@ Checking test 163 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1238.568553
-  0: The maximum resident set size (KB)                   = 1416580
+  0: The total amount of wall time                        = 1249.891000
+  0: The maximum resident set size (KB)                   = 1409420
 
 Test 163 regional_atmaq_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /work/noaa/epic-ps/zshrader/rt-1646/stmp/zshrader/FV3_RT/rt_225370/regional_atmaq_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1692/stmp/jongkim/FV3_RT/rt_98941/regional_atmaq_faster
 Checking test 164 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5097,12 +5097,12 @@ Checking test 164 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 545.397838
-  0: The maximum resident set size (KB)                   = 1473436
+  0: The total amount of wall time                        = 539.677141
+  0: The maximum resident set size (KB)                   = 1481880
 
 Test 164 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 10:26:36 CDT 2023
-Elapsed time: 01h:15m:39s. Have a nice day!
+Sun Apr  2 09:31:51 CDT 2023
+Elapsed time: 01h:14m:50s. Have a nice day!

--- a/tests/RegressionTests_wcoss2.intel.log
+++ b/tests/RegressionTests_wcoss2.intel.log
@@ -1,34 +1,34 @@
-Thu Mar 30 16:43:37 UTC 2023
+Mon Apr  3 17:53:26 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 583 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1090 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1241 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 1194 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 507 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 1300 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 524 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 983 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 468 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 693 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1430 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 391 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 149 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 1127 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 973 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 512 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 1166 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 715 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 837 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 1158 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 670 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 1103 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 786 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 519 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 561 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 953 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 578 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 540 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 1226 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 497 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 1629 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 965 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 765 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 467 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 966 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 760 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 592 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 148 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 883 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 969 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 241 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 214 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 590 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 601 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 902 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 682 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 723 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 627 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 426 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 826 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_p8_mixedmode
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 339.356527
-The maximum resident set size (KB)                   = 2947488
+The total amount of wall time                        = 337.489535
+The maximum resident set size (KB)                   = 2950372
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_p8
 Checking test 002 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -165,14 +165,14 @@ Checking test 002 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 388.737483
-The maximum resident set size (KB)                   = 2983224
+The total amount of wall time                        = 384.892323
+The maximum resident set size (KB)                   = 2981724
 
 Test 002 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_restart_p8
 Checking test 003 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -225,14 +225,14 @@ Checking test 003 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 238.375219
-The maximum resident set size (KB)                   = 2867060
+The total amount of wall time                        = 232.791247
+The maximum resident set size (KB)                   = 2865828
 
 Test 003 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_qr_p8
 Checking test 004 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -297,14 +297,14 @@ Checking test 004 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 389.541412
-The maximum resident set size (KB)                   = 3000076
+The total amount of wall time                        = 387.812452
+The maximum resident set size (KB)                   = 2992396
 
 Test 004 cpld_control_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_restart_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_restart_qr_p8
 Checking test 005 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -357,14 +357,14 @@ Checking test 005 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 243.206878
-The maximum resident set size (KB)                   = 2881052
+The total amount of wall time                        = 233.552347
+The maximum resident set size (KB)                   = 2883352
 
 Test 005 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_2threads_p8
 Checking test 006 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -417,14 +417,14 @@ Checking test 006 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 374.436641
-The maximum resident set size (KB)                   = 3281804
+The total amount of wall time                        = 366.550339
+The maximum resident set size (KB)                   = 3284564
 
 Test 006 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -477,14 +477,14 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 387.568506
-The maximum resident set size (KB)                   = 2980852
+The total amount of wall time                        = 382.186434
+The maximum resident set size (KB)                   = 2980100
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_mpi_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -537,14 +537,14 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 323.434443
-The maximum resident set size (KB)                   = 2915192
+The total amount of wall time                        = 319.237893
+The maximum resident set size (KB)                   = 2917724
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_ciceC_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -609,14 +609,14 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 385.813143
-The maximum resident set size (KB)                   = 2981136
+The total amount of wall time                        = 385.159819
+The maximum resident set size (KB)                   = 2986796
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_bmark_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -664,14 +664,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 947.587975
-The maximum resident set size (KB)                   = 3928936
+The total amount of wall time                        = 946.255433
+The maximum resident set size (KB)                   = 3927932
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_bmark_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_restart_bmark_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_bmark_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -719,14 +719,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 675.894020
-The maximum resident set size (KB)                   = 3902436
+The total amount of wall time                        = 652.011956
+The maximum resident set size (KB)                   = 3896808
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_noaero_p8
 Checking test 012 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -790,14 +790,14 @@ Checking test 012 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 291.238122
-The maximum resident set size (KB)                   = 1576780
+The total amount of wall time                        = 282.253788
+The maximum resident set size (KB)                   = 1576148
 
 Test 012 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_nowave_noaero_p8
 Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -859,14 +859,14 @@ Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 308.095725
-The maximum resident set size (KB)                   = 1635952
+The total amount of wall time                        = 301.544828
+The maximum resident set size (KB)                   = 1632772
 
 Test 013 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_noaero_p8_agrid
 Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -928,14 +928,14 @@ Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 312.234147
-The maximum resident set size (KB)                   = 1633464
+The total amount of wall time                        = 307.188134
+The maximum resident set size (KB)                   = 1628496
 
 Test 014 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_c48
 Checking test 015 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -985,14 +985,14 @@ Checking test 015 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 435.165742
-The maximum resident set size (KB)                   = 2636940
+The total amount of wall time                        = 437.267283
+The maximum resident set size (KB)                   = 2638172
 
 Test 015 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_warmstart_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_warmstart_c48
 Checking test 016 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1042,14 +1042,14 @@ Checking test 016 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 123.273780
-The maximum resident set size (KB)                   = 2650464
+The total amount of wall time                        = 127.094144
+The maximum resident set size (KB)                   = 2655636
 
 Test 016 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_restart_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_restart_c48
 Checking test 017 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1099,14 +1099,14 @@ Checking test 017 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 67.528582
-The maximum resident set size (KB)                   = 2068236
+The total amount of wall time                        = 70.004850
+The maximum resident set size (KB)                   = 2064856
 
 Test 017 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/cpld_control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/cpld_control_p8_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/cpld_control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/cpld_control_p8_faster
 Checking test 018 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1171,14 +1171,14 @@ Checking test 018 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 384.012870
-The maximum resident set size (KB)                   = 2980036
+The total amount of wall time                        = 379.990340
+The maximum resident set size (KB)                   = 2980548
 
 Test 018 cpld_control_p8_faster PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_CubedSphereGrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1205,14 +1205,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 130.483218
-The maximum resident set size (KB)                   = 514772
+The total amount of wall time                        = 130.664148
+The maximum resident set size (KB)                   = 513492
 
 Test 019 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_latlon
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1223,14 +1223,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.606261
-The maximum resident set size (KB)                   = 516340
+The total amount of wall time                        = 133.155363
+The maximum resident set size (KB)                   = 516108
 
 Test 020 control_latlon PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1241,14 +1241,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.298354
-The maximum resident set size (KB)                   = 520204
+The total amount of wall time                        = 138.996144
+The maximum resident set size (KB)                   = 517432
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1287,14 +1287,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 326.180164
-The maximum resident set size (KB)                   = 674752
+The total amount of wall time                        = 327.518357
+The maximum resident set size (KB)                   = 675096
 
 Test 022 control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_c192
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1305,14 +1305,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 529.925635
-The maximum resident set size (KB)                   = 617000
+The total amount of wall time                        = 530.723391
+The maximum resident set size (KB)                   = 615960
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_c384
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1323,14 +1323,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 572.468467
-The maximum resident set size (KB)                   = 921816
+The total amount of wall time                        = 574.295178
+The maximum resident set size (KB)                   = 926916
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_c384gdas
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1373,14 +1373,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 495.522462
-The maximum resident set size (KB)                   = 1055512
+The total amount of wall time                        = 498.610914
+The maximum resident set size (KB)                   = 1059256
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_stochy
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,28 +1391,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 90.160810
-The maximum resident set size (KB)                   = 521304
+The total amount of wall time                        = 90.094194
+The maximum resident set size (KB)                   = 523264
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_stochy_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 48.990982
-The maximum resident set size (KB)                   = 291808
+The total amount of wall time                        = 49.404689
+The maximum resident set size (KB)                   = 292460
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1423,14 +1423,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 83.545430
-The maximum resident set size (KB)                   = 520876
+The total amount of wall time                        = 84.271750
+The maximum resident set size (KB)                   = 517696
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_iovr4
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1445,14 +1445,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 138.864274
-The maximum resident set size (KB)                   = 518420
+The total amount of wall time                        = 137.272839
+The maximum resident set size (KB)                   = 518008
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_iovr5
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1467,14 +1467,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.610595
-The maximum resident set size (KB)                   = 517008
+The total amount of wall time                        = 137.495265
+The maximum resident set size (KB)                   = 517204
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1521,14 +1521,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.111697
-The maximum resident set size (KB)                   = 1491636
+The total amount of wall time                        = 180.620164
+The maximum resident set size (KB)                   = 1492792
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_restart_p8
 Checking test 032 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1567,14 +1567,14 @@ Checking test 032 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 101.252551
-The maximum resident set size (KB)                   = 656044
+The total amount of wall time                        = 100.435536
+The maximum resident set size (KB)                   = 657404
 
 Test 032 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_qr_p8
 Checking test 033 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1621,14 +1621,14 @@ Checking test 033 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 177.413551
-The maximum resident set size (KB)                   = 1492516
+The total amount of wall time                        = 179.116649
+The maximum resident set size (KB)                   = 1497036
 
 Test 033 control_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_restart_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_restart_qr_p8
 Checking test 034 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1667,14 +1667,14 @@ Checking test 034 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 102.273538
-The maximum resident set size (KB)                   = 670808
+The total amount of wall time                        = 101.864674
+The maximum resident set size (KB)                   = 662832
 
 Test 034 control_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_decomp_p8
 Checking test 035 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1717,14 +1717,14 @@ Checking test 035 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 181.866662
-The maximum resident set size (KB)                   = 1474700
+The total amount of wall time                        = 182.625300
+The maximum resident set size (KB)                   = 1479216
 
 Test 035 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_2threads_p8
 Checking test 036 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1767,14 +1767,14 @@ Checking test 036 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 157.361175
-The maximum resident set size (KB)                   = 1573928
+The total amount of wall time                        = 156.300756
+The maximum resident set size (KB)                   = 1577284
 
 Test 036 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_p8_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_p8_lndp
 Checking test 037 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1793,14 +1793,14 @@ Checking test 037 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 323.208059
-The maximum resident set size (KB)                   = 1490060
+The total amount of wall time                        = 322.592086
+The maximum resident set size (KB)                   = 1490552
 
 Test 037 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_p8_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_p8_rrtmgp
 Checking test 038 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1847,14 +1847,14 @@ Checking test 038 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 233.386219
-The maximum resident set size (KB)                   = 1550284
+The total amount of wall time                        = 236.746598
+The maximum resident set size (KB)                   = 1546908
 
 Test 038 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_mynn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_p8_mynn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_mynn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_p8_mynn
 Checking test 039 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1901,14 +1901,14 @@ Checking test 039 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.627971
-The maximum resident set size (KB)                   = 1483868
+The total amount of wall time                        = 181.527869
+The maximum resident set size (KB)                   = 1486568
 
 Test 039 control_p8_mynn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/merra2_thompson
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/merra2_thompson
 Checking test 040 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1955,14 +1955,14 @@ Checking test 040 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 210.194255
-The maximum resident set size (KB)                   = 1489748
+The total amount of wall time                        = 205.400034
+The maximum resident set size (KB)                   = 1499088
 
 Test 040 merra2_thompson PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_control
 Checking test 041 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1973,28 +1973,28 @@ Checking test 041 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 287.090084
-The maximum resident set size (KB)                   = 651652
+The total amount of wall time                        = 287.754384
+The maximum resident set size (KB)                   = 657372
 
 Test 041 regional_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_restart
 Checking test 042 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 164.015793
-The maximum resident set size (KB)                   = 650612
+The total amount of wall time                        = 155.227921
+The maximum resident set size (KB)                   = 653956
 
 Test 042 regional_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_control_qr
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_control_qr
 Checking test 043 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2005,28 +2005,28 @@ Checking test 043 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 288.903807
-The maximum resident set size (KB)                   = 657072
+The total amount of wall time                        = 289.669159
+The maximum resident set size (KB)                   = 652320
 
 Test 043 regional_control_qr PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_restart_qr
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_restart_qr
 Checking test 044 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 161.960677
-The maximum resident set size (KB)                   = 654108
+The total amount of wall time                        = 156.158091
+The maximum resident set size (KB)                   = 652964
 
 Test 044 regional_restart_qr PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_decomp
 Checking test 045 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2037,14 +2037,14 @@ Checking test 045 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 304.186242
-The maximum resident set size (KB)                   = 655976
+The total amount of wall time                        = 304.934877
+The maximum resident set size (KB)                   = 655468
 
 Test 045 regional_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_2threads
 Checking test 046 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2055,14 +2055,14 @@ Checking test 046 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 177.418116
-The maximum resident set size (KB)                   = 698528
+The total amount of wall time                        = 177.020440
+The maximum resident set size (KB)                   = 694936
 
 Test 046 regional_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_noquilt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_noquilt
 Checking test 047 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2070,28 +2070,28 @@ Checking test 047 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 312.984505
-The maximum resident set size (KB)                   = 649000
+The total amount of wall time                        = 311.726052
+The maximum resident set size (KB)                   = 646316
 
 Test 047 regional_noquilt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_netcdf_parallel
 Checking test 048 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-The total amount of wall time                        = 283.761438
-The maximum resident set size (KB)                   = 648312
+The total amount of wall time                        = 285.317967
+The maximum resident set size (KB)                   = 649340
 
 Test 048 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_2dwrtdecomp
 Checking test 049 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2102,14 +2102,14 @@ Checking test 049 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 292.499809
-The maximum resident set size (KB)                   = 655408
+The total amount of wall time                        = 291.744435
+The maximum resident set size (KB)                   = 651944
 
 Test 049 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/fv3_regional_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_wofs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/fv3_regional_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_wofs
 Checking test 050 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2120,14 +2120,14 @@ Checking test 050 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 365.568894
-The maximum resident set size (KB)                   = 341400
+The total amount of wall time                        = 362.598186
+The maximum resident set size (KB)                   = 340768
 
 Test 050 regional_wofs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_control
 Checking test 051 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2174,14 +2174,14 @@ Checking test 051 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 426.398033
-The maximum resident set size (KB)                   = 889704
+The total amount of wall time                        = 420.116609
+The maximum resident set size (KB)                   = 894320
 
 Test 051 rap_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_spp_sppt_shum_skeb
 Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2192,14 +2192,14 @@ Checking test 052 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 247.580329
-The maximum resident set size (KB)                   = 986796
+The total amount of wall time                        = 245.033569
+The maximum resident set size (KB)                   = 989992
 
 Test 052 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_decomp
 Checking test 053 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 053 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 439.570540
-The maximum resident set size (KB)                   = 895284
+The total amount of wall time                        = 436.064549
+The maximum resident set size (KB)                   = 892688
 
 Test 053 rap_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_2threads
 Checking test 054 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 054 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 396.990878
-The maximum resident set size (KB)                   = 969480
+The total amount of wall time                        = 388.199920
+The maximum resident set size (KB)                   = 964000
 
 Test 054 rap_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_restart
 Checking test 055 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2346,14 +2346,14 @@ Checking test 055 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 213.081226
-The maximum resident set size (KB)                   = 646632
+The total amount of wall time                        = 213.511333
+The maximum resident set size (KB)                   = 645564
 
 Test 055 rap_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_sfcdiff
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_sfcdiff
 Checking test 056 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2400,14 +2400,14 @@ Checking test 056 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 431.579594
-The maximum resident set size (KB)                   = 889116
+The total amount of wall time                        = 422.975040
+The maximum resident set size (KB)                   = 891156
 
 Test 056 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_sfcdiff_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_sfcdiff_decomp
 Checking test 057 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2454,14 +2454,14 @@ Checking test 057 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 446.110948
-The maximum resident set size (KB)                   = 895304
+The total amount of wall time                        = 436.589800
+The maximum resident set size (KB)                   = 893000
 
 Test 057 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_sfcdiff_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_sfcdiff_restart
 Checking test 058 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2500,14 +2500,14 @@ Checking test 058 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 312.263861
-The maximum resident set size (KB)                   = 645312
+The total amount of wall time                        = 309.199751
+The maximum resident set size (KB)                   = 640912
 
 Test 058 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control
 Checking test 059 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2554,14 +2554,14 @@ Checking test 059 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 412.453949
-The maximum resident set size (KB)                   = 888108
+The total amount of wall time                        = 406.256367
+The maximum resident set size (KB)                   = 893164
 
 Test 059 hrrr_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_decomp
 Checking test 060 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2608,14 +2608,14 @@ Checking test 060 hrrr_control_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 428.910135
-The maximum resident set size (KB)                   = 888712
+The total amount of wall time                        = 420.643622
+The maximum resident set size (KB)                   = 892000
 
 Test 060 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_2threads
 Checking test 061 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2662,14 +2662,14 @@ Checking test 061 hrrr_control_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 380.294590
-The maximum resident set size (KB)                   = 961836
+The total amount of wall time                        = 373.805934
+The maximum resident set size (KB)                   = 961188
 
 Test 061 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_restart
 Checking test 062 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2708,14 +2708,14 @@ Checking test 062 hrrr_control_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 298.757290
-The maximum resident set size (KB)                   = 637392
+The total amount of wall time                        = 300.798080
+The maximum resident set size (KB)                   = 639632
 
 Test 062 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_v1beta
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_v1beta
 Checking test 063 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2762,14 +2762,14 @@ Checking test 063 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 427.000330
-The maximum resident set size (KB)                   = 891684
+The total amount of wall time                        = 417.174639
+The maximum resident set size (KB)                   = 891016
 
 Test 063 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_v1nssl
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_v1nssl
 Checking test 064 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2784,14 +2784,14 @@ Checking test 064 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 485.488767
-The maximum resident set size (KB)                   = 576532
+The total amount of wall time                        = 482.772214
+The maximum resident set size (KB)                   = 576524
 
 Test 064 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_v1nssl_nohailnoccn
 Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2806,14 +2806,14 @@ Checking test 065 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 471.690244
-The maximum resident set size (KB)                   = 569248
+The total amount of wall time                        = 471.478038
+The maximum resident set size (KB)                   = 571096
 
 Test 065 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_smoke_conus13km_hrrr_warm
 Checking test 066 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2822,14 +2822,14 @@ Checking test 066 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 148.082861
-The maximum resident set size (KB)                   = 801700
+The total amount of wall time                        = 147.672488
+The maximum resident set size (KB)                   = 800968
 
 Test 066 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2838,14 +2838,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 104.206183
-The maximum resident set size (KB)                   = 802340
+The total amount of wall time                        = 103.489943
+The maximum resident set size (KB)                   = 805060
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_conus13km_hrrr_warm
 Checking test 068 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2854,14 +2854,14 @@ Checking test 068 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 134.939888
-The maximum resident set size (KB)                   = 777144
+The total amount of wall time                        = 133.944444
+The maximum resident set size (KB)                   = 777520
 
 Test 068 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 069 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2870,26 +2870,26 @@ Checking test 069 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 152.992877
-The maximum resident set size (KB)                   = 801708
+The total amount of wall time                        = 149.811496
+The maximum resident set size (KB)                   = 802488
 
 Test 069 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 070 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 76.423415
-The maximum resident set size (KB)                   = 758968
+The total amount of wall time                        = 68.271797
+The maximum resident set size (KB)                   = 765056
 
 Test 070 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_csawmg
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_csawmg
 Checking test 071 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2900,14 +2900,14 @@ Checking test 071 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 348.225736
-The maximum resident set size (KB)                   = 587004
+The total amount of wall time                        = 349.624549
+The maximum resident set size (KB)                   = 592888
 
 Test 071 control_csawmg PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_csawmgt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_csawmgt
 Checking test 072 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2918,14 +2918,14 @@ Checking test 072 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 347.946480
-The maximum resident set size (KB)                   = 588788
+The total amount of wall time                        = 346.880771
+The maximum resident set size (KB)                   = 587408
 
 Test 072 control_csawmgt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_ras
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_ras
 Checking test 073 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2936,26 +2936,26 @@ Checking test 073 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 182.525162
-The maximum resident set size (KB)                   = 554612
+The total amount of wall time                        = 186.375383
+The maximum resident set size (KB)                   = 557680
 
 Test 073 control_ras PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_wam
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_wam
 Checking test 074 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 118.148895
-The maximum resident set size (KB)                   = 289456
+The total amount of wall time                        = 119.951939
+The maximum resident set size (KB)                   = 276724
 
 Test 074 control_wam PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_p8_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_p8_faster
 Checking test 075 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3002,14 +3002,14 @@ Checking test 075 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.917617
-The maximum resident set size (KB)                   = 1486624
+The total amount of wall time                        = 175.115470
+The maximum resident set size (KB)                   = 1490300
 
 Test 075 control_p8_faster PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_control_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_control_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_control_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_control_faster
 Checking test 076 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3020,56 +3020,56 @@ Checking test 076 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 281.742502
-The maximum resident set size (KB)                   = 656560
+The total amount of wall time                        = 280.361293
+The maximum resident set size (KB)                   = 653076
 
 Test 076 regional_control_faster PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 077 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 903.032498
-The maximum resident set size (KB)                   = 834644
+The total amount of wall time                        = 902.613044
+The maximum resident set size (KB)                   = 838928
 
 Test 077 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 078 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 523.361096
-The maximum resident set size (KB)                   = 838952
+The total amount of wall time                        = 523.112094
+The maximum resident set size (KB)                   = 840460
 
 Test 078 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_conus13km_hrrr_warm_debug
 Checking test 079 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 809.430939
-The maximum resident set size (KB)                   = 818640
+The total amount of wall time                        = 809.636380
+The maximum resident set size (KB)                   = 813004
 
 Test 079 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_CubedSphereGrid_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_CubedSphereGrid_debug
 Checking test 080 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3096,334 +3096,334 @@ Checking test 080 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 171.532151
-The maximum resident set size (KB)                   = 680448
+The total amount of wall time                        = 168.784719
+The maximum resident set size (KB)                   = 678924
 
 Test 080 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_wrtGauss_netcdf_parallel_debug
 Checking test 081 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.326909
-The maximum resident set size (KB)                   = 678732
+The total amount of wall time                        = 159.553202
+The maximum resident set size (KB)                   = 680056
 
 Test 081 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_stochy_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_stochy_debug
 Checking test 082 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.184390
-The maximum resident set size (KB)                   = 687080
+The total amount of wall time                        = 179.610460
+The maximum resident set size (KB)                   = 685428
 
 Test 082 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_lndp_debug
 Checking test 083 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.656141
-The maximum resident set size (KB)                   = 687416
+The total amount of wall time                        = 161.666562
+The maximum resident set size (KB)                   = 687648
 
 Test 083 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_csawmg_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_csawmg_debug
 Checking test 084 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 256.520821
-The maximum resident set size (KB)                   = 726120
+The total amount of wall time                        = 256.302992
+The maximum resident set size (KB)                   = 727848
 
 Test 084 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_csawmgt_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_csawmgt_debug
 Checking test 085 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 252.019112
-The maximum resident set size (KB)                   = 724212
+The total amount of wall time                        = 251.969692
+The maximum resident set size (KB)                   = 721688
 
 Test 085 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_ras_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_ras_debug
 Checking test 086 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 164.308167
-The maximum resident set size (KB)                   = 692736
+The total amount of wall time                        = 162.493887
+The maximum resident set size (KB)                   = 697604
 
 Test 086 control_ras_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_diag_debug
 Checking test 087 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.308211
-The maximum resident set size (KB)                   = 740436
+The total amount of wall time                        = 165.222955
+The maximum resident set size (KB)                   = 740544
 
 Test 087 control_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_debug_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_debug_p8
 Checking test 088 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 186.828576
-The maximum resident set size (KB)                   = 1506780
+The total amount of wall time                        = 187.678802
+The maximum resident set size (KB)                   = 1515860
 
 Test 088 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_debug
 Checking test 089 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1038.346426
-The maximum resident set size (KB)                   = 681772
+The total amount of wall time                        = 1040.194343
+The maximum resident set size (KB)                   = 678988
 
 Test 089 regional_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_control_debug
 Checking test 090 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.256650
-The maximum resident set size (KB)                   = 1059504
+The total amount of wall time                        = 297.654152
+The maximum resident set size (KB)                   = 1062624
 
 Test 090 rap_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_debug
 Checking test 091 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.385070
-The maximum resident set size (KB)                   = 1058336
+The total amount of wall time                        = 292.318389
+The maximum resident set size (KB)                   = 1056392
 
 Test 091 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_unified_drag_suite_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_unified_drag_suite_debug
 Checking test 092 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.109395
-The maximum resident set size (KB)                   = 1058804
+The total amount of wall time                        = 298.738191
+The maximum resident set size (KB)                   = 1060760
 
 Test 092 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_diag_debug
 Checking test 093 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 311.647344
-The maximum resident set size (KB)                   = 1141140
+The total amount of wall time                        = 311.078614
+The maximum resident set size (KB)                   = 1140616
 
 Test 093 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_cires_ugwp_debug
 Checking test 094 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.082215
-The maximum resident set size (KB)                   = 1058056
+The total amount of wall time                        = 304.369670
+The maximum resident set size (KB)                   = 1057456
 
 Test 094 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_unified_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_unified_ugwp_debug
 Checking test 095 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 310.330185
-The maximum resident set size (KB)                   = 1054816
+The total amount of wall time                        = 306.242187
+The maximum resident set size (KB)                   = 1060280
 
 Test 095 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_lndp_debug
 Checking test 096 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.111996
-The maximum resident set size (KB)                   = 1058052
+The total amount of wall time                        = 301.076582
+The maximum resident set size (KB)                   = 1062396
 
 Test 096 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_flake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_flake_debug
 Checking test 097 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.621295
-The maximum resident set size (KB)                   = 1060992
+The total amount of wall time                        = 298.070780
+The maximum resident set size (KB)                   = 1062512
 
 Test 097 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_progcld_thompson_debug
 Checking test 098 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.158222
-The maximum resident set size (KB)                   = 1059292
+The total amount of wall time                        = 298.508068
+The maximum resident set size (KB)                   = 1057804
 
 Test 098 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_noah_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_noah_debug
 Checking test 099 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.098198
-The maximum resident set size (KB)                   = 1054976
+The total amount of wall time                        = 292.929681
+The maximum resident set size (KB)                   = 1055588
 
 Test 099 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_sfcdiff_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_sfcdiff_debug
 Checking test 100 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.616694
-The maximum resident set size (KB)                   = 1060948
+The total amount of wall time                        = 298.766993
+The maximum resident set size (KB)                   = 1058564
 
 Test 100 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 101 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 488.014533
-The maximum resident set size (KB)                   = 1056272
+The total amount of wall time                        = 486.670644
+The maximum resident set size (KB)                   = 1056772
 
 Test 101 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rrfs_v1beta_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rrfs_v1beta_debug
 Checking test 102 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.913237
-The maximum resident set size (KB)                   = 1055732
+The total amount of wall time                        = 294.472843
+The maximum resident set size (KB)                   = 1052832
 
 Test 102 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_wam_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_wam_debug
 Checking test 103 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 299.793460
-The maximum resident set size (KB)                   = 306016
+The total amount of wall time                        = 298.949810
+The maximum resident set size (KB)                   = 309428
 
 Test 103 control_wam_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 104 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3434,14 +3434,14 @@ Checking test 104 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 236.320718
-The maximum resident set size (KB)                   = 887476
+The total amount of wall time                        = 234.396444
+The maximum resident set size (KB)                   = 892876
 
 Test 104 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_control_dyn32_phy32
 Checking test 105 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3488,14 +3488,14 @@ Checking test 105 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 354.095509
-The maximum resident set size (KB)                   = 782644
+The total amount of wall time                        = 352.006667
+The maximum resident set size (KB)                   = 778376
 
 Test 105 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_dyn32_phy32
 Checking test 106 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3542,14 +3542,14 @@ Checking test 106 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 188.160779
-The maximum resident set size (KB)                   = 781180
+The total amount of wall time                        = 188.326894
+The maximum resident set size (KB)                   = 777024
 
 Test 106 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_2threads_dyn32_phy32
 Checking test 107 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3596,14 +3596,14 @@ Checking test 107 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 331.505108
-The maximum resident set size (KB)                   = 834416
+The total amount of wall time                        = 332.982358
+The maximum resident set size (KB)                   = 838084
 
 Test 107 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_2threads_dyn32_phy32
 Checking test 108 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3650,14 +3650,14 @@ Checking test 108 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.287598
-The maximum resident set size (KB)                   = 831568
+The total amount of wall time                        = 173.501107
+The maximum resident set size (KB)                   = 832768
 
 Test 108 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_decomp_dyn32_phy32
 Checking test 109 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3704,14 +3704,14 @@ Checking test 109 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.217770
-The maximum resident set size (KB)                   = 778076
+The total amount of wall time                        = 195.850502
+The maximum resident set size (KB)                   = 776880
 
 Test 109 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_restart_dyn32_phy32
 Checking test 110 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3750,14 +3750,14 @@ Checking test 110 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 260.651052
-The maximum resident set size (KB)                   = 619224
+The total amount of wall time                        = 257.573903
+The maximum resident set size (KB)                   = 617984
 
 Test 110 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_restart_dyn32_phy32
 Checking test 111 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3796,14 +3796,14 @@ Checking test 111 hrrr_control_restart_dyn32_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 97.582915
-The maximum resident set size (KB)                   = 610740
+The total amount of wall time                        = 100.045619
+The maximum resident set size (KB)                   = 611816
 
 Test 111 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_control_dyn64_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_control_dyn64_phy32
 Checking test 112 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3850,81 +3850,81 @@ Checking test 112 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 236.832942
-The maximum resident set size (KB)                   = 797592
+The total amount of wall time                        = 239.133574
+The maximum resident set size (KB)                   = 797264
 
 Test 112 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_control_debug_dyn32_phy32
 Checking test 113 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.227110
-The maximum resident set size (KB)                   = 943020
+The total amount of wall time                        = 294.782864
+The maximum resident set size (KB)                   = 946480
 
 Test 113 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hrrr_control_debug_dyn32_phy32
 Checking test 114 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.291112
-The maximum resident set size (KB)                   = 942104
+The total amount of wall time                        = 288.802565
+The maximum resident set size (KB)                   = 943012
 
 Test 114 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/rap_control_dyn64_phy32_debug
 Checking test 115 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.473775
-The maximum resident set size (KB)                   = 961688
+The total amount of wall time                        = 294.637423
+The maximum resident set size (KB)                   = 963628
 
 Test 115 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_atm
 Checking test 116 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 277.873298
-The maximum resident set size (KB)                   = 825016
+The total amount of wall time                        = 272.543149
+The maximum resident set size (KB)                   = 821908
 
 Test 116 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_atm_thompson_gfdlsf
 Checking test 117 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 326.982800
-The maximum resident set size (KB)                   = 1176368
+The total amount of wall time                        = 317.907634
+The maximum resident set size (KB)                   = 1176660
 
 Test 117 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_atm_ocn
 Checking test 118 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3933,30 +3933,30 @@ Checking test 118 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 399.416959
-The maximum resident set size (KB)                   = 858960
+The total amount of wall time                        = 394.933607
+The maximum resident set size (KB)                   = 858820
 
 Test 118 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_atm_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_atm_wav
 Checking test 119 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 717.648857
-The maximum resident set size (KB)                   = 887676
+The total amount of wall time                        = 717.726338
+The maximum resident set size (KB)                   = 890512
 
 Test 119 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_atm_ocn_wav
 Checking test 120 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3964,31 +3964,31 @@ Checking test 120 hafs_regional_atm_ocn_wav results ....
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
- Comparing 20190829.060000.restart.ww3 .........OK
+ Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 911.891362
-The maximum resident set size (KB)                   = 914916
+The total amount of wall time                        = 901.915818
+The maximum resident set size (KB)                   = 913544
 
 Test 120 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_1nest_atm
 Checking test 121 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 331.919854
-The maximum resident set size (KB)                   = 393376
+The total amount of wall time                        = 336.764464
+The maximum resident set size (KB)                   = 392476
 
 Test 121 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_telescopic_2nests_atm
 Checking test 122 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3997,28 +3997,28 @@ Checking test 122 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 407.095373
-The maximum resident set size (KB)                   = 399928
+The total amount of wall time                        = 412.112058
+The maximum resident set size (KB)                   = 402400
 
 Test 122 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_global_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_global_1nest_atm
 Checking test 123 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 173.994352
-The maximum resident set size (KB)                   = 289456
+The total amount of wall time                        = 173.477461
+The maximum resident set size (KB)                   = 265876
 
 Test 123 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_global_multiple_4nests_atm
 Checking test 124 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4036,14 +4036,14 @@ Checking test 124 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 491.399102
-The maximum resident set size (KB)                   = 346988
+The total amount of wall time                        = 490.415833
+The maximum resident set size (KB)                   = 345080
 
 Test 124 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_specified_moving_1nest_atm
 Checking test 125 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4052,28 +4052,28 @@ Checking test 125 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 219.746341
-The maximum resident set size (KB)                   = 415052
+The total amount of wall time                        = 230.070819
+The maximum resident set size (KB)                   = 415308
 
 Test 125 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_storm_following_1nest_atm
 Checking test 126 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 208.225837
-The maximum resident set size (KB)                   = 407428
+The total amount of wall time                        = 210.949553
+The maximum resident set size (KB)                   = 407124
 
 Test 126 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 127 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4082,42 +4082,42 @@ Checking test 127 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 254.161566
-The maximum resident set size (KB)                   = 469588
+The total amount of wall time                        = 254.215894
+The maximum resident set size (KB)                   = 468240
 
 Test 127 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_global_storm_following_1nest_atm
 Checking test 128 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 86.136793
-The maximum resident set size (KB)                   = 289116
+The total amount of wall time                        = 85.798504
+The maximum resident set size (KB)                   = 288304
 
 Test 128 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 129 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 816.250653
-The maximum resident set size (KB)                   = 495800
+The total amount of wall time                        = 824.179779
+The maximum resident set size (KB)                   = 496132
 
 Test 129 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4128,14 +4128,14 @@ Checking test 130 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 512.772628
-The maximum resident set size (KB)                   = 526004
+The total amount of wall time                        = 507.430542
+The maximum resident set size (KB)                   = 523188
 
 Test 130 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/control_p8_atmlnd_sbs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/control_p8_atmlnd_sbs
 Checking test 131 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4220,14 +4220,14 @@ Checking test 131 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 239.726233
-The maximum resident set size (KB)                   = 1542172
+The total amount of wall time                        = 236.231141
+The maximum resident set size (KB)                   = 1540232
 
 Test 131 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/atmaero_control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/atmaero_control_p8
 Checking test 132 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4271,14 +4271,14 @@ Checking test 132 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 252.249460
-The maximum resident set size (KB)                   = 2818188
+The total amount of wall time                        = 247.440992
+The maximum resident set size (KB)                   = 2815552
 
 Test 132 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/atmaero_control_p8_rad
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/atmaero_control_p8_rad
 Checking test 133 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4322,14 +4322,14 @@ Checking test 133 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 290.114600
-The maximum resident set size (KB)                   = 2878688
+The total amount of wall time                        = 285.091655
+The maximum resident set size (KB)                   = 2876428
 
 Test 133 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/atmaero_control_p8_rad_micro
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/atmaero_control_p8_rad_micro
 Checking test 134 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4373,14 +4373,14 @@ Checking test 134 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 292.906212
-The maximum resident set size (KB)                   = 2886684
+The total amount of wall time                        = 290.444989
+The maximum resident set size (KB)                   = 2888124
 
 Test 134 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_atmaq
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_atmaq
 Checking test 135 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4396,14 +4396,14 @@ Checking test 135 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 698.761629
-The maximum resident set size (KB)                   = 1267792
+The total amount of wall time                        = 684.924491
+The maximum resident set size (KB)                   = 1262932
 
 Test 135 regional_atmaq PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_atmaq_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_atmaq_debug
 Checking test 136 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4417,14 +4417,14 @@ Checking test 136 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1320.355462
-The maximum resident set size (KB)                   = 1299784
+The total amount of wall time                        = 1333.629615
+The maximum resident set size (KB)                   = 1296148
 
 Test 136 regional_atmaq_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230329/INTEL/regional_atmaq_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_248745/regional_atmaq_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230401/INTEL/regional_atmaq_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_174598/regional_atmaq_faster
 Checking test 137 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4440,12 +4440,12 @@ Checking test 137 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 647.905909
-The maximum resident set size (KB)                   = 1261780
+The total amount of wall time                        = 638.618207
+The maximum resident set size (KB)                   = 1262004
 
 Test 137 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 30 17:50:25 UTC 2023
-Elapsed time: 01h:06m:49s. Have a nice day!
+Mon Apr  3 19:29:03 UTC 2023
+Elapsed time: 01h:35m:38s. Have a nice day!

--- a/tests/fv3_conf/cpld_control_run.IN
+++ b/tests/fv3_conf/cpld_control_run.IN
@@ -130,7 +130,8 @@ else
 
      # WAVE restart file
      if [[ $CPLWAV == .true. ]]; then
-       cp ../${DEP_RUN}${SUFFIX}/${RESTART_FILE_PREFIX}.restart.ww3 ./restart.ww3
+       RFILE=ufs.cpld.ww3.r.${RESTART_FILE_SUFFIX_SECS}
+       cp ../${DEP_RUN}${SUFFIX}/${RFILE} .
      fi
 
   else

--- a/tests/parm/nems.configure.cpld.IN
+++ b/tests/parm/nems.configure.cpld.IN
@@ -74,6 +74,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.cpld_esmfthreads.IN
+++ b/tests/parm/nems.configure.cpld_esmfthreads.IN
@@ -74,6 +74,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.cpld_noaero.IN
+++ b/tests/parm/nems.configure.cpld_noaero.IN
@@ -67,6 +67,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.cpld_noaero_outwav.IN
+++ b/tests/parm/nems.configure.cpld_noaero_outwav.IN
@@ -61,6 +61,7 @@ WAV_attributes::
   logfile = wav.log
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # CMEPS warm run sequence

--- a/tests/parm/nems.configure.hafs_atm_ocn_wav.IN
+++ b/tests/parm/nems.configure.hafs_atm_ocn_wav.IN
@@ -86,6 +86,7 @@ WAV_attributes::
   merge_import = .true.
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # Run Sequence #

--- a/tests/parm/nems.configure.hafs_atm_wav.IN
+++ b/tests/parm/nems.configure.hafs_atm_wav.IN
@@ -55,6 +55,7 @@ WAV_attributes::
   merge_import = .true.
   mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
+  user_sets_restname = true
 ::
 
 # Run Sequence #

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -85,7 +85,7 @@ RUN     | regional_2threads                                                     
 RUN     | regional_noquilt                                                                                                        | - jet.intel                             | fv3 |
 RUN     | regional_netcdf_parallel                                                                                                | - acorn.intel                           | fv3 |
 RUN     | regional_2dwrtdecomp                                                                                                    |                                         |     |
-RUN     | regional_wofs                                                                                                           |                                         | fv3 |
+RUN     | regional_wofs                                                                                                           | - jet.intel                             | fv3 |
 
 COMPILE | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON | + acorn.intel | fv3 |
 RUN     | regional_ifi_control                                                                                                    | + acorn.intel                           | fv3 |
@@ -295,9 +295,9 @@ RUN     | atmaero_control_p8_rad_micro                                          
 ###################################################################################################################################################################################
 
 COMPILE | -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON                                                                    |                                           | fv3 |
-RUN     | regional_atmaq                                                                                                        |                                           | fv3 |
+RUN     | regional_atmaq                                                                                                        | - jet.intel                               | fv3 |
 COMPILE | -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON                                                         |                                           | fv3 |
 RUN     | regional_atmaq_debug                                                                                                  | - jet.intel gaea.intel cheyenne.intel     | fv3 |
 
 COMPILE | -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON                                                        |                                           | fv3 |
-RUN     | regional_atmaq_faster                                                                                                 |                                           | fv3 |
+RUN     | regional_atmaq_faster                                                                                                 | - jet.intel                               | fv3 |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -82,7 +82,7 @@ RUN     | regional_control_qr                                                   
 RUN     | regional_restart_qr                                                                                                     |                                         |     | regional_control_qr
 RUN     | regional_decomp                                                                                                         |                                         |     |
 RUN     | regional_2threads                                                                                                       |                                         |     |
-RUN     | regional_noquilt                                                                                                        |                                         | fv3 |
+RUN     | regional_noquilt                                                                                                        | - jet.intel                             | fv3 |
 RUN     | regional_netcdf_parallel                                                                                                | - acorn.intel                           | fv3 |
 RUN     | regional_2dwrtdecomp                                                                                                    |                                         |     |
 RUN     | regional_wofs                                                                                                           |                                         | fv3 |
@@ -229,7 +229,7 @@ RUN     | hafs_regional_storm_following_1nest_atm_ocn_wav                       
 COMPILE | -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON                        | - wcoss2.intel                          | fv3 |
 RUN     | hafs_regional_docn                                                                                                      | - wcoss2.intel                          | fv3 |
 RUN     | hafs_regional_docn_oisst                                                                                                | - wcoss2.intel                          | fv3 |
-RUN     | hafs_regional_datm_cdeps                                                                                                | - wcoss2.intel                          | fv3 |
+RUN     | hafs_regional_datm_cdeps                                                                                                | - wcoss2.intel -jet.intel               | fv3 |
 
 ###################################################################################################################################################################################
 # CDEPS Data Atmosphere tests                                                                                                                                                     #

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -446,7 +446,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
 fi
 
 
-BL_DATE=20230329
+BL_DATE=20230401
 
 RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 

--- a/tests/tests/hafs_regional_atm_ocn_wav
+++ b/tests/tests/hafs_regional_atm_ocn_wav
@@ -14,7 +14,7 @@ export LIST_FILES="atmf006.nc \
                    archs.2019_241_06.a \
                    out_grd.ww3 \
                    out_pnt.ww3 \
-                   20190829.060000.restart.ww3 \
+                   ufs.hafs.ww3.r.2019-08-29-21600 \
                    ufs.hafs.cpl.r.2019-08-29-21600.nc"
 
 export_fv3

--- a/tests/tests/hafs_regional_atm_wav
+++ b/tests/tests/hafs_regional_atm_wav
@@ -12,7 +12,7 @@ export LIST_FILES="atmf006.nc \
                    sfcf006.nc \
                    out_grd.ww3 \
                    out_pnt.ww3 \
-                   20190829.060000.restart.ww3 \
+                   ufs.hafs.ww3.r.2019-08-29-21600 \
                    ufs.hafs.cpl.r.2019-08-29-21600.nc"
 
 export_fv3


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->

Changes the mapping of state fields between ATM and WAV for the coupled model to use bilinear with nearest-source-to-destination filling.

A test case was run using the ``cpld_control_p8`` test for 24 hours with and w/o this change. The following figure shows the difference in ``U10M`` along ~62S, from 90W:40W imported by the WAV model with the current mapping (``mapnstod_consf``, black line) vs the change in this PR (``mapbilnr_nstod``, red line).

<img width="546" alt="Screen Shot 2023-03-29 at 10 03 35 AM" src="https://user-images.githubusercontent.com/40498404/228564664-bdaec4fa-fc6b-4a5d-9367-dfb345c8a9f7.png">

The  impact on the ``Z0`` imported by the ATM at ~0.5S,6E (on the coast of Brazil, where a large difference in ``Z0`` is seen) for the current mapping (red) vs this PR (black) is shown below

<img width="599" alt="Screen Shot 2023-03-29 at 10 25 09 AM" src="https://user-images.githubusercontent.com/40498404/228570043-fc84ddab-c1e8-4f10-9d30-98f2bb35f8b5.png">

In the bmark test, the difference in ``Z0`` imported by the ATM on tile 1 (scaled by 1.0e4) after 6 hours is shown below

<img width="566" alt="Screen Shot 2023-03-29 at 11 20 05 AM" src="https://user-images.githubusercontent.com/40498404/228587451-607b000a-b950-49ae-9fa0-b2eb0c5f3d94.png">


### Top of commit queue on: TBD
<!-- Please have sub-component Code Managers ready for merging sub-component PR's on the date above and the day after the date above -->

### Input data additions/changes
- [x] No changes are expected to input data.
- [ ] There will be new input data. <!-- Add "input data change" Label -->
- [ ] Input data will be updated. <!-- Add "New Input Data Req'd" Label -->

### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test. <!-- Add "No Baseline Change" Label -->
- [x] Changes are expected to the following tests: <!-- Add "Baseline Change" Label -->
<!-- Please insert what RT's change and why you expect them to change -->

This will change baselines for all coupled tests using ATM-WAV coupling. HAFS wave tests do not change since their mapping is mapfillv_bilnr and does not change.

Full RTs on cheyenne show the following:

GNU: 
```
FAILED TESTS:
Test cpld_control_p8 047 failed in check_result failed
Test cpld_control_p8 047 failed in run_test failed
Test cpld_debug_p8 049 failed in check_result failed
Test cpld_debug_p8 049 failed in run_test failed
```
INTEL: 
```
FAILED TESTS:
Test cpld_control_p8_mixedmode 001 failed in check_result failed
Test cpld_control_p8_mixedmode 001 failed in run_test failed
Test cpld_control_gfsv17 002 failed in check_result failed
Test cpld_control_gfsv17 002 failed in run_test failed
Test cpld_control_p8 003 failed in check_result failed
Test cpld_control_p8 003 failed in run_test failed
Test cpld_control_qr_p8 005 failed in check_result failed
Test cpld_control_qr_p8 005 failed in run_test failed
Test cpld_2threads_p8 007 failed in check_result failed
Test cpld_2threads_p8 007 failed in run_test failed
Test cpld_decomp_p8 008 failed in check_result failed
Test cpld_decomp_p8 008 failed in run_test failed
Test cpld_mpi_p8 009 failed in check_result failed
Test cpld_mpi_p8 009 failed in run_test failed
Test cpld_control_ciceC_p8 010 failed in check_result failed
Test cpld_control_ciceC_p8 010 failed in run_test failed
Test cpld_control_c192_p8 011 failed in check_result failed
Test cpld_control_c192_p8 011 failed in run_test failed
Test cpld_control_noaero_p8 013 failed in check_result failed
Test cpld_control_noaero_p8 013 failed in run_test failed
Test cpld_debug_p8 015 failed in check_result failed
Test cpld_debug_p8 015 failed in run_test failed
Test cpld_debug_noaero_p8 016 failed in check_result failed
Test cpld_debug_noaero_p8 016 failed in run_test failed
```

[RegressionTests_cheyenne.gnu.log](https://github.com/ufs-community/ufs-weather-model/files/11101512/RegressionTests_cheyenne.gnu.log)
[RegressionTests_cheyenne.intel.log](https://github.com/ufs-community/ufs-weather-model/files/11101513/RegressionTests_cheyenne.intel.log)

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [x] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [ ] none

### Combined with PR's (If Applicable):

- PR #1684 
## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [x] Link PR's from all sub-components involved
- [x] Confirm reviews completed in sub-component PR's
- [x] Add all appropriate labels to this PR.
- [x] Run full RT suite on either Hera/Cheyenne with both Intel/GNU compilers
- [x] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on NOAA-EMC/fv3atm/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes NOAA-EMC/fv3atm/issues/<issue_number>
-->

- Fixes https://github.com/NOAA-EMC/CMEPS/issues/85
- Depends on https://github.com/NOAA-EMC/CMEPS/pull/86
- Associated with Issue https://github.com/ufs-community/ufs-weather-model/issues/1556
- Fixes https://github.com/ufs-community/ufs-weather-model/issues/1590

## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - Intel
    - [x] Hera
    - [x] Orion
    - [x] Jet
    - [x] Gaea
    - [x] Cheyenne
  - GNU
    - [x] Hera
    - [x] Cheyenne
- WCOSS2
  - [x] Dogwood/Cactus
  - [x] Acorn
- CI
  - [x] Completed
- opnReqTest
  - [ ] N/A
  - [x] Log attached to comment
