### PR TITLE
Create new baseline to fix the issue with develop-20230504 and recover baseline on gaea

### DIFF
--- a/modulefiles/ufs_gaea.intel.lua
+++ b/modulefiles/ufs_gaea.intel.lua
@@ -1,22 +1,21 @@
 help([[
   This module loads libraries required for building and running UFS Weather Model 
-  on the NOAA RDHPC machine Gaea using Intel-2022.1.2
+  on the NOAA RDHPC machine Gaea using Intel-2022.0.2
 ]])
 
 whatis([===[Loads libraries needed for building the UFS Weather Model on Gaea ]===])
 
-load(pathJoin("cmake", os.getenv("cmake_ver") or "3.20.1"))
+load_any(pathJoin("cmake", os.getenv("cmake_ver") or "3.20.1"),"cmake")
 
-prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/hpc-stack/intel-2021.3.0_noarch/modulefiles/stack")
+prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/hpc-stack/intel-2022.0.2/modulefiles/stack")
 load(pathJoin("hpc", os.getenv("hpc_ver") or "1.2.0"))
-load(pathJoin("intel", os.getenv("intel_ver") or "2021.3.0"))
-load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver") or "2021.3.0"))
+
+load(pathJoin("intel-classic", os.getenv("intel_ver") or "2022.0.2"))
+load_any(pathJoin("cray-mpich", os.getenv("cray_mpich_ver") or "7.7.11"),"cray-mpich")
+load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver") or "2022.0.2"))
 load(pathJoin("hpc-cray-mpich", os.getenv("hpc_cray_mpich_ver") or "7.7.11"))
-load(pathJoin("gcc", os.getenv("gcc_ver") or "8.3.0"))
 load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
 
--- needed for WW3 build
-load(pathJoin("gcc", os.getenv("gcc_ver") or "8.3.0"))
 -- Needed at runtime:
 load("alps")
 

--- a/tests/RegressionTests_acorn.intel.log
+++ b/tests/RegressionTests_acorn.intel.log
@@ -1,41 +1,41 @@
-Tue May  9 13:48:34 UTC 2023
+Wed May 10 21:30:37 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 1117 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 698 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 543 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 501 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 1201 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 711 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 688 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 1560 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 1007 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 1556 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1133 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 1171 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 481 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 576 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 703 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 475 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 524 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 371 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 719 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 674 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 021 elapsed time 710 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 503 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 320 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 024 elapsed time 166 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 803 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 941 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 520 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 771 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 629 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 782 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 313 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 032 elapsed time 698 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 582 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1129 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 556 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 542 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 518 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 670 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1698 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1048 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1097 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 1178 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 1275 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 621 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 830 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 609 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 1148 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 501 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 657 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 398 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 530 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 478 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 021 elapsed time 982 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 697 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 495 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 024 elapsed time 286 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 142 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 546 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 562 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 739 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 912 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 654 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 243 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 032 elapsed time 668 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_p8_mixedmode
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -100,14 +100,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 336.363959
-The maximum resident set size (KB)                   = 2946824
+The total amount of wall time                        = 334.103195
+The maximum resident set size (KB)                   = 2945008
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_gfsv17
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_gfsv17
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_gfsv17
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -171,14 +171,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 256.744435
-The maximum resident set size (KB)                   = 1575372
+The total amount of wall time                        = 257.756531
+The maximum resident set size (KB)                   = 1581932
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -243,14 +243,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.625964
-The maximum resident set size (KB)                   = 2984092
+The total amount of wall time                        = 386.272129
+The maximum resident set size (KB)                   = 2978096
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -303,14 +303,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 231.545030
-The maximum resident set size (KB)                   = 2866808
+The total amount of wall time                        = 230.236237
+The maximum resident set size (KB)                   = 2864688
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -375,14 +375,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 387.994257
-The maximum resident set size (KB)                   = 2989600
+The total amount of wall time                        = 386.219452
+The maximum resident set size (KB)                   = 2990352
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_restart_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -435,14 +435,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 234.214218
-The maximum resident set size (KB)                   = 2880012
+The total amount of wall time                        = 231.360922
+The maximum resident set size (KB)                   = 2877612
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -495,14 +495,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 369.229710
-The maximum resident set size (KB)                   = 3282976
+The total amount of wall time                        = 368.900907
+The maximum resident set size (KB)                   = 3282964
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -555,14 +555,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 380.117371
-The maximum resident set size (KB)                   = 2977252
+The total amount of wall time                        = 383.467588
+The maximum resident set size (KB)                   = 2980416
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_mpi_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -615,14 +615,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 316.600731
-The maximum resident set size (KB)                   = 2906004
+The total amount of wall time                        = 319.358363
+The maximum resident set size (KB)                   = 2909052
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_ciceC_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -687,14 +687,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 387.088747
-The maximum resident set size (KB)                   = 2983916
+The total amount of wall time                        = 386.794090
+The maximum resident set size (KB)                   = 2981120
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_noaero_p8
 Checking test 011 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -758,14 +758,14 @@ Checking test 011 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 288.043237
-The maximum resident set size (KB)                   = 1571324
+The total amount of wall time                        = 286.471011
+The maximum resident set size (KB)                   = 1574268
 
 Test 011 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_nowave_noaero_p8
 Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -827,14 +827,14 @@ Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 302.775396
-The maximum resident set size (KB)                   = 1619192
+The total amount of wall time                        = 303.769702
+The maximum resident set size (KB)                   = 1620092
 
 Test 012 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_noaero_p8_agrid
 Checking test 013 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -896,14 +896,14 @@ Checking test 013 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 311.242252
-The maximum resident set size (KB)                   = 1624168
+The total amount of wall time                        = 310.657986
+The maximum resident set size (KB)                   = 1629460
 
 Test 013 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_c48
 Checking test 014 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -953,14 +953,14 @@ Checking test 014 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 440.579996
-The maximum resident set size (KB)                   = 2627996
+The total amount of wall time                        = 440.933249
+The maximum resident set size (KB)                   = 2637520
 
 Test 014 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_warmstart_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_warmstart_c48
 Checking test 015 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1010,14 +1010,14 @@ Checking test 015 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 124.387910
-The maximum resident set size (KB)                   = 2648620
+The total amount of wall time                        = 122.418026
+The maximum resident set size (KB)                   = 2647960
 
 Test 015 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_restart_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_restart_c48
 Checking test 016 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1067,14 +1067,14 @@ Checking test 016 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 67.231318
-The maximum resident set size (KB)                   = 2063356
+The total amount of wall time                        = 68.766799
+The maximum resident set size (KB)                   = 2061308
 
 Test 016 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/cpld_control_p8_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/cpld_control_p8_faster
 Checking test 017 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1139,14 +1139,14 @@ Checking test 017 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 378.806501
-The maximum resident set size (KB)                   = 2980508
+The total amount of wall time                        = 377.393357
+The maximum resident set size (KB)                   = 2977812
 
 Test 017 cpld_control_p8_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_flake
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_flake
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_flake
 Checking test 018 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1157,14 +1157,14 @@ Checking test 018 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 212.680390
-The maximum resident set size (KB)                   = 560972
+The total amount of wall time                        = 213.716313
+The maximum resident set size (KB)                   = 560864
 
 Test 018 control_flake PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_CubedSphereGrid
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 129.442093
-The maximum resident set size (KB)                   = 510480
+The total amount of wall time                        = 128.910857
+The maximum resident set size (KB)                   = 512412
 
 Test 019 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_latlon
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.313437
-The maximum resident set size (KB)                   = 514292
+The total amount of wall time                        = 131.760413
+The maximum resident set size (KB)                   = 512168
 
 Test 020 control_latlon PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1227,14 +1227,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 134.587190
-The maximum resident set size (KB)                   = 516324
+The total amount of wall time                        = 134.660908
+The maximum resident set size (KB)                   = 515264
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_c48
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 330.158061
-The maximum resident set size (KB)                   = 674744
+The total amount of wall time                        = 331.628426
+The maximum resident set size (KB)                   = 671592
 
 Test 022 control_c48 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_c192
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 528.827409
-The maximum resident set size (KB)                   = 613968
+The total amount of wall time                        = 528.431107
+The maximum resident set size (KB)                   = 614692
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_c384
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1309,14 +1309,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 567.740010
-The maximum resident set size (KB)                   = 922308
+The total amount of wall time                        = 566.071849
+The maximum resident set size (KB)                   = 922524
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_c384gdas
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1359,14 +1359,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 501.063852
-The maximum resident set size (KB)                   = 1057488
+The total amount of wall time                        = 497.576766
+The maximum resident set size (KB)                   = 1054948
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_stochy
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1377,28 +1377,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 89.548602
-The maximum resident set size (KB)                   = 520556
+The total amount of wall time                        = 89.459411
+The maximum resident set size (KB)                   = 516152
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_stochy_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 49.805313
-The maximum resident set size (KB)                   = 286884
+The total amount of wall time                        = 49.246527
+The maximum resident set size (KB)                   = 287220
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_lndp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1409,14 +1409,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 83.261682
-The maximum resident set size (KB)                   = 514508
+The total amount of wall time                        = 82.821673
+The maximum resident set size (KB)                   = 516600
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_iovr4
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1431,14 +1431,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.443496
-The maximum resident set size (KB)                   = 515316
+The total amount of wall time                        = 136.338454
+The maximum resident set size (KB)                   = 514432
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_iovr5
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1453,14 +1453,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.131040
-The maximum resident set size (KB)                   = 517488
+The total amount of wall time                        = 135.096758
+The maximum resident set size (KB)                   = 514692
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1507,14 +1507,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.586291
-The maximum resident set size (KB)                   = 1486440
+The total amount of wall time                        = 179.724838
+The maximum resident set size (KB)                   = 1481608
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_restart_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_restart_p8
 Checking test 032 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1553,14 +1553,14 @@ Checking test 032 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 102.039083
-The maximum resident set size (KB)                   = 652712
+The total amount of wall time                        = 100.999382
+The maximum resident set size (KB)                   = 650984
 
 Test 032 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_qr_p8
 Checking test 033 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1607,14 +1607,14 @@ Checking test 033 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 177.069032
-The maximum resident set size (KB)                   = 1496520
+The total amount of wall time                        = 178.318774
+The maximum resident set size (KB)                   = 1494052
 
 Test 033 control_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_restart_qr_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_restart_qr_p8
 Checking test 034 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1653,14 +1653,14 @@ Checking test 034 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 99.997949
-The maximum resident set size (KB)                   = 661824
+The total amount of wall time                        = 101.156076
+The maximum resident set size (KB)                   = 660412
 
 Test 034 control_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_decomp_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_decomp_p8
 Checking test 035 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1703,14 +1703,14 @@ Checking test 035 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 181.600221
-The maximum resident set size (KB)                   = 1476356
+The total amount of wall time                        = 181.362821
+The maximum resident set size (KB)                   = 1480112
 
 Test 035 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_2threads_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_2threads_p8
 Checking test 036 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1753,14 +1753,14 @@ Checking test 036 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 155.072124
-The maximum resident set size (KB)                   = 1562436
+The total amount of wall time                        = 156.589945
+The maximum resident set size (KB)                   = 1563816
 
 Test 036 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_p8_lndp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_p8_lndp
 Checking test 037 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1779,14 +1779,14 @@ Checking test 037 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 320.952524
-The maximum resident set size (KB)                   = 1482664
+The total amount of wall time                        = 322.290349
+The maximum resident set size (KB)                   = 1481700
 
 Test 037 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_p8_rrtmgp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_p8_rrtmgp
 Checking test 038 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1833,14 +1833,14 @@ Checking test 038 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 233.481542
-The maximum resident set size (KB)                   = 1549580
+The total amount of wall time                        = 234.621895
+The maximum resident set size (KB)                   = 1540284
 
 Test 038 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_mynn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_p8_mynn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_p8_mynn
 Checking test 039 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1887,14 +1887,14 @@ Checking test 039 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.056537
-The maximum resident set size (KB)                   = 1482184
+The total amount of wall time                        = 178.783996
+The maximum resident set size (KB)                   = 1488052
 
 Test 039 control_p8_mynn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/merra2_thompson
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/merra2_thompson
 Checking test 040 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1941,14 +1941,14 @@ Checking test 040 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 204.150063
-The maximum resident set size (KB)                   = 1495252
+The total amount of wall time                        = 203.382881
+The maximum resident set size (KB)                   = 1486428
 
 Test 040 merra2_thompson PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_control
 Checking test 041 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1959,28 +1959,28 @@ Checking test 041 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 286.768961
-The maximum resident set size (KB)                   = 652256
+The total amount of wall time                        = 288.645241
+The maximum resident set size (KB)                   = 653152
 
 Test 041 regional_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_restart
 Checking test 042 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 157.757532
-The maximum resident set size (KB)                   = 646500
+The total amount of wall time                        = 156.136315
+The maximum resident set size (KB)                   = 649116
 
 Test 042 regional_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_control_qr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_control_qr
 Checking test 043 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1991,28 +1991,28 @@ Checking test 043 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 288.660681
-The maximum resident set size (KB)                   = 651596
+The total amount of wall time                        = 291.194065
+The maximum resident set size (KB)                   = 652800
 
 Test 043 regional_control_qr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_restart_qr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_restart_qr
 Checking test 044 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 157.125493
-The maximum resident set size (KB)                   = 647372
+The total amount of wall time                        = 156.171478
+The maximum resident set size (KB)                   = 648748
 
 Test 044 regional_restart_qr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_decomp
 Checking test 045 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2023,14 +2023,14 @@ Checking test 045 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 302.719313
-The maximum resident set size (KB)                   = 653444
+The total amount of wall time                        = 301.920895
+The maximum resident set size (KB)                   = 653664
 
 Test 045 regional_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_2threads
 Checking test 046 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2041,14 +2041,14 @@ Checking test 046 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 177.098448
-The maximum resident set size (KB)                   = 690084
+The total amount of wall time                        = 176.051319
+The maximum resident set size (KB)                   = 696748
 
 Test 046 regional_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_noquilt
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_noquilt
 Checking test 047 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2056,14 +2056,14 @@ Checking test 047 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 312.288321
-The maximum resident set size (KB)                   = 641836
+The total amount of wall time                        = 311.703664
+The maximum resident set size (KB)                   = 641896
 
 Test 047 regional_noquilt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_2dwrtdecomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_2dwrtdecomp
 Checking test 048 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2074,14 +2074,14 @@ Checking test 048 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 291.297269
-The maximum resident set size (KB)                   = 648664
+The total amount of wall time                        = 288.306608
+The maximum resident set size (KB)                   = 648464
 
 Test 048 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/fv3_regional_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_wofs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/fv3_regional_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_wofs
 Checking test 049 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2092,14 +2092,14 @@ Checking test 049 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 363.681402
-The maximum resident set size (KB)                   = 339880
+The total amount of wall time                        = 363.155741
+The maximum resident set size (KB)                   = 340464
 
 Test 049 regional_wofs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_ifi_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_ifi_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_ifi_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_ifi_control
 Checking test 050 regional_ifi_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2110,14 +2110,14 @@ Checking test 050 regional_ifi_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 319.829398
-The maximum resident set size (KB)                   = 652716
+The total amount of wall time                        = 323.158240
+The maximum resident set size (KB)                   = 654820
 
 Test 050 regional_ifi_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_ifi_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_ifi_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_ifi_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_ifi_decomp
 Checking test 051 regional_ifi_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2128,14 +2128,14 @@ Checking test 051 regional_ifi_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 337.637772
-The maximum resident set size (KB)                   = 651640
+The total amount of wall time                        = 339.183003
+The maximum resident set size (KB)                   = 652476
 
 Test 051 regional_ifi_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_ifi_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_ifi_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_ifi_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_ifi_2threads
 Checking test 052 regional_ifi_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2146,14 +2146,14 @@ Checking test 052 regional_ifi_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 197.923256
-The maximum resident set size (KB)                   = 694224
+The total amount of wall time                        = 200.744122
+The maximum resident set size (KB)                   = 691308
 
 Test 052 regional_ifi_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_control
 Checking test 053 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2200,14 +2200,14 @@ Checking test 053 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 420.529683
-The maximum resident set size (KB)                   = 890820
+The total amount of wall time                        = 418.802981
+The maximum resident set size (KB)                   = 890888
 
 Test 053 rap_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_spp_sppt_shum_skeb
 Checking test 054 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2218,14 +2218,14 @@ Checking test 054 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 246.595334
-The maximum resident set size (KB)                   = 984960
+The total amount of wall time                        = 244.403167
+The maximum resident set size (KB)                   = 982392
 
 Test 054 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_decomp
 Checking test 055 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2272,14 +2272,14 @@ Checking test 055 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 433.623522
-The maximum resident set size (KB)                   = 889564
+The total amount of wall time                        = 433.835082
+The maximum resident set size (KB)                   = 890164
 
 Test 055 rap_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_2threads
 Checking test 056 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2326,14 +2326,14 @@ Checking test 056 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 389.187607
-The maximum resident set size (KB)                   = 965076
+The total amount of wall time                        = 388.062843
+The maximum resident set size (KB)                   = 969856
 
 Test 056 rap_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_restart
 Checking test 057 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2372,14 +2372,14 @@ Checking test 057 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 212.797248
-The maximum resident set size (KB)                   = 643128
+The total amount of wall time                        = 212.418995
+The maximum resident set size (KB)                   = 642708
 
 Test 057 rap_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_sfcdiff
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_sfcdiff
 Checking test 058 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2426,14 +2426,14 @@ Checking test 058 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 421.937458
-The maximum resident set size (KB)                   = 891224
+The total amount of wall time                        = 420.762832
+The maximum resident set size (KB)                   = 891764
 
 Test 058 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_sfcdiff_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_sfcdiff_decomp
 Checking test 059 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2480,14 +2480,14 @@ Checking test 059 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 438.488075
-The maximum resident set size (KB)                   = 889616
+The total amount of wall time                        = 439.201691
+The maximum resident set size (KB)                   = 892268
 
 Test 059 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_sfcdiff_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_sfcdiff_restart
 Checking test 060 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2526,14 +2526,14 @@ Checking test 060 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 309.652010
-The maximum resident set size (KB)                   = 638856
+The total amount of wall time                        = 309.615882
+The maximum resident set size (KB)                   = 640328
 
 Test 060 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control
 Checking test 061 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2580,14 +2580,14 @@ Checking test 061 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 390.537386
-The maximum resident set size (KB)                   = 885484
+The total amount of wall time                        = 390.747112
+The maximum resident set size (KB)                   = 885060
 
 Test 061 hrrr_control PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_decomp
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_decomp
 Checking test 062 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2634,14 +2634,14 @@ Checking test 062 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.625872
-The maximum resident set size (KB)                   = 885312
+The total amount of wall time                        = 404.189715
+The maximum resident set size (KB)                   = 885600
 
 Test 062 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_2threads
 Checking test 063 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2688,28 +2688,28 @@ Checking test 063 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 350.187083
-The maximum resident set size (KB)                   = 963176
+The total amount of wall time                        = 350.060031
+The maximum resident set size (KB)                   = 964560
 
 Test 063 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_restart
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_restart
 Checking test 064 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 286.567256
-The maximum resident set size (KB)                   = 637920
+The total amount of wall time                        = 287.215639
+The maximum resident set size (KB)                   = 637440
 
 Test 064 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_v1beta
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_v1beta
 Checking test 065 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2756,14 +2756,14 @@ Checking test 065 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 420.781959
-The maximum resident set size (KB)                   = 887468
+The total amount of wall time                        = 417.765798
+The maximum resident set size (KB)                   = 887300
 
 Test 065 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_v1nssl
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_v1nssl
 Checking test 066 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2778,14 +2778,14 @@ Checking test 066 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 483.049540
-The maximum resident set size (KB)                   = 580772
+The total amount of wall time                        = 482.823085
+The maximum resident set size (KB)                   = 579420
 
 Test 066 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_v1nssl_nohailnoccn
 Checking test 067 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2800,14 +2800,14 @@ Checking test 067 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 469.470987
-The maximum resident set size (KB)                   = 567484
+The total amount of wall time                        = 470.769631
+The maximum resident set size (KB)                   = 567144
 
 Test 067 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_smoke_conus13km_hrrr_warm
 Checking test 068 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2816,14 +2816,14 @@ Checking test 068 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 149.357899
-The maximum resident set size (KB)                   = 797204
+The total amount of wall time                        = 150.158252
+The maximum resident set size (KB)                   = 799248
 
 Test 068 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2832,14 +2832,14 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 104.267413
-The maximum resident set size (KB)                   = 798048
+The total amount of wall time                        = 111.630569
+The maximum resident set size (KB)                   = 798928
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_conus13km_hrrr_warm
 Checking test 070 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2848,14 +2848,14 @@ Checking test 070 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 135.253002
-The maximum resident set size (KB)                   = 789912
+The total amount of wall time                        = 136.818241
+The maximum resident set size (KB)                   = 792260
 
 Test 070 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 071 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2864,26 +2864,26 @@ Checking test 071 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 150.721902
-The maximum resident set size (KB)                   = 798076
+The total amount of wall time                        = 150.866709
+The maximum resident set size (KB)                   = 798704
 
 Test 071 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 072 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 69.356727
-The maximum resident set size (KB)                   = 762976
+The total amount of wall time                        = 70.014616
+The maximum resident set size (KB)                   = 764104
 
 Test 072 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_csawmg
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_csawmg
 Checking test 073 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2894,14 +2894,14 @@ Checking test 073 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 346.903408
-The maximum resident set size (KB)                   = 582132
+The total amount of wall time                        = 349.784949
+The maximum resident set size (KB)                   = 583712
 
 Test 073 control_csawmg PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_csawmgt
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_csawmgt
 Checking test 074 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2912,14 +2912,14 @@ Checking test 074 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 343.889755
-The maximum resident set size (KB)                   = 584616
+The total amount of wall time                        = 343.617802
+The maximum resident set size (KB)                   = 582340
 
 Test 074 control_csawmgt PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_ras
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_ras
 Checking test 075 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2930,26 +2930,26 @@ Checking test 075 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 180.969138
-The maximum resident set size (KB)                   = 549940
+The total amount of wall time                        = 181.909824
+The maximum resident set size (KB)                   = 550016
 
 Test 075 control_ras PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_wam
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_wam
 Checking test 076 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 117.727981
-The maximum resident set size (KB)                   = 271620
+The total amount of wall time                        = 116.944974
+The maximum resident set size (KB)                   = 269824
 
 Test 076 control_wam PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_p8_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_p8_faster
 Checking test 077 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2996,14 +2996,14 @@ Checking test 077 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.470930
-The maximum resident set size (KB)                   = 1485504
+The total amount of wall time                        = 176.540812
+The maximum resident set size (KB)                   = 1486044
 
 Test 077 control_p8_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_control_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_control_faster
 Checking test 078 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3014,56 +3014,56 @@ Checking test 078 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 285.157731
-The maximum resident set size (KB)                   = 651384
+The total amount of wall time                        = 283.275868
+The maximum resident set size (KB)                   = 648672
 
 Test 078 regional_control_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 911.396994
-The maximum resident set size (KB)                   = 824496
+The total amount of wall time                        = 919.372519
+The maximum resident set size (KB)                   = 827296
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 522.835240
-The maximum resident set size (KB)                   = 828620
+The total amount of wall time                        = 528.235701
+The maximum resident set size (KB)                   = 826128
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_conus13km_hrrr_warm_debug
 Checking test 081 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 807.153458
-The maximum resident set size (KB)                   = 821048
+The total amount of wall time                        = 810.398353
+The maximum resident set size (KB)                   = 821160
 
 Test 081 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_CubedSphereGrid_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_CubedSphereGrid_debug
 Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3090,348 +3090,348 @@ Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 157.586723
-The maximum resident set size (KB)                   = 680688
+The total amount of wall time                        = 156.733417
+The maximum resident set size (KB)                   = 676152
 
 Test 082 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_wrtGauss_netcdf_parallel_debug
 Checking test 083 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 156.668771
-The maximum resident set size (KB)                   = 684644
+The total amount of wall time                        = 157.278332
+The maximum resident set size (KB)                   = 677428
 
 Test 083 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_stochy_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_stochy_debug
 Checking test 084 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 177.068927
-The maximum resident set size (KB)                   = 684384
+The total amount of wall time                        = 179.348107
+The maximum resident set size (KB)                   = 679884
 
 Test 084 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_lndp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_lndp_debug
 Checking test 085 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.465969
-The maximum resident set size (KB)                   = 683312
+The total amount of wall time                        = 160.557271
+The maximum resident set size (KB)                   = 684004
 
 Test 085 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_csawmg_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_csawmg_debug
 Checking test 086 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 251.764378
-The maximum resident set size (KB)                   = 719940
+The total amount of wall time                        = 254.627169
+The maximum resident set size (KB)                   = 717872
 
 Test 086 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_csawmgt_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_csawmgt_debug
 Checking test 087 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 249.361541
-The maximum resident set size (KB)                   = 720840
+The total amount of wall time                        = 248.848628
+The maximum resident set size (KB)                   = 717220
 
 Test 087 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_ras_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_ras_debug
 Checking test 088 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.030484
-The maximum resident set size (KB)                   = 692700
+The total amount of wall time                        = 161.076658
+The maximum resident set size (KB)                   = 692720
 
 Test 088 control_ras_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_diag_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_diag_debug
 Checking test 089 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.443811
-The maximum resident set size (KB)                   = 736976
+The total amount of wall time                        = 161.223959
+The maximum resident set size (KB)                   = 736824
 
 Test 089 control_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_debug_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_debug_p8
 Checking test 090 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 185.903939
-The maximum resident set size (KB)                   = 1497888
+The total amount of wall time                        = 183.137826
+The maximum resident set size (KB)                   = 1498168
 
 Test 090 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_debug
 Checking test 091 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1039.888379
-The maximum resident set size (KB)                   = 673284
+The total amount of wall time                        = 1040.599186
+The maximum resident set size (KB)                   = 675040
 
 Test 091 regional_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_control_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_control_debug
 Checking test 092 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.282402
-The maximum resident set size (KB)                   = 1049644
+The total amount of wall time                        = 296.455272
+The maximum resident set size (KB)                   = 1051912
 
 Test 092 rap_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_debug
 Checking test 093 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.761857
-The maximum resident set size (KB)                   = 1045756
+The total amount of wall time                        = 289.392892
+The maximum resident set size (KB)                   = 1046356
 
 Test 093 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_unified_drag_suite_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_unified_drag_suite_debug
 Checking test 094 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.703058
-The maximum resident set size (KB)                   = 1054660
+The total amount of wall time                        = 295.439046
+The maximum resident set size (KB)                   = 1048172
 
 Test 094 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_diag_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_diag_debug
 Checking test 095 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.403952
-The maximum resident set size (KB)                   = 1135448
+The total amount of wall time                        = 306.872848
+The maximum resident set size (KB)                   = 1136068
 
 Test 095 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_cires_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_cires_ugwp_debug
 Checking test 096 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.522266
-The maximum resident set size (KB)                   = 1053976
+The total amount of wall time                        = 302.943933
+The maximum resident set size (KB)                   = 1049760
 
 Test 096 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_unified_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_unified_ugwp_debug
 Checking test 097 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.877103
-The maximum resident set size (KB)                   = 1054988
+The total amount of wall time                        = 301.908208
+The maximum resident set size (KB)                   = 1052332
 
 Test 097 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_lndp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_lndp_debug
 Checking test 098 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.263580
-The maximum resident set size (KB)                   = 1054040
+The total amount of wall time                        = 300.094157
+The maximum resident set size (KB)                   = 1051064
 
 Test 098 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_progcld_thompson_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_progcld_thompson_debug
 Checking test 099 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.992735
-The maximum resident set size (KB)                   = 1055396
+The total amount of wall time                        = 296.952730
+The maximum resident set size (KB)                   = 1050240
 
 Test 099 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_noah_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_noah_debug
 Checking test 100 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.879077
-The maximum resident set size (KB)                   = 1051356
+The total amount of wall time                        = 289.748558
+The maximum resident set size (KB)                   = 1046316
 
 Test 100 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_sfcdiff_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_sfcdiff_debug
 Checking test 101 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.769756
-The maximum resident set size (KB)                   = 1056012
+The total amount of wall time                        = 296.799457
+The maximum resident set size (KB)                   = 1054772
 
 Test 101 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 102 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 485.248172
-The maximum resident set size (KB)                   = 1053808
+The total amount of wall time                        = 486.985720
+The maximum resident set size (KB)                   = 1048760
 
 Test 102 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rrfs_v1beta_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rrfs_v1beta_debug
 Checking test 103 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.168689
-The maximum resident set size (KB)                   = 1051216
+The total amount of wall time                        = 291.698503
+The maximum resident set size (KB)                   = 1048004
 
 Test 103 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_clm_lake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_clm_lake_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_clm_lake_debug
 Checking test 104 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 375.496163
-The maximum resident set size (KB)                   = 1054136
+The total amount of wall time                        = 375.148482
+The maximum resident set size (KB)                   = 1049728
 
 Test 104 rap_clm_lake_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_flake_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_flake_debug
 Checking test 105 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.191398
-The maximum resident set size (KB)                   = 1053512
+The total amount of wall time                        = 297.686556
+The maximum resident set size (KB)                   = 1054336
 
 Test 105 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_wam_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_wam_debug
 Checking test 106 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 298.306328
-The maximum resident set size (KB)                   = 300136
+The total amount of wall time                        = 298.972023
+The maximum resident set size (KB)                   = 301548
 
 Test 106 control_wam_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3442,14 +3442,14 @@ Checking test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 232.241044
-The maximum resident set size (KB)                   = 893180
+The total amount of wall time                        = 231.819373
+The maximum resident set size (KB)                   = 903208
 
 Test 107 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_control_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_control_dyn32_phy32
 Checking test 108 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3496,14 +3496,14 @@ Checking test 108 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 353.166121
-The maximum resident set size (KB)                   = 778836
+The total amount of wall time                        = 354.372295
+The maximum resident set size (KB)                   = 774244
 
 Test 108 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_dyn32_phy32
 Checking test 109 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3550,14 +3550,14 @@ Checking test 109 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.665397
-The maximum resident set size (KB)                   = 775532
+The total amount of wall time                        = 178.973356
+The maximum resident set size (KB)                   = 773244
 
 Test 109 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_2threads_dyn32_phy32
 Checking test 110 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3604,14 +3604,14 @@ Checking test 110 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 329.569917
-The maximum resident set size (KB)                   = 830220
+The total amount of wall time                        = 328.581852
+The maximum resident set size (KB)                   = 830616
 
 Test 110 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_2threads_dyn32_phy32
 Checking test 111 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3658,14 +3658,14 @@ Checking test 111 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 160.017313
-The maximum resident set size (KB)                   = 824276
+The total amount of wall time                        = 160.807328
+The maximum resident set size (KB)                   = 823392
 
 Test 111 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_decomp_dyn32_phy32
 Checking test 112 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3712,14 +3712,14 @@ Checking test 112 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 186.593899
-The maximum resident set size (KB)                   = 774056
+The total amount of wall time                        = 186.721171
+The maximum resident set size (KB)                   = 772328
 
 Test 112 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_restart_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_restart_dyn32_phy32
 Checking test 113 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3758,28 +3758,28 @@ Checking test 113 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 258.426638
-The maximum resident set size (KB)                   = 613916
+The total amount of wall time                        = 258.898169
+The maximum resident set size (KB)                   = 613516
 
 Test 113 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_restart_dyn32_phy32
 Checking test 114 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 92.268874
-The maximum resident set size (KB)                   = 608780
+The total amount of wall time                        = 92.389860
+The maximum resident set size (KB)                   = 601424
 
 Test 114 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_control_dyn64_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_control_dyn64_phy32
 Checking test 115 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3826,81 +3826,81 @@ Checking test 115 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 234.769471
-The maximum resident set size (KB)                   = 793068
+The total amount of wall time                        = 236.282431
+The maximum resident set size (KB)                   = 790828
 
 Test 115 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_control_debug_dyn32_phy32
 Checking test 116 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.250645
-The maximum resident set size (KB)                   = 937720
+The total amount of wall time                        = 291.048090
+The maximum resident set size (KB)                   = 939068
 
 Test 116 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hrrr_control_debug_dyn32_phy32
 Checking test 117 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 283.265837
-The maximum resident set size (KB)                   = 938596
+The total amount of wall time                        = 285.725869
+The maximum resident set size (KB)                   = 937768
 
 Test 117 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/rap_control_dyn64_phy32_debug
 Checking test 118 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.568086
-The maximum resident set size (KB)                   = 951188
+The total amount of wall time                        = 294.750727
+The maximum resident set size (KB)                   = 952868
 
 Test 118 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_atm
 Checking test 119 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 270.575055
-The maximum resident set size (KB)                   = 819092
+The total amount of wall time                        = 269.297629
+The maximum resident set size (KB)                   = 817644
 
 Test 119 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_atm_thompson_gfdlsf
 Checking test 120 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 310.019167
-The maximum resident set size (KB)                   = 1171428
+The total amount of wall time                        = 311.684660
+The maximum resident set size (KB)                   = 1181360
 
 Test 120 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_atm_ocn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_atm_ocn
 Checking test 121 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3909,14 +3909,14 @@ Checking test 121 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 387.848541
-The maximum resident set size (KB)                   = 857772
+The total amount of wall time                        = 387.905846
+The maximum resident set size (KB)                   = 855928
 
 Test 121 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_atm_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_atm_wav
 Checking test 122 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3925,14 +3925,14 @@ Checking test 122 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 708.254334
-The maximum resident set size (KB)                   = 887828
+The total amount of wall time                        = 705.434466
+The maximum resident set size (KB)                   = 888796
 
 Test 122 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_atm_ocn_wav
 Checking test 123 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3943,28 +3943,28 @@ Checking test 123 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 899.934683
-The maximum resident set size (KB)                   = 913080
+The total amount of wall time                        = 894.843739
+The maximum resident set size (KB)                   = 910560
 
 Test 123 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_1nest_atm
 Checking test 124 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 331.253605
-The maximum resident set size (KB)                   = 391104
+The total amount of wall time                        = 333.063207
+The maximum resident set size (KB)                   = 392660
 
 Test 124 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_telescopic_2nests_atm
 Checking test 125 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3973,28 +3973,28 @@ Checking test 125 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 400.888883
-The maximum resident set size (KB)                   = 398688
+The total amount of wall time                        = 404.021457
+The maximum resident set size (KB)                   = 397960
 
 Test 125 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_global_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_global_1nest_atm
 Checking test 126 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 171.530611
-The maximum resident set size (KB)                   = 260584
+The total amount of wall time                        = 172.637498
+The maximum resident set size (KB)                   = 259752
 
 Test 126 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_global_multiple_4nests_atm
 Checking test 127 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4012,14 +4012,14 @@ Checking test 127 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 489.402314
-The maximum resident set size (KB)                   = 342596
+The total amount of wall time                        = 492.771009
+The maximum resident set size (KB)                   = 346508
 
 Test 127 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_specified_moving_1nest_atm
 Checking test 128 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4028,28 +4028,28 @@ Checking test 128 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 217.997175
-The maximum resident set size (KB)                   = 404772
+The total amount of wall time                        = 219.095648
+The maximum resident set size (KB)                   = 408008
 
 Test 128 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_storm_following_1nest_atm
 Checking test 129 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 206.140001
-The maximum resident set size (KB)                   = 407460
+The total amount of wall time                        = 206.473090
+The maximum resident set size (KB)                   = 399324
 
 Test 129 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 130 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4058,42 +4058,42 @@ Checking test 130 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 251.283608
-The maximum resident set size (KB)                   = 467736
+The total amount of wall time                        = 253.046747
+The maximum resident set size (KB)                   = 466096
 
 Test 130 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_global_storm_following_1nest_atm
 Checking test 131 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 84.501360
-The maximum resident set size (KB)                   = 277208
+The total amount of wall time                        = 84.491427
+The maximum resident set size (KB)                   = 278032
 
 Test 131 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 803.380641
-The maximum resident set size (KB)                   = 488060
+The total amount of wall time                        = 802.971645
+The maximum resident set size (KB)                   = 487340
 
 Test 132 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 133 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4104,14 +4104,14 @@ Checking test 133 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 499.621703
-The maximum resident set size (KB)                   = 522020
+The total amount of wall time                        = 499.512830
+The maximum resident set size (KB)                   = 520680
 
 Test 133 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_docn
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_docn
 Checking test 134 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4119,14 +4119,14 @@ Checking test 134 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 368.968063
-The maximum resident set size (KB)                   = 861620
+The total amount of wall time                        = 370.558038
+The maximum resident set size (KB)                   = 862732
 
 Test 134 hafs_regional_docn PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_docn_oisst
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_docn_oisst
 Checking test 135 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4134,131 +4134,131 @@ Checking test 135 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 373.084886
-The maximum resident set size (KB)                   = 852044
+The total amount of wall time                        = 369.413073
+The maximum resident set size (KB)                   = 852296
 
 Test 135 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/hafs_regional_datm_cdeps
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/hafs_regional_datm_cdeps
 Checking test 136 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 943.300758
-The maximum resident set size (KB)                   = 834100
+The total amount of wall time                        = 945.067224
+The maximum resident set size (KB)                   = 835404
 
 Test 136 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_control_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_control_cfsr
 Checking test 137 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.077664
-The maximum resident set size (KB)                   = 734016
+The total amount of wall time                        = 140.960984
+The maximum resident set size (KB)                   = 733480
 
 Test 137 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_restart_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_restart_cfsr
 Checking test 138 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 85.501202
-The maximum resident set size (KB)                   = 727844
+The total amount of wall time                        = 85.955236
+The maximum resident set size (KB)                   = 728356
 
 Test 138 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_control_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_control_gefs
 Checking test 139 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 134.969062
-The maximum resident set size (KB)                   = 613912
+The total amount of wall time                        = 134.082328
+The maximum resident set size (KB)                   = 615008
 
 Test 139 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_iau_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_iau_gefs
 Checking test 140 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 136.103046
-The maximum resident set size (KB)                   = 614860
+The total amount of wall time                        = 136.475450
+The maximum resident set size (KB)                   = 613368
 
 Test 140 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_stochy_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_stochy_gefs
 Checking test 141 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 137.541242
-The maximum resident set size (KB)                   = 615512
+The total amount of wall time                        = 138.578475
+The maximum resident set size (KB)                   = 613696
 
 Test 141 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_ciceC_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_ciceC_cfsr
 Checking test 142 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 140.756770
-The maximum resident set size (KB)                   = 733292
+The total amount of wall time                        = 141.751450
+The maximum resident set size (KB)                   = 736460
 
 Test 142 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_bulk_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_bulk_cfsr
 Checking test 143 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.232509
-The maximum resident set size (KB)                   = 731380
+The total amount of wall time                        = 141.830580
+The maximum resident set size (KB)                   = 731944
 
 Test 143 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_bulk_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_bulk_gefs
 Checking test 144 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 133.415352
-The maximum resident set size (KB)                   = 611032
+The total amount of wall time                        = 134.267436
+The maximum resident set size (KB)                   = 613848
 
 Test 144 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_mx025_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_mx025_cfsr
 Checking test 145 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4267,14 +4267,14 @@ Checking test 145 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 429.509832
-The maximum resident set size (KB)                   = 569868
+The total amount of wall time                        = 429.142775
+The maximum resident set size (KB)                   = 571704
 
 Test 145 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_mx025_gefs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_mx025_gefs
 Checking test 146 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4283,64 +4283,64 @@ Checking test 146 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 430.724925
-The maximum resident set size (KB)                   = 547828
+The total amount of wall time                        = 428.688371
+The maximum resident set size (KB)                   = 549968
 
 Test 146 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_multiple_files_cfsr
 Checking test 147 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.076767
-The maximum resident set size (KB)                   = 732764
+The total amount of wall time                        = 141.587128
+The maximum resident set size (KB)                   = 731796
 
 Test 147 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_3072x1536_cfsr
 Checking test 148 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 257.300795
-The maximum resident set size (KB)                   = 1980580
+The total amount of wall time                        = 256.776589
+The maximum resident set size (KB)                   = 1981328
 
 Test 148 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_gfs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_gfs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_gfs
 Checking test 149 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 257.374949
-The maximum resident set size (KB)                   = 1981816
+The total amount of wall time                        = 256.964727
+The maximum resident set size (KB)                   = 1978544
 
 Test 149 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_control_cfsr_faster
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_control_cfsr_faster
 Checking test 150 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.014891
-The maximum resident set size (KB)                   = 736604
+The total amount of wall time                        = 141.508246
+The maximum resident set size (KB)                   = 733600
 
 Test 150 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_lnd_gswp3
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_lnd_gswp3
 Checking test 151 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4349,14 +4349,14 @@ Checking test 151 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 21.967855
-The maximum resident set size (KB)                   = 226740
+The total amount of wall time                        = 21.840443
+The maximum resident set size (KB)                   = 227780
 
 Test 151 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/datm_cdeps_lnd_gswp3_rst
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/datm_cdeps_lnd_gswp3_rst
 Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4365,14 +4365,14 @@ Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 27.074508
-The maximum resident set size (KB)                   = 230032
+The total amount of wall time                        = 27.316911
+The maximum resident set size (KB)                   = 228088
 
 Test 152 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_p8_atmlnd_sbs
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_p8_atmlnd_sbs
 Checking test 153 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4457,14 +4457,14 @@ Checking test 153 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 233.778318
-The maximum resident set size (KB)                   = 1538084
+The total amount of wall time                        = 234.753492
+The maximum resident set size (KB)                   = 1542656
 
 Test 153 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmwav_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/atmwav_control_noaero_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmwav_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/atmwav_control_noaero_p8
 Checking test 154 atmwav_control_noaero_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4507,14 +4507,14 @@ Checking test 154 atmwav_control_noaero_p8 results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-The total amount of wall time                        = 107.758489
-The maximum resident set size (KB)                   = 1529048
+The total amount of wall time                        = 107.709651
+The maximum resident set size (KB)                   = 1525940
 
 Test 154 atmwav_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_atmwav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/control_atmwav
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_atmwav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/control_atmwav
 Checking test 155 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4558,14 +4558,14 @@ Checking test 155 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 91.300620
-The maximum resident set size (KB)                   = 540416
+The total amount of wall time                        = 90.288014
+The maximum resident set size (KB)                   = 544216
 
 Test 155 control_atmwav PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/atmaero_control_p8
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/atmaero_control_p8
 Checking test 156 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4609,14 +4609,14 @@ Checking test 156 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.781569
-The maximum resident set size (KB)                   = 2815684
+The total amount of wall time                        = 244.896297
+The maximum resident set size (KB)                   = 2811928
 
 Test 156 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/atmaero_control_p8_rad
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/atmaero_control_p8_rad
 Checking test 157 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4660,14 +4660,14 @@ Checking test 157 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 284.941388
-The maximum resident set size (KB)                   = 2876476
+The total amount of wall time                        = 282.933698
+The maximum resident set size (KB)                   = 2874540
 
 Test 157 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/atmaero_control_p8_rad_micro
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/atmaero_control_p8_rad_micro
 Checking test 158 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4711,14 +4711,14 @@ Checking test 158 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 288.119953
-The maximum resident set size (KB)                   = 2885652
+The total amount of wall time                        = 287.940817
+The maximum resident set size (KB)                   = 2883628
 
 Test 158 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_atmaq
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_atmaq
 Checking test 159 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4734,14 +4734,14 @@ Checking test 159 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 684.497360
-The maximum resident set size (KB)                   = 1257648
+The total amount of wall time                        = 675.610090
+The maximum resident set size (KB)                   = 1253632
 
 Test 159 regional_atmaq PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_171451/regional_atmaq_debug
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_47764/regional_atmaq_debug
 Checking test 160 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4755,12 +4755,12 @@ Checking test 160 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1298.969894
-The maximum resident set size (KB)                   = 1282084
+The total amount of wall time                        = 1297.982680
+The maximum resident set size (KB)                   = 1290764
 
 Test 160 regional_atmaq_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue May  9 15:25:58 UTC 2023
-Elapsed time: 01h:37m:25s. Have a nice day!
+Wed May 10 23:14:47 UTC 2023
+Elapsed time: 01h:44m:10s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,21 +1,21 @@
-Fri May  5 04:04:33 MDT 2023
+Wed May 10 14:38:31 MDT 2023
 Start Regression test
 
-Compile 001 elapsed time 394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 405 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 914 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1148 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 393 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 403 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 910 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1141 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 007 elapsed time 897 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 914 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 619 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 587 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 336 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 295 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 898 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 646 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 573 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 361 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 298 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_c48
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_c48
 Checking test 001 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,14 +54,14 @@ Checking test 001 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 815.480234
-0:The maximum resident set size (KB)                   = 680420
+0:The total amount of wall time                        = 816.173357
+0:The maximum resident set size (KB)                   = 680392
 
 Test 001 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_stochy
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_stochy
 Checking test 002 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -72,14 +72,14 @@ Checking test 002 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 177.402887
-0:The maximum resident set size (KB)                   = 443712
+0:The total amount of wall time                        = 174.545949
+0:The maximum resident set size (KB)                   = 443752
 
 Test 002 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_ras
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_ras
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_ras
 Checking test 003 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -90,14 +90,14 @@ Checking test 003 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 292.422375
-0:The maximum resident set size (KB)                   = 452412
+0:The total amount of wall time                        = 290.248431
+0:The maximum resident set size (KB)                   = 452336
 
 Test 003 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_p8
 Checking test 004 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 004 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 310.277991
+0:The total amount of wall time                        = 313.236163
 0:The maximum resident set size (KB)                   = 1225396
 
 Test 004 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_flake
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_flake
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_flake
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -162,14 +162,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 356.342994
-0:The maximum resident set size (KB)                   = 490524
+0:The total amount of wall time                        = 353.333449
+0:The maximum resident set size (KB)                   = 490584
 
 Test 005 control_flake PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_control
 Checking test 006 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -216,14 +216,14 @@ Checking test 006 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 712.142443
-0:The maximum resident set size (KB)                   = 792380
+0:The total amount of wall time                        = 716.938014
+0:The maximum resident set size (KB)                   = 792444
 
 Test 006 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_decomp
 Checking test 007 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -270,14 +270,14 @@ Checking test 007 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 716.643434
-0:The maximum resident set size (KB)                   = 791704
+0:The total amount of wall time                        = 720.163774
+0:The maximum resident set size (KB)                   = 791752
 
 Test 007 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_2threads
 Checking test 008 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -324,14 +324,14 @@ Checking test 008 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 654.604419
-0:The maximum resident set size (KB)                   = 865968
+0:The total amount of wall time                        = 655.437733
+0:The maximum resident set size (KB)                   = 866016
 
 Test 008 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_restart
 Checking test 009 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -370,14 +370,14 @@ Checking test 009 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 353.254777
-0:The maximum resident set size (KB)                   = 539344
+0:The total amount of wall time                        = 362.621200
+0:The maximum resident set size (KB)                   = 539284
 
 Test 009 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_sfcdiff
 Checking test 010 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -424,14 +424,14 @@ Checking test 010 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 712.612280
-0:The maximum resident set size (KB)                   = 791688
+0:The total amount of wall time                        = 716.579434
+0:The maximum resident set size (KB)                   = 791856
 
 Test 010 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_sfcdiff_decomp
 Checking test 011 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -478,14 +478,14 @@ Checking test 011 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 722.607342
-0:The maximum resident set size (KB)                   = 791524
+0:The total amount of wall time                        = 722.285387
+0:The maximum resident set size (KB)                   = 791636
 
 Test 011 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_sfcdiff
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_sfcdiff_restart
 Checking test 012 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -524,14 +524,14 @@ Checking test 012 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 523.487983
-0:The maximum resident set size (KB)                   = 544668
+0:The total amount of wall time                        = 529.759059
+0:The maximum resident set size (KB)                   = 544560
 
 Test 012 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control
 Checking test 013 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -578,14 +578,14 @@ Checking test 013 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 685.441953
-0:The maximum resident set size (KB)                   = 789064
+0:The total amount of wall time                        = 690.622767
+0:The maximum resident set size (KB)                   = 789016
 
 Test 013 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_2threads
 Checking test 014 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -632,14 +632,14 @@ Checking test 014 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 706.043873
-0:The maximum resident set size (KB)                   = 855888
+0:The total amount of wall time                        = 707.380172
+0:The maximum resident set size (KB)                   = 855756
 
 Test 014 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_decomp
 Checking test 015 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -686,28 +686,28 @@ Checking test 015 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 682.241630
-0:The maximum resident set size (KB)                   = 788552
+0:The total amount of wall time                        = 686.679265
+0:The maximum resident set size (KB)                   = 788412
 
 Test 015 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_restart
 Checking test 016 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 506.150669
-0:The maximum resident set size (KB)                   = 539912
+0:The total amount of wall time                        = 505.563021
+0:The maximum resident set size (KB)                   = 539736
 
 Test 016 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_v1beta
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_v1beta
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -754,14 +754,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 703.906877
-0:The maximum resident set size (KB)                   = 789108
+0:The total amount of wall time                        = 706.598325
+0:The maximum resident set size (KB)                   = 789016
 
 Test 017 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_smoke_conus13km_hrrr_warm
 Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -770,14 +770,14 @@ Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 239.470312
-0:The maximum resident set size (KB)                   = 639764
+0:The total amount of wall time                        = 240.187378
+0:The maximum resident set size (KB)                   = 639704
 
 Test 018 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 019 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -786,14 +786,14 @@ Checking test 019 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 150.141650
-0:The maximum resident set size (KB)                   = 658528
+0:The total amount of wall time                        = 152.278970
+0:The maximum resident set size (KB)                   = 658536
 
 Test 019 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_conus13km_hrrr_warm
 Checking test 020 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -802,14 +802,14 @@ Checking test 020 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 219.792470
-0:The maximum resident set size (KB)                   = 618852
+0:The total amount of wall time                        = 220.469538
+0:The maximum resident set size (KB)                   = 618500
 
 Test 020 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 021 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -818,262 +818,262 @@ Checking test 021 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 241.487717
-0:The maximum resident set size (KB)                   = 642424
+0:The total amount of wall time                        = 240.458301
+0:The maximum resident set size (KB)                   = 642292
 
 Test 021 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 022 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 115.306913
-0:The maximum resident set size (KB)                   = 599588
+0:The total amount of wall time                        = 116.141404
+0:The maximum resident set size (KB)                   = 599608
 
 Test 022 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_diag_debug
 Checking test 023 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 81.884814
-0:The maximum resident set size (KB)                   = 492036
+0:The total amount of wall time                        = 83.093628
+0:The maximum resident set size (KB)                   = 492240
 
 Test 023 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/regional_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/regional_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/regional_debug
 Checking test 024 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 479.193602
-0:The maximum resident set size (KB)                   = 567300
+0:The total amount of wall time                        = 482.933546
+0:The maximum resident set size (KB)                   = 567328
 
 Test 024 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_control_debug
 Checking test 025 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.048157
-0:The maximum resident set size (KB)                   = 806312
+0:The total amount of wall time                        = 146.460152
+0:The maximum resident set size (KB)                   = 806468
 
 Test 025 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_debug
 Checking test 026 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.255144
-0:The maximum resident set size (KB)                   = 801756
+0:The total amount of wall time                        = 144.653325
+0:The maximum resident set size (KB)                   = 801696
 
 Test 026 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_diag_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_diag_debug
 Checking test 027 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 152.680367
-0:The maximum resident set size (KB)                   = 888496
+0:The total amount of wall time                        = 152.812909
+0:The maximum resident set size (KB)                   = 888544
 
 Test 027 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 028 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 234.710988
-0:The maximum resident set size (KB)                   = 804596
+0:The total amount of wall time                        = 236.904023
+0:The maximum resident set size (KB)                   = 804688
 
 Test 028 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_progcld_thompson_debug
 Checking test 029 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.669938
-0:The maximum resident set size (KB)                   = 806512
+0:The total amount of wall time                        = 146.826545
+0:The maximum resident set size (KB)                   = 806432
 
 Test 029 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_v1beta_debug
 Checking test 030 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.646493
-0:The maximum resident set size (KB)                   = 801440
+0:The total amount of wall time                        = 146.737528
+0:The maximum resident set size (KB)                   = 801456
 
 Test 030 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_ras_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_ras_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_ras_debug
 Checking test 031 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 81.149052
-0:The maximum resident set size (KB)                   = 446740
+0:The total amount of wall time                        = 81.915803
+0:The maximum resident set size (KB)                   = 446416
 
 Test 031 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_stochy_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_stochy_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_stochy_debug
 Checking test 032 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 88.535128
-0:The maximum resident set size (KB)                   = 438820
+0:The total amount of wall time                        = 90.791783
+0:The maximum resident set size (KB)                   = 438816
 
 Test 032 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_debug_p8
 Checking test 033 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.356838
-0:The maximum resident set size (KB)                   = 1221880
+0:The total amount of wall time                        = 91.521170
+0:The maximum resident set size (KB)                   = 1221952
 
 Test 033 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 034 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 445.690545
-0:The maximum resident set size (KB)                   = 644980
+0:The total amount of wall time                        = 446.935953
+0:The maximum resident set size (KB)                   = 645052
 
 Test 034 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 035 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 259.824078
-0:The maximum resident set size (KB)                   = 664096
+0:The total amount of wall time                        = 262.876823
+0:The maximum resident set size (KB)                   = 664828
 
 Test 035 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rrfs_conus13km_hrrr_warm_debug
 Checking test 036 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 402.880230
-0:The maximum resident set size (KB)                   = 623520
+0:The total amount of wall time                        = 404.708376
+0:The maximum resident set size (KB)                   = 623484
 
 Test 036 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_flake_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_flake_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_flake_debug
 Checking test 037 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.280735
-0:The maximum resident set size (KB)                   = 806316
+0:The total amount of wall time                        = 145.715124
+0:The maximum resident set size (KB)                   = 806340
 
 Test 037 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_clm_lake_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_clm_lake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_clm_lake_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_clm_lake_debug
 Checking test 038 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 164.819596
-0:The maximum resident set size (KB)                   = 807840
+0:The total amount of wall time                        = 165.881073
+0:The maximum resident set size (KB)                   = 807876
 
 Test 038 rap_clm_lake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/control_wam_debug
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/control_wam_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/control_wam_debug
 Checking test 039 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 140.143132
-0:The maximum resident set size (KB)                   = 182888
+0:The total amount of wall time                        = 140.633006
+0:The maximum resident set size (KB)                   = 182924
 
 Test 039 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_control_dyn32_phy32
 Checking test 040 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1120,14 +1120,14 @@ Checking test 040 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 699.489469
-0:The maximum resident set size (KB)                   = 672628
+0:The total amount of wall time                        = 704.792937
+0:The maximum resident set size (KB)                   = 672712
 
 Test 040 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_dyn32_phy32
 Checking test 041 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1174,14 +1174,14 @@ Checking test 041 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 352.641227
-0:The maximum resident set size (KB)                   = 671112
+0:The total amount of wall time                        = 353.181108
+0:The maximum resident set size (KB)                   = 671224
 
 Test 041 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_2threads_dyn32_phy32
 Checking test 042 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1228,14 +1228,14 @@ Checking test 042 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 643.040342
-0:The maximum resident set size (KB)                   = 720036
+0:The total amount of wall time                        = 645.448112
+0:The maximum resident set size (KB)                   = 720196
 
 Test 042 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_2threads_dyn32_phy32
 Checking test 043 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1282,14 +1282,14 @@ Checking test 043 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 403.092652
-0:The maximum resident set size (KB)                   = 712460
+0:The total amount of wall time                        = 405.203647
+0:The maximum resident set size (KB)                   = 711824
 
 Test 043 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_decomp_dyn32_phy32
 Checking test 044 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1336,14 +1336,14 @@ Checking test 044 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 351.172256
-0:The maximum resident set size (KB)                   = 670068
+0:The total amount of wall time                        = 351.742758
+0:The maximum resident set size (KB)                   = 670060
 
 Test 044 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_restart_dyn32_phy32
 Checking test 045 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1382,28 +1382,28 @@ Checking test 045 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 520.157001
-0:The maximum resident set size (KB)                   = 511708
+0:The total amount of wall time                        = 522.125874
+0:The maximum resident set size (KB)                   = 511664
 
 Test 045 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_restart_dyn32_phy32
 Checking test 046 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 178.758570
-0:The maximum resident set size (KB)                   = 505972
+0:The total amount of wall time                        = 179.262433
+0:The maximum resident set size (KB)                   = 506124
 
 Test 046 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn64_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_control_dyn64_phy32
 Checking test 047 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1450,56 +1450,56 @@ Checking test 047 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 413.889092
-0:The maximum resident set size (KB)                   = 693804
+0:The total amount of wall time                        = 418.249077
+0:The maximum resident set size (KB)                   = 694464
 
 Test 047 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_control_debug_dyn32_phy32
 Checking test 048 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.185860
-0:The maximum resident set size (KB)                   = 687056
+0:The total amount of wall time                        = 144.154337
+0:The maximum resident set size (KB)                   = 686988
 
 Test 048 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/hrrr_control_debug_dyn32_phy32
 Checking test 049 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 141.476420
-0:The maximum resident set size (KB)                   = 684228
+0:The total amount of wall time                        = 142.008243
+0:The maximum resident set size (KB)                   = 684308
 
 Test 049 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/rap_control_dyn64_phy32_debug
 Checking test 050 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 148.643835
-0:The maximum resident set size (KB)                   = 708028
+0:The total amount of wall time                        = 148.571448
+0:The maximum resident set size (KB)                   = 708020
 
 Test 050 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/cpld_control_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/cpld_control_p8
 Checking test 051 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1564,14 +1564,14 @@ Checking test 051 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 499.255766
-0:The maximum resident set size (KB)                   = 3161428
+0:The total amount of wall time                        = 502.732791
+0:The maximum resident set size (KB)                   = 3159536
 
 Test 051 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/cpld_control_nowave_noaero_p8
 Checking test 052 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1633,14 +1633,14 @@ Checking test 052 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 239.383698
-0:The maximum resident set size (KB)                   = 1240728
+0:The total amount of wall time                        = 254.546678
+0:The maximum resident set size (KB)                   = 1240984
 
 Test 052 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/cpld_debug_p8
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/cpld_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/cpld_debug_p8
 Checking test 053 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1693,25 +1693,25 @@ Checking test 053 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 202.179415
-0:The maximum resident set size (KB)                   = 3175064
+0:The total amount of wall time                        = 207.817904
+0:The maximum resident set size (KB)                   = 3174588
 
 Test 053 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/GNU/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_54655/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/GNU/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_69700/datm_cdeps_control_cfsr
 Checking test 054 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 178.657507
-0:The maximum resident set size (KB)                   = 676024
+0:The total amount of wall time                        = 179.118060
+0:The maximum resident set size (KB)                   = 672492
 
 Test 054 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  5 04:40:47 MDT 2023
-Elapsed time: 00h:36m:14s. Have a nice day!
+Wed May 10 15:14:49 MDT 2023
+Elapsed time: 00h:36m:18s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,42 +1,42 @@
-Sat May  6 07:46:17 MDT 2023
+Wed May 10 14:23:36 MDT 2023
 Start Regression test
 
-Compile 001 elapsed time 1587 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1518 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1428 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 457 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 405 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1140 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1143 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 1167 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 1074 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 1016 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 863 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 1352 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 443 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 265 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 920 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 915 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 294 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 297 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 1228 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 356 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 021 elapsed time 1650 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 1204 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 427 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 024 elapsed time 197 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 025 elapsed time 428 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 026 elapsed time 104 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 1003 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 1071 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 1059 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 976 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 948 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 310 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 033 elapsed time 1102 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1480 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1617 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1435 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 463 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 393 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1167 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1135 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1159 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1065 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 1009 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 876 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 1351 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 433 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 285 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 914 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 925 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 297 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 294 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 1207 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 351 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 021 elapsed time 1651 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 1186 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 429 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 024 elapsed time 200 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 025 elapsed time 425 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 026 elapsed time 109 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 1027 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 1082 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 1121 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 951 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 931 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 312 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 033 elapsed time 1107 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_mixedmode
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_p8_mixedmode
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -101,14 +101,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 319.544609
-0:The maximum resident set size (KB)                   = 2698760
+0:The total amount of wall time                        = 312.944047
+0:The maximum resident set size (KB)                   = 2699052
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_gfsv17
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_gfsv17
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_gfsv17
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -172,14 +172,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 282.033907
-0:The maximum resident set size (KB)                   = 1437756
+0:The total amount of wall time                        = 285.959509
+0:The maximum resident set size (KB)                   = 1437648
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -244,14 +244,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 323.529452
-0:The maximum resident set size (KB)                   = 2715428
+0:The total amount of wall time                        = 328.564420
+0:The maximum resident set size (KB)                   = 2715440
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -304,14 +304,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 186.860231
-0:The maximum resident set size (KB)                   = 2576764
+0:The total amount of wall time                        = 188.725796
+0:The maximum resident set size (KB)                   = 2576532
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -376,14 +376,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 329.694969
-0:The maximum resident set size (KB)                   = 2719992
+0:The total amount of wall time                        = 329.349318
+0:The maximum resident set size (KB)                   = 2720096
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_restart_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -436,14 +436,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 200.761474
-0:The maximum resident set size (KB)                   = 2593872
+0:The total amount of wall time                        = 202.174297
+0:The maximum resident set size (KB)                   = 2593208
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -496,14 +496,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 249.551018
-0:The maximum resident set size (KB)                   = 3178456
+0:The total amount of wall time                        = 255.472628
+0:The maximum resident set size (KB)                   = 3177788
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -556,14 +556,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 322.275955
-0:The maximum resident set size (KB)                   = 2720620
+0:The total amount of wall time                        = 326.269425
+0:The maximum resident set size (KB)                   = 2720200
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_mpi_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -616,14 +616,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 280.595475
-0:The maximum resident set size (KB)                   = 2681440
+0:The total amount of wall time                        = 281.327107
+0:The maximum resident set size (KB)                   = 2681744
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_ciceC_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_ciceC_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_ciceC_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -688,14 +688,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 325.778808
+0:The total amount of wall time                        = 327.508008
 0:The maximum resident set size (KB)                   = 2715260
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -748,14 +748,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 627.058141
-0:The maximum resident set size (KB)                   = 3351720
+0:The total amount of wall time                        = 627.326236
+0:The maximum resident set size (KB)                   = 3351492
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_restart_c192_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -808,14 +808,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 381.779742
-0:The maximum resident set size (KB)                   = 3276152
+0:The total amount of wall time                        = 459.679187
+0:The maximum resident set size (KB)                   = 3276068
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_noaero_p8
 Checking test 013 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -879,14 +879,14 @@ Checking test 013 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 295.577147
-0:The maximum resident set size (KB)                   = 1435776
+0:The total amount of wall time                        = 296.542979
+0:The maximum resident set size (KB)                   = 1435860
 
 Test 013 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c96_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_nowave_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_nowave_noaero_p8
 Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -948,14 +948,14 @@ Checking test 014 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 198.337851
-0:The maximum resident set size (KB)                   = 1453396
+0:The total amount of wall time                        = 199.884537
+0:The maximum resident set size (KB)                   = 1453312
 
 Test 014 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1008,14 +1008,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 349.597925
-0:The maximum resident set size (KB)                   = 2780652
+0:The total amount of wall time                        = 350.618824
+0:The maximum resident set size (KB)                   = 2779940
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_debug_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_debug_noaero_p8
 Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1067,14 +1067,14 @@ Checking test 016 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 302.597149
-0:The maximum resident set size (KB)                   = 1454940
+0:The total amount of wall time                        = 303.878872
+0:The maximum resident set size (KB)                   = 1454392
 
 Test 016 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_noaero_p8_agrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_noaero_p8_agrid
 Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1136,14 +1136,14 @@ Checking test 017 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 251.790780
-0:The maximum resident set size (KB)                   = 1457044
+0:The total amount of wall time                        = 251.210292
+0:The maximum resident set size (KB)                   = 1457088
 
 Test 017 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c48
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_control_c48
 Checking test 018 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1193,14 +1193,14 @@ Checking test 018 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 609.571758
-0:The maximum resident set size (KB)                   = 2586800
+0:The total amount of wall time                        = 613.003892
+0:The maximum resident set size (KB)                   = 2586684
 
 Test 018 cpld_control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_warmstart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_warmstart_c48
 Checking test 019 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1250,14 +1250,14 @@ Checking test 019 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 162.965347
-0:The maximum resident set size (KB)                   = 2602612
+0:The total amount of wall time                        = 164.462458
+0:The maximum resident set size (KB)                   = 2602584
 
 Test 019 cpld_warmstart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/cpld_restart_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/cpld_restart_c48
 Checking test 020 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1307,14 +1307,14 @@ Checking test 020 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 85.380411
-0:The maximum resident set size (KB)                   = 2019952
+0:The total amount of wall time                        = 87.208269
+0:The maximum resident set size (KB)                   = 2020300
 
 Test 020 cpld_restart_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_flake
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_flake
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_flake
 Checking test 021 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1325,14 +1325,14 @@ Checking test 021 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 217.647145
-0:The maximum resident set size (KB)                   = 501448
+0:The total amount of wall time                        = 220.963387
+0:The maximum resident set size (KB)                   = 501436
 
 Test 021 control_flake PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_CubedSphereGrid
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.366063
-0:The maximum resident set size (KB)                   = 454624
+0:The total amount of wall time                        = 142.901734
+0:The maximum resident set size (KB)                   = 454580
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_parallel
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_CubedSphereGrid_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_CubedSphereGrid_parallel
 Checking test 023 control_CubedSphereGrid_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 139.906136
-0:The maximum resident set size (KB)                   = 454520
+0:The total amount of wall time                        = 140.116532
+0:The maximum resident set size (KB)                   = 454456
 
 Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_latlon
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_latlon
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_latlon
 Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1391,17 +1391,17 @@ Checking test 024 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.709422
-0:The maximum resident set size (KB)                   = 454584
+0:The total amount of wall time                        = 143.240487
+0:The maximum resident set size (KB)                   = 454564
 
 Test 024 control_latlon PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_wrtGauss_netcdf_parallel
 Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1409,14 +1409,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 149.238871
-0:The maximum resident set size (KB)                   = 454604
+0:The total amount of wall time                        = 149.619799
+0:The maximum resident set size (KB)                   = 454616
 
 Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c48
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_c48
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_c48
 Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1455,14 +1455,14 @@ Checking test 026 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 441.114330
-0:The maximum resident set size (KB)                   = 634276
+0:The total amount of wall time                        = 443.403883
+0:The maximum resident set size (KB)                   = 634928
 
 Test 026 control_c48 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c192
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_c192
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_c192
 Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1473,14 +1473,14 @@ Checking test 027 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 592.672442
-0:The maximum resident set size (KB)                   = 560248
+0:The total amount of wall time                        = 599.955582
+0:The maximum resident set size (KB)                   = 560244
 
 Test 027 control_c192 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_c384
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_c384
 Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1491,14 +1491,14 @@ Checking test 028 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 592.928324
-0:The maximum resident set size (KB)                   = 900432
+0:The total amount of wall time                        = 589.234666
+0:The maximum resident set size (KB)                   = 901284
 
 Test 028 control_c384 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384gdas
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_c384gdas
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_c384gdas
 Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1541,14 +1541,14 @@ Checking test 029 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 516.649977
-0:The maximum resident set size (KB)                   = 1028888
+0:The total amount of wall time                        = 520.113317
+0:The maximum resident set size (KB)                   = 1028556
 
 Test 029 control_c384gdas PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_stochy
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_stochy
 Checking test 030 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1559,28 +1559,28 @@ Checking test 030 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 98.282045
-0:The maximum resident set size (KB)                   = 459416
+0:The total amount of wall time                        = 98.375990
+0:The maximum resident set size (KB)                   = 459424
 
 Test 030 control_stochy PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_stochy_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_stochy_restart
 Checking test 031 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 53.448086
-0:The maximum resident set size (KB)                   = 227948
+0:The total amount of wall time                        = 53.657533
+0:The maximum resident set size (KB)                   = 227648
 
 Test 031 control_stochy_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_lndp
 Checking test 032 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1591,14 +1591,14 @@ Checking test 032 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 90.827000
-0:The maximum resident set size (KB)                   = 459200
+0:The total amount of wall time                        = 90.905115
+0:The maximum resident set size (KB)                   = 459000
 
 Test 032 control_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr4
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_iovr4
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_iovr4
 Checking test 033 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1613,14 +1613,14 @@ Checking test 033 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 144.991596
-0:The maximum resident set size (KB)                   = 454532
+0:The total amount of wall time                        = 148.862223
+0:The maximum resident set size (KB)                   = 454572
 
 Test 033 control_iovr4 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr5
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_iovr5
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_iovr5
 Checking test 034 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 034 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 150.452526
+0:The total amount of wall time                        = 145.466642
 0:The maximum resident set size (KB)                   = 454496
 
 Test 034 control_iovr5 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_p8
 Checking test 035 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 035 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 182.205472
-0:The maximum resident set size (KB)                   = 1423928
+0:The total amount of wall time                        = 183.020402
+0:The maximum resident set size (KB)                   = 1423996
 
 Test 035 control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_restart_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_restart_p8
 Checking test 036 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1735,14 +1735,14 @@ Checking test 036 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 96.626032
-0:The maximum resident set size (KB)                   = 582132
+0:The total amount of wall time                        = 96.562414
+0:The maximum resident set size (KB)                   = 582152
 
 Test 036 control_restart_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_qr_p8
 Checking test 037 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1789,14 +1789,14 @@ Checking test 037 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 184.088698
-0:The maximum resident set size (KB)                   = 1427616
+0:The total amount of wall time                        = 183.439181
+0:The maximum resident set size (KB)                   = 1427676
 
 Test 037 control_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_restart_qr_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_restart_qr_p8
 Checking test 038 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1835,14 +1835,14 @@ Checking test 038 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 99.706604
-0:The maximum resident set size (KB)                   = 597216
+0:The total amount of wall time                        = 100.323847
+0:The maximum resident set size (KB)                   = 597212
 
 Test 038 control_restart_qr_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_decomp_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_decomp_p8
 Checking test 039 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1885,14 +1885,14 @@ Checking test 039 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 190.475383
-0:The maximum resident set size (KB)                   = 1417728
+0:The total amount of wall time                        = 190.361713
+0:The maximum resident set size (KB)                   = 1417740
 
 Test 039 control_decomp_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_2threads_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_2threads_p8
 Checking test 040 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1935,14 +1935,14 @@ Checking test 040 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.161166
-0:The maximum resident set size (KB)                   = 1509260
+0:The total amount of wall time                        = 172.832857
+0:The maximum resident set size (KB)                   = 1508424
 
 Test 040 control_2threads_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_lndp
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_p8_lndp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_p8_lndp
 Checking test 041 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1961,14 +1961,14 @@ Checking test 041 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 335.855857
-0:The maximum resident set size (KB)                   = 1424216
+0:The total amount of wall time                        = 336.705747
+0:The maximum resident set size (KB)                   = 1424304
 
 Test 041 control_p8_lndp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_rrtmgp
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_p8_rrtmgp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_p8_rrtmgp
 Checking test 042 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2015,14 +2015,14 @@ Checking test 042 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 254.926464
+0:The total amount of wall time                        = 255.252670
 0:The maximum resident set size (KB)                   = 1480576
 
 Test 042 control_p8_rrtmgp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_mynn
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_p8_mynn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_p8_mynn
 Checking test 043 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2069,14 +2069,14 @@ Checking test 043 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 185.673954
-0:The maximum resident set size (KB)                   = 1428428
+0:The total amount of wall time                        = 186.349154
+0:The maximum resident set size (KB)                   = 1428464
 
 Test 043 control_p8_mynn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/merra2_thompson
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/merra2_thompson
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/merra2_thompson
 Checking test 044 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2123,14 +2123,14 @@ Checking test 044 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 207.735299
-0:The maximum resident set size (KB)                   = 1429944
+0:The total amount of wall time                        = 207.234497
+0:The maximum resident set size (KB)                   = 1430016
 
 Test 044 merra2_thompson PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_control
 Checking test 045 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2141,28 +2141,28 @@ Checking test 045 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 342.263461
-0:The maximum resident set size (KB)                   = 605068
+0:The total amount of wall time                        = 345.045920
+0:The maximum resident set size (KB)                   = 605080
 
 Test 045 regional_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_restart
 Checking test 046 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 176.774690
+0:The total amount of wall time                        = 178.797731
 0:The maximum resident set size (KB)                   = 594372
 
 Test 046 regional_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_control_qr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_control_qr
 Checking test 047 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2173,28 +2173,28 @@ Checking test 047 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 343.043390
-0:The maximum resident set size (KB)                   = 605020
+0:The total amount of wall time                        = 351.962331
+0:The maximum resident set size (KB)                   = 605076
 
 Test 047 regional_control_qr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_restart_qr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_restart_qr
 Checking test 048 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 175.499656
-0:The maximum resident set size (KB)                   = 594360
+0:The total amount of wall time                        = 177.420938
+0:The maximum resident set size (KB)                   = 594424
 
 Test 048 regional_restart_qr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_decomp
 Checking test 049 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2205,14 +2205,14 @@ Checking test 049 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 363.507975
-0:The maximum resident set size (KB)                   = 598972
+0:The total amount of wall time                        = 358.023198
+0:The maximum resident set size (KB)                   = 598960
 
 Test 049 regional_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_2threads
 Checking test 050 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2223,14 +2223,14 @@ Checking test 050 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 202.640040
-0:The maximum resident set size (KB)                   = 611844
+0:The total amount of wall time                        = 213.544113
+0:The maximum resident set size (KB)                   = 611972
 
 Test 050 regional_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_noquilt
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_noquilt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_noquilt
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_noquilt
 Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2238,28 +2238,28 @@ Checking test 051 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 364.602808
-0:The maximum resident set size (KB)                   = 599564
+0:The total amount of wall time                        = 364.814236
+0:The maximum resident set size (KB)                   = 599468
 
 Test 051 regional_noquilt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_netcdf_parallel
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_netcdf_parallel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_netcdf_parallel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_netcdf_parallel
 Checking test 052 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf006.nc ............ALT CHECK......OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 341.209017
-0:The maximum resident set size (KB)                   = 597016
+0:The total amount of wall time                        = 342.786007
+0:The maximum resident set size (KB)                   = 597000
 
 Test 052 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_2dwrtdecomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_2dwrtdecomp
 Checking test 053 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2270,14 +2270,14 @@ Checking test 053 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 341.811660
+0:The total amount of wall time                        = 342.370220
 0:The maximum resident set size (KB)                   = 605080
 
 Test 053 regional_2dwrtdecomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/fv3_regional_wofs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_wofs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/fv3_regional_wofs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_wofs
 Checking test 054 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2288,14 +2288,14 @@ Checking test 054 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 428.573325
-0:The maximum resident set size (KB)                   = 276128
+0:The total amount of wall time                        = 429.482795
+0:The maximum resident set size (KB)                   = 276260
 
 Test 054 regional_wofs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_control
 Checking test 055 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2342,14 +2342,14 @@ Checking test 055 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 475.908364
+0:The total amount of wall time                        = 481.894784
 0:The maximum resident set size (KB)                   = 823820
 
 Test 055 rap_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_spp_sppt_shum_skeb
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_spp_sppt_shum_skeb
 Checking test 056 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2360,14 +2360,14 @@ Checking test 056 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 261.915424
-0:The maximum resident set size (KB)                   = 953640
+0:The total amount of wall time                        = 263.947093
+0:The maximum resident set size (KB)                   = 953684
 
 Test 056 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_decomp
 Checking test 057 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2414,14 +2414,14 @@ Checking test 057 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 505.879688
-0:The maximum resident set size (KB)                   = 822812
+0:The total amount of wall time                        = 503.655938
+0:The maximum resident set size (KB)                   = 822600
 
 Test 057 rap_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_2threads
 Checking test 058 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2468,14 +2468,14 @@ Checking test 058 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 461.028591
-0:The maximum resident set size (KB)                   = 894188
+0:The total amount of wall time                        = 462.567059
+0:The maximum resident set size (KB)                   = 893884
 
 Test 058 rap_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_restart
 Checking test 059 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2514,14 +2514,14 @@ Checking test 059 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 243.402879
-0:The maximum resident set size (KB)                   = 571812
+0:The total amount of wall time                        = 244.671107
+0:The maximum resident set size (KB)                   = 571800
 
 Test 059 rap_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_sfcdiff
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_sfcdiff
 Checking test 060 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2568,14 +2568,14 @@ Checking test 060 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 483.628090
-0:The maximum resident set size (KB)                   = 823752
+0:The total amount of wall time                        = 480.724470
+0:The maximum resident set size (KB)                   = 823852
 
 Test 060 rap_sfcdiff PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_sfcdiff_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_sfcdiff_decomp
 Checking test 061 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2622,14 +2622,14 @@ Checking test 061 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 504.956544
-0:The maximum resident set size (KB)                   = 822720
+0:The total amount of wall time                        = 506.599205
+0:The maximum resident set size (KB)                   = 822444
 
 Test 061 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_sfcdiff_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_sfcdiff_restart
 Checking test 062 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2668,14 +2668,14 @@ Checking test 062 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 355.157372
-0:The maximum resident set size (KB)                   = 571384
+0:The total amount of wall time                        = 357.874009
+0:The maximum resident set size (KB)                   = 571460
 
 Test 062 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control
 Checking test 063 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2722,14 +2722,14 @@ Checking test 063 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 445.184360
-0:The maximum resident set size (KB)                   = 820916
+0:The total amount of wall time                        = 447.761033
+0:The maximum resident set size (KB)                   = 820948
 
 Test 063 hrrr_control PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_decomp
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_decomp
 Checking test 064 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2776,14 +2776,14 @@ Checking test 064 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 469.636942
-0:The maximum resident set size (KB)                   = 820688
+0:The total amount of wall time                        = 467.656428
+0:The maximum resident set size (KB)                   = 820616
 
 Test 064 hrrr_control_decomp PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_2threads
 Checking test 065 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2830,28 +2830,28 @@ Checking test 065 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 505.516341
-0:The maximum resident set size (KB)                   = 890720
+0:The total amount of wall time                        = 508.492551
+0:The maximum resident set size (KB)                   = 890820
 
 Test 065 hrrr_control_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_restart
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_restart
 Checking test 066 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 329.995620
-0:The maximum resident set size (KB)                   = 567936
+0:The total amount of wall time                        = 330.445149
+0:The maximum resident set size (KB)                   = 567692
 
 Test 066 hrrr_control_restart PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_v1beta
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_v1beta
 Checking test 067 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2898,14 +2898,14 @@ Checking test 067 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 468.357238
-0:The maximum resident set size (KB)                   = 819760
+0:The total amount of wall time                        = 476.350122
+0:The maximum resident set size (KB)                   = 819908
 
 Test 067 rrfs_v1beta PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_v1nssl
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_v1nssl
 Checking test 068 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2920,14 +2920,14 @@ Checking test 068 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 585.515821
-0:The maximum resident set size (KB)                   = 508904
+0:The total amount of wall time                        = 585.146894
+0:The maximum resident set size (KB)                   = 508732
 
 Test 068 rrfs_v1nssl PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_v1nssl_nohailnoccn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_v1nssl_nohailnoccn
 Checking test 069 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2942,14 +2942,14 @@ Checking test 069 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 564.249771
-0:The maximum resident set size (KB)                   = 503104
+0:The total amount of wall time                        = 566.125986
+0:The maximum resident set size (KB)                   = 503032
 
 Test 069 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_smoke_conus13km_hrrr_warm
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2958,14 +2958,14 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 155.984607
-0:The maximum resident set size (KB)                   = 671108
+0:The total amount of wall time                        = 158.604640
+0:The maximum resident set size (KB)                   = 671096
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2974,14 +2974,14 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 96.973312
-0:The maximum resident set size (KB)                   = 693016
+0:The total amount of wall time                        = 95.848192
+0:The maximum resident set size (KB)                   = 692984
 
 Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_conus13km_hrrr_warm
 Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2990,14 +2990,14 @@ Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 139.530450
-0:The maximum resident set size (KB)                   = 667476
+0:The total amount of wall time                        = 142.273808
+0:The maximum resident set size (KB)                   = 667448
 
 Test 072 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 073 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3006,26 +3006,26 @@ Checking test 073 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 158.134007
-0:The maximum resident set size (KB)                   = 677612
+0:The total amount of wall time                        = 159.665462
+0:The maximum resident set size (KB)                   = 677556
 
 Test 073 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 074 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 72.897798
-0:The maximum resident set size (KB)                   = 640308
+0:The total amount of wall time                        = 73.185399
+0:The maximum resident set size (KB)                   = 640440
 
 Test 074 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_csawmg
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_csawmg
 Checking test 075 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3036,14 +3036,14 @@ Checking test 075 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 398.731365
-0:The maximum resident set size (KB)                   = 528140
+0:The total amount of wall time                        = 402.075695
+0:The maximum resident set size (KB)                   = 528048
 
 Test 075 control_csawmg PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_csawmgt
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_csawmgt
 Checking test 076 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3054,14 +3054,14 @@ Checking test 076 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 395.482771
-0:The maximum resident set size (KB)                   = 528656
+0:The total amount of wall time                        = 395.774870
+0:The maximum resident set size (KB)                   = 529264
 
 Test 076 control_csawmgt PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_ras
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_ras
 Checking test 077 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3072,26 +3072,26 @@ Checking test 077 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 209.833440
-0:The maximum resident set size (KB)                   = 491380
+0:The total amount of wall time                        = 208.259279
+0:The maximum resident set size (KB)                   = 491308
 
 Test 077 control_ras PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_wam
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_wam
 Checking test 078 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 129.995007
-0:The maximum resident set size (KB)                   = 207020
+0:The total amount of wall time                        = 130.294769
+0:The maximum resident set size (KB)                   = 206764
 
 Test 078 control_wam PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_faster
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_p8_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_p8_faster
 Checking test 079 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3138,14 +3138,14 @@ Checking test 079 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 174.071888
-0:The maximum resident set size (KB)                   = 1423728
+0:The total amount of wall time                        = 172.189868
+0:The maximum resident set size (KB)                   = 1423800
 
 Test 079 control_p8_faster PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control_faster
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_control_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_control_faster
 Checking test 080 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3156,56 +3156,56 @@ Checking test 080 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 320.383787
-0:The maximum resident set size (KB)                   = 604840
+0:The total amount of wall time                        = 324.435607
+0:The maximum resident set size (KB)                   = 604848
 
 Test 080 regional_control_faster PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 875.773072
-0:The maximum resident set size (KB)                   = 704324
+0:The total amount of wall time                        = 885.324588
+0:The maximum resident set size (KB)                   = 704260
 
 Test 081 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 500.158979
-0:The maximum resident set size (KB)                   = 723212
+0:The total amount of wall time                        = 504.778243
+0:The maximum resident set size (KB)                   = 723260
 
 Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_conus13km_hrrr_warm_debug
 Checking test 083 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 786.866811
-0:The maximum resident set size (KB)                   = 697580
+0:The total amount of wall time                        = 793.412373
+0:The maximum resident set size (KB)                   = 697516
 
 Test 083 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_CubedSphereGrid_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_CubedSphereGrid_debug
 Checking test 084 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3232,348 +3232,348 @@ Checking test 084 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 155.809745
-0:The maximum resident set size (KB)                   = 617944
+0:The total amount of wall time                        = 157.167537
+0:The maximum resident set size (KB)                   = 617904
 
 Test 084 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_wrtGauss_netcdf_parallel_debug
 Checking test 085 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 156.046099
-0:The maximum resident set size (KB)                   = 615432
+0:The total amount of wall time                        = 157.696233
+0:The maximum resident set size (KB)                   = 615524
 
 Test 085 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_stochy_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_stochy_debug
 Checking test 086 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 174.717880
-0:The maximum resident set size (KB)                   = 620872
+0:The total amount of wall time                        = 177.553434
+0:The maximum resident set size (KB)                   = 621048
 
 Test 086 control_stochy_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_lndp_debug
 Checking test 087 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 158.344963
-0:The maximum resident set size (KB)                   = 620424
+0:The total amount of wall time                        = 158.858357
+0:The maximum resident set size (KB)                   = 620516
 
 Test 087 control_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_csawmg_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_csawmg_debug
 Checking test 088 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 248.577603
-0:The maximum resident set size (KB)                   = 666760
+0:The total amount of wall time                        = 247.078005
+0:The maximum resident set size (KB)                   = 666824
 
 Test 088 control_csawmg_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_csawmgt_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_csawmgt_debug
 Checking test 089 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 245.727035
-0:The maximum resident set size (KB)                   = 667684
+0:The total amount of wall time                        = 245.893893
+0:The maximum resident set size (KB)                   = 667724
 
 Test 089 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_ras_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_ras_debug
 Checking test 090 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 159.757762
-0:The maximum resident set size (KB)                   = 630012
+0:The total amount of wall time                        = 160.475604
+0:The maximum resident set size (KB)                   = 629932
 
 Test 090 control_ras_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_diag_debug
 Checking test 091 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 158.915743
-0:The maximum resident set size (KB)                   = 675352
+0:The total amount of wall time                        = 165.090754
+0:The maximum resident set size (KB)                   = 675252
 
 Test 091 control_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_debug_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_debug_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_debug_p8
 Checking test 092 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 174.495032
-0:The maximum resident set size (KB)                   = 1443264
+0:The total amount of wall time                        = 179.576106
+0:The maximum resident set size (KB)                   = 1443360
 
 Test 092 control_debug_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_debug
 Checking test 093 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 1037.010690
-0:The maximum resident set size (KB)                   = 626404
+0:The total amount of wall time                        = 1041.208612
+0:The maximum resident set size (KB)                   = 626416
 
 Test 093 regional_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_control_debug
 Checking test 094 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.272780
-0:The maximum resident set size (KB)                   = 987188
+0:The total amount of wall time                        = 289.092677
+0:The maximum resident set size (KB)                   = 986908
 
 Test 094 rap_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_debug
 Checking test 095 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 280.144032
-0:The maximum resident set size (KB)                   = 983132
+0:The total amount of wall time                        = 284.719646
+0:The maximum resident set size (KB)                   = 983100
 
 Test 095 hrrr_control_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_unified_drag_suite_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_unified_drag_suite_debug
 Checking test 096 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.819120
-0:The maximum resident set size (KB)                   = 987260
+0:The total amount of wall time                        = 288.096246
+0:The maximum resident set size (KB)                   = 987240
 
 Test 096 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_diag_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_diag_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_diag_debug
 Checking test 097 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 297.122933
-0:The maximum resident set size (KB)                   = 1070236
+0:The total amount of wall time                        = 299.656447
+0:The maximum resident set size (KB)                   = 1070392
 
 Test 097 rap_diag_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_cires_ugwp_debug
 Checking test 098 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 293.036173
-0:The maximum resident set size (KB)                   = 986272
+0:The total amount of wall time                        = 293.433110
+0:The maximum resident set size (KB)                   = 986220
 
 Test 098 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_unified_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_unified_ugwp_debug
 Checking test 099 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 293.586870
-0:The maximum resident set size (KB)                   = 987096
+0:The total amount of wall time                        = 295.907395
+0:The maximum resident set size (KB)                   = 987308
 
 Test 099 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_lndp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_lndp_debug
 Checking test 100 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.113313
-0:The maximum resident set size (KB)                   = 987892
+0:The total amount of wall time                        = 293.063190
+0:The maximum resident set size (KB)                   = 987832
 
 Test 100 rap_lndp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_progcld_thompson_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_progcld_thompson_debug
 Checking test 101 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.257467
-0:The maximum resident set size (KB)                   = 986992
+0:The total amount of wall time                        = 287.069375
+0:The maximum resident set size (KB)                   = 986816
 
 Test 101 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_noah_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_noah_debug
 Checking test 102 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 279.856384
-0:The maximum resident set size (KB)                   = 984956
+0:The total amount of wall time                        = 281.505648
+0:The maximum resident set size (KB)                   = 984924
 
 Test 102 rap_noah_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_sfcdiff_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_sfcdiff_debug
 Checking test 103 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.541229
-0:The maximum resident set size (KB)                   = 986996
+0:The total amount of wall time                        = 289.899488
+0:The maximum resident set size (KB)                   = 986848
 
 Test 103 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 472.497753
-0:The maximum resident set size (KB)                   = 985732
+0:The total amount of wall time                        = 472.585785
+0:The maximum resident set size (KB)                   = 985840
 
 Test 104 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rrfs_v1beta_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rrfs_v1beta_debug
 Checking test 105 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 281.870448
-0:The maximum resident set size (KB)                   = 982844
+0:The total amount of wall time                        = 284.951884
+0:The maximum resident set size (KB)                   = 982952
 
 Test 105 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_clm_lake_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_clm_lake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_clm_lake_debug
 Checking test 106 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 350.769501
-0:The maximum resident set size (KB)                   = 989964
+0:The total amount of wall time                        = 356.095482
+0:The maximum resident set size (KB)                   = 989988
 
 Test 106 rap_clm_lake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_flake_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_flake_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_flake_debug
 Checking test 107 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.142000
-0:The maximum resident set size (KB)                   = 987216
+0:The total amount of wall time                        = 286.983649
+0:The maximum resident set size (KB)                   = 987260
 
 Test 107 rap_flake_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_wam_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_wam_debug
 Checking test 108 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 289.164381
-0:The maximum resident set size (KB)                   = 235724
+0:The total amount of wall time                        = 291.699489
+0:The maximum resident set size (KB)                   = 235680
 
 Test 108 control_wam_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3584,14 +3584,14 @@ Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 248.765865
-0:The maximum resident set size (KB)                   = 855404
+0:The total amount of wall time                        = 247.764089
+0:The maximum resident set size (KB)                   = 855272
 
 Test 109 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_control_dyn32_phy32
 Checking test 110 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3638,14 +3638,14 @@ Checking test 110 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 400.789003
-0:The maximum resident set size (KB)                   = 708264
+0:The total amount of wall time                        = 392.706276
+0:The maximum resident set size (KB)                   = 708104
 
 Test 110 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_dyn32_phy32
 Checking test 111 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3692,14 +3692,14 @@ Checking test 111 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 202.224699
-0:The maximum resident set size (KB)                   = 707924
+0:The total amount of wall time                        = 202.198152
+0:The maximum resident set size (KB)                   = 707912
 
 Test 111 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_2threads_dyn32_phy32
 Checking test 112 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3746,14 +3746,14 @@ Checking test 112 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 381.970502
-0:The maximum resident set size (KB)                   = 756588
+0:The total amount of wall time                        = 390.245208
+0:The maximum resident set size (KB)                   = 756576
 
 Test 112 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_2threads_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_2threads_dyn32_phy32
 Checking test 113 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3800,14 +3800,14 @@ Checking test 113 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 277.308917
-0:The maximum resident set size (KB)                   = 752108
+0:The total amount of wall time                        = 277.151381
+0:The maximum resident set size (KB)                   = 753048
 
 Test 113 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_decomp_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_decomp_dyn32_phy32
 Checking test 114 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3854,14 +3854,14 @@ Checking test 114 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 215.848961
-0:The maximum resident set size (KB)                   = 705964
+0:The total amount of wall time                        = 210.647510
+0:The maximum resident set size (KB)                   = 705932
 
 Test 114 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_restart_dyn32_phy32
 Checking test 115 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3900,28 +3900,28 @@ Checking test 115 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 291.572354
-0:The maximum resident set size (KB)                   = 545144
+0:The total amount of wall time                        = 298.206645
+0:The maximum resident set size (KB)                   = 545192
 
 Test 115 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_restart_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_restart_dyn32_phy32
 Checking test 116 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 105.757994
-0:The maximum resident set size (KB)                   = 536696
+0:The total amount of wall time                        = 103.479212
+0:The maximum resident set size (KB)                   = 536516
 
 Test 116 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_control_dyn64_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_control_dyn64_phy32
 Checking test 117 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3968,81 +3968,81 @@ Checking test 117 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 273.595358
-0:The maximum resident set size (KB)                   = 730656
+0:The total amount of wall time                        = 264.235524
+0:The maximum resident set size (KB)                   = 730588
 
 Test 117 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_control_debug_dyn32_phy32
 Checking test 118 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 280.434840
-0:The maximum resident set size (KB)                   = 872352
+0:The total amount of wall time                        = 283.070670
+0:The maximum resident set size (KB)                   = 872280
 
 Test 118 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hrrr_control_debug_dyn32_phy32
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hrrr_control_debug_dyn32_phy32
 Checking test 119 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 275.619384
-0:The maximum resident set size (KB)                   = 871072
+0:The total amount of wall time                        = 276.097307
+0:The maximum resident set size (KB)                   = 871068
 
 Test 119 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/rap_control_dyn64_phy32_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/rap_control_dyn64_phy32_debug
 Checking test 120 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.399337
-0:The maximum resident set size (KB)                   = 893004
+0:The total amount of wall time                        = 288.501406
+0:The maximum resident set size (KB)                   = 893008
 
 Test 120 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_atm
 Checking test 121 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 259.521982
-0:The maximum resident set size (KB)                   = 743088
+0:The total amount of wall time                        = 263.121936
+0:The maximum resident set size (KB)                   = 743428
 
 Test 121 hafs_regional_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_atm_thompson_gfdlsf
 Checking test 122 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 343.523925
-0:The maximum resident set size (KB)                   = 1101216
+0:The total amount of wall time                        = 293.465137
+0:The maximum resident set size (KB)                   = 1098976
 
 Test 122 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_atm_ocn
 Checking test 123 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4051,14 +4051,14 @@ Checking test 123 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 455.199375
-0:The maximum resident set size (KB)                   = 743224
+0:The total amount of wall time                        = 456.712835
+0:The maximum resident set size (KB)                   = 743260
 
 Test 123 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_atm_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_atm_wav
 Checking test 124 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4067,14 +4067,14 @@ Checking test 124 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1074.359986
-0:The maximum resident set size (KB)                   = 772520
+0:The total amount of wall time                        = 1024.582698
+0:The maximum resident set size (KB)                   = 772592
 
 Test 124 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_atm_ocn_wav
 Checking test 125 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4085,28 +4085,28 @@ Checking test 125 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1093.796132
-0:The maximum resident set size (KB)                   = 793076
+0:The total amount of wall time                        = 1171.347442
+0:The maximum resident set size (KB)                   = 793004
 
 Test 125 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_1nest_atm
 Checking test 126 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 376.707190
-0:The maximum resident set size (KB)                   = 301340
+0:The total amount of wall time                        = 375.800269
+0:The maximum resident set size (KB)                   = 300712
 
 Test 126 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_telescopic_2nests_atm
 Checking test 127 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4115,28 +4115,28 @@ Checking test 127 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 426.005482
-0:The maximum resident set size (KB)                   = 320976
+0:The total amount of wall time                        = 427.572876
+0:The maximum resident set size (KB)                   = 320964
 
 Test 127 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_global_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_global_1nest_atm
 Checking test 128 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 173.446271
-0:The maximum resident set size (KB)                   = 214684
+0:The total amount of wall time                        = 169.354412
+0:The maximum resident set size (KB)                   = 214508
 
 Test 128 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_global_multiple_4nests_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_global_multiple_4nests_atm
 Checking test 129 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4154,14 +4154,14 @@ Checking test 129 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-0:The total amount of wall time                        = 484.860707
-0:The maximum resident set size (KB)                   = 303488
+0:The total amount of wall time                        = 483.138515
+0:The maximum resident set size (KB)                   = 302980
 
 Test 129 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_specified_moving_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_specified_moving_1nest_atm
 Checking test 130 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4170,28 +4170,28 @@ Checking test 130 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 241.934138
-0:The maximum resident set size (KB)                   = 318996
+0:The total amount of wall time                        = 241.711130
+0:The maximum resident set size (KB)                   = 319004
 
 Test 130 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_storm_following_1nest_atm
 Checking test 131 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 230.972152
-0:The maximum resident set size (KB)                   = 319144
+0:The total amount of wall time                        = 230.803977
+0:The maximum resident set size (KB)                   = 318956
 
 Test 131 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 132 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4200,42 +4200,42 @@ Checking test 132 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 277.549806
-0:The maximum resident set size (KB)                   = 375332
+0:The total amount of wall time                        = 283.469921
+0:The maximum resident set size (KB)                   = 375780
 
 Test 132 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_global_storm_following_1nest_atm
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_global_storm_following_1nest_atm
 Checking test 133 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 70.505526
-0:The maximum resident set size (KB)                   = 233916
+0:The total amount of wall time                        = 68.277604
+0:The maximum resident set size (KB)                   = 233944
 
 Test 133 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 134 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-0:The total amount of wall time                        = 767.145788
-0:The maximum resident set size (KB)                   = 402076
+0:The total amount of wall time                        = 774.632734
+0:The maximum resident set size (KB)                   = 401900
 
 Test 134 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4246,14 +4246,14 @@ Checking test 135 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 786.860062
-0:The maximum resident set size (KB)                   = 427636
+0:The total amount of wall time                        = 795.546650
+0:The maximum resident set size (KB)                   = 428280
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_docn
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_docn
 Checking test 136 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4261,14 +4261,14 @@ Checking test 136 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 390.635766
-0:The maximum resident set size (KB)                   = 756580
+0:The total amount of wall time                        = 391.939834
+0:The maximum resident set size (KB)                   = 756592
 
 Test 136 hafs_regional_docn PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_docn_oisst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_docn_oisst
 Checking test 137 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4276,131 +4276,131 @@ Checking test 137 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 481.252227
-0:The maximum resident set size (KB)                   = 736616
+0:The total amount of wall time                        = 462.149700
+0:The maximum resident set size (KB)                   = 736044
 
 Test 137 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/hafs_regional_datm_cdeps
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/hafs_regional_datm_cdeps
 Checking test 138 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1285.869506
-0:The maximum resident set size (KB)                   = 887928
+0:The total amount of wall time                        = 1292.942104
+0:The maximum resident set size (KB)                   = 887908
 
 Test 138 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_control_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_control_cfsr
 Checking test 139 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.762009
-0:The maximum resident set size (KB)                   = 716676
+0:The total amount of wall time                        = 168.306054
+0:The maximum resident set size (KB)                   = 716712
 
 Test 139 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_restart_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_restart_cfsr
 Checking test 140 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 100.779304
-0:The maximum resident set size (KB)                   = 704832
+0:The total amount of wall time                        = 97.326517
+0:The maximum resident set size (KB)                   = 704864
 
 Test 140 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_control_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_control_gefs
 Checking test 141 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.001626
-0:The maximum resident set size (KB)                   = 607504
+0:The total amount of wall time                        = 160.931873
+0:The maximum resident set size (KB)                   = 607476
 
 Test 141 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_iau_gefs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_iau_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_iau_gefs
 Checking test 142 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.841932
-0:The maximum resident set size (KB)                   = 607508
+0:The total amount of wall time                        = 160.129447
+0:The maximum resident set size (KB)                   = 607464
 
 Test 142 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_stochy_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_stochy_gefs
 Checking test 143 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.108923
-0:The maximum resident set size (KB)                   = 607504
+0:The total amount of wall time                        = 165.648601
+0:The maximum resident set size (KB)                   = 607440
 
 Test 143 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_ciceC_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_ciceC_cfsr
 Checking test 144 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 169.530537
-0:The maximum resident set size (KB)                   = 716676
+0:The total amount of wall time                        = 169.085110
+0:The maximum resident set size (KB)                   = 716696
 
 Test 144 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_bulk_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_bulk_cfsr
 Checking test 145 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.823598
-0:The maximum resident set size (KB)                   = 716676
+0:The total amount of wall time                        = 169.314225
+0:The maximum resident set size (KB)                   = 716696
 
 Test 145 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_bulk_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_bulk_gefs
 Checking test 146 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.889454
-0:The maximum resident set size (KB)                   = 607512
+0:The total amount of wall time                        = 161.169207
+0:The maximum resident set size (KB)                   = 607436
 
 Test 146 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_mx025_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_mx025_cfsr
 Checking test 147 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4409,14 +4409,14 @@ Checking test 147 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 429.997398
-0:The maximum resident set size (KB)                   = 514704
+0:The total amount of wall time                        = 821.293210
+0:The maximum resident set size (KB)                   = 514364
 
 Test 147 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_mx025_gefs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_mx025_gefs
 Checking test 148 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4425,77 +4425,77 @@ Checking test 148 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 421.745325
-0:The maximum resident set size (KB)                   = 494900
+0:The total amount of wall time                        = 433.441407
+0:The maximum resident set size (KB)                   = 494764
 
 Test 148 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_multiple_files_cfsr
 Checking test 149 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.930718
-0:The maximum resident set size (KB)                   = 716740
+0:The total amount of wall time                        = 166.660255
+0:The maximum resident set size (KB)                   = 716736
 
 Test 149 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_3072x1536_cfsr
 Checking test 150 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 268.648702
-0:The maximum resident set size (KB)                   = 1941404
+0:The total amount of wall time                        = 256.502415
+0:The maximum resident set size (KB)                   = 1910036
 
 Test 150 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_gfs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_gfs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_gfs
 Checking test 151 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 269.067076
-0:The maximum resident set size (KB)                   = 1939416
+0:The total amount of wall time                        = 269.306711
+0:The maximum resident set size (KB)                   = 1941084
 
 Test 151 datm_cdeps_gfs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_debug_cfsr
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_debug_cfsr
 Checking test 152 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 368.953988
-0:The maximum resident set size (KB)                   = 700612
+0:The total amount of wall time                        = 369.137286
+0:The maximum resident set size (KB)                   = 700716
 
 Test 152 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_control_cfsr_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_control_cfsr_faster
 Checking test 153 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 163.543653
-0:The maximum resident set size (KB)                   = 716736
+0:The total amount of wall time                        = 162.266042
+0:The maximum resident set size (KB)                   = 716740
 
 Test 153 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_lnd_gswp3
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_lnd_gswp3
 Checking test 154 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4504,14 +4504,14 @@ Checking test 154 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 10.719925
-0:The maximum resident set size (KB)                   = 208240
+0:The total amount of wall time                        = 10.086677
+0:The maximum resident set size (KB)                   = 208292
 
 Test 154 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/datm_cdeps_lnd_gswp3_rst
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/datm_cdeps_lnd_gswp3_rst
 Checking test 155 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4520,14 +4520,14 @@ Checking test 155 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 16.301166
-0:The maximum resident set size (KB)                   = 216368
+0:The total amount of wall time                        = 15.871247
+0:The maximum resident set size (KB)                   = 210140
 
 Test 155 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_atmlnd_sbs
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_p8_atmlnd_sbs
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_p8_atmlnd_sbs
 Checking test 156 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4612,14 +4612,14 @@ Checking test 156 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-0:The total amount of wall time                        = 234.579635
-0:The maximum resident set size (KB)                   = 1463216
+0:The total amount of wall time                        = 235.555771
+0:The maximum resident set size (KB)                   = 1463224
 
 Test 156 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/atmwav_control_noaero_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/atmwav_control_noaero_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/atmwav_control_noaero_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/atmwav_control_noaero_p8
 Checking test 157 atmwav_control_noaero_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4662,14 +4662,14 @@ Checking test 157 atmwav_control_noaero_p8 results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-0:The total amount of wall time                        = 98.686716
-0:The maximum resident set size (KB)                   = 1434600
+0:The total amount of wall time                        = 101.536937
+0:The maximum resident set size (KB)                   = 1434500
 
 Test 157 atmwav_control_noaero_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/control_atmwav
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/control_atmwav
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/control_atmwav
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/control_atmwav
 Checking test 158 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4713,14 +4713,14 @@ Checking test 158 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 101.144680
-0:The maximum resident set size (KB)                   = 475312
+0:The total amount of wall time                        = 101.877108
+0:The maximum resident set size (KB)                   = 475292
 
 Test 158 control_atmwav PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/atmaero_control_p8
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/atmaero_control_p8
 Checking test 159 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4764,14 +4764,14 @@ Checking test 159 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 249.525744
-0:The maximum resident set size (KB)                   = 2703984
+0:The total amount of wall time                        = 253.573256
+0:The maximum resident set size (KB)                   = 2703992
 
 Test 159 atmaero_control_p8 PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/atmaero_control_p8_rad
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/atmaero_control_p8_rad
 Checking test 160 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4815,14 +4815,14 @@ Checking test 160 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 302.020892
-0:The maximum resident set size (KB)                   = 2758880
+0:The total amount of wall time                        = 307.307900
+0:The maximum resident set size (KB)                   = 2758840
 
 Test 160 atmaero_control_p8_rad PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad_micro
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/atmaero_control_p8_rad_micro
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/atmaero_control_p8_rad_micro
 Checking test 161 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4866,14 +4866,14 @@ Checking test 161 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 309.003540
-0:The maximum resident set size (KB)                   = 2765588
+0:The total amount of wall time                        = 308.775831
+0:The maximum resident set size (KB)                   = 2765556
 
 Test 161 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_atmaq
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_atmaq
 Checking test 162 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4889,14 +4889,14 @@ Checking test 162 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 760.029388
-0:The maximum resident set size (KB)                   = 999616
+0:The total amount of wall time                        = 750.670771
+0:The maximum resident set size (KB)                   = 999724
 
 Test 162 regional_atmaq PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_faster
-working dir  = /glade/scratch/jongkim/rt-1731-intel/jongkim/FV3_RT/rt_49163/regional_atmaq_faster
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_faster
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_8251/regional_atmaq_faster
 Checking test 163 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4912,12 +4912,12 @@ Checking test 163 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 706.397204
-0:The maximum resident set size (KB)                   = 999612
+0:The total amount of wall time                        = 699.838306
+0:The maximum resident set size (KB)                   = 999488
 
 Test 163 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat May  6 10:06:49 MDT 2023
-Elapsed time: 02h:20m:33s. Have a nice day!
+Wed May 10 15:47:12 MDT 2023
+Elapsed time: 01h:23m:37s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,43 +1,43 @@
-Sun Apr  9 21:07:10 EDT 2023
+Thu 11 May 2023 03:27:43 PM EDT
 Start Regression test
 
-Compile 001 elapsed time 937 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 872 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 829 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 350 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 296 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 785 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 746 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 1131 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 758 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 738 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 656 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 637 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 890 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 258 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 207 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 650 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 635 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 299 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 208 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 697 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 256 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 888 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 728 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 281 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 162 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 354 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 98 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 704 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 668 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 698 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 646 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 776 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 258 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 034 elapsed time 777 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 953 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 975 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 900 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 349 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 308 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 821 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 808 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1049 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 842 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 768 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 757 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 731 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 927 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 327 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 272 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 742 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 810 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 255 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 274 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 812 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 295 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 1014 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 915 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 342 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 243 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 331 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 188 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 799 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 818 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 837 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 791 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 760 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 281 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 034 elapsed time 928 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8_mixedmode
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_p8_mixedmode
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -102,14 +102,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 387.614474
-  0: The maximum resident set size (KB)                   = 1534188
+  0: The total amount of wall time                        = 321.154633
+  0: The maximum resident set size (KB)                   = 1549056
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_gfsv17
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_gfsv17
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_gfsv17
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -173,14 +173,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 285.429925
-  0: The maximum resident set size (KB)                   = 1443460
+  0: The total amount of wall time                        = 235.191425
+  0: The maximum resident set size (KB)                   = 1443400
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -245,14 +245,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 407.693495
-  0: The maximum resident set size (KB)                   = 1566692
+  0: The total amount of wall time                        = 365.122502
+  0: The maximum resident set size (KB)                   = 1582296
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -305,14 +305,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 248.002024
-  0: The maximum resident set size (KB)                   = 1018328
+  0: The total amount of wall time                        = 209.942826
+  0: The maximum resident set size (KB)                   = 1021188
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_qr_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -377,14 +377,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 406.611085
-  0: The maximum resident set size (KB)                   = 1577640
+  0: The total amount of wall time                        = 371.549266
+  0: The maximum resident set size (KB)                   = 1593916
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_restart_qr_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -437,14 +437,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 247.338311
-  0: The maximum resident set size (KB)                   = 1031440
+  0: The total amount of wall time                        = 211.711733
+  0: The maximum resident set size (KB)                   = 1035248
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -497,14 +497,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 418.517646
-  0: The maximum resident set size (KB)                   = 1758916
+  0: The total amount of wall time                        = 380.909110
+  0: The maximum resident set size (KB)                   = 1774940
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -557,14 +557,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 404.237894
-  0: The maximum resident set size (KB)                   = 1561660
+  0: The total amount of wall time                        = 367.950629
+  0: The maximum resident set size (KB)                   = 1573100
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -617,14 +617,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 350.542338
-  0: The maximum resident set size (KB)                   = 1527016
+  0: The total amount of wall time                        = 306.985943
+  0: The maximum resident set size (KB)                   = 1541436
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -672,14 +672,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 893.650557
-   0: The maximum resident set size (KB)                   = 2503316
+   0: The total amount of wall time                        = 739.641408
+   0: The maximum resident set size (KB)                   = 2518216
 
-Test 010 cpld_bmark_p8 PASS
+Test 010 cpld_bmark_p8 PASS Tries: 2
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_restart_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -727,14 +727,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 608.551522
-   0: The maximum resident set size (KB)                   = 2323640
+   0: The total amount of wall time                        = 448.125643
+   0: The maximum resident set size (KB)                   = 2333952
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_noaero_p8
 Checking test 012 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -798,14 +798,14 @@ Checking test 012 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 310.545752
-  0: The maximum resident set size (KB)                   = 1441408
+  0: The total amount of wall time                        = 274.922653
+  0: The maximum resident set size (KB)                   = 1440468
 
 Test 012 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_nowave_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_nowave_noaero_p8
 Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -867,14 +867,14 @@ Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 313.962676
-  0: The maximum resident set size (KB)                   = 1474212
+  0: The total amount of wall time                        = 283.247583
+  0: The maximum resident set size (KB)                   = 1474220
 
 Test 013 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_debug_p8
 Checking test 014 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -927,14 +927,14 @@ Checking test 014 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 582.658867
-  0: The maximum resident set size (KB)                   = 1592244
+  0: The total amount of wall time                        = 548.490799
+  0: The maximum resident set size (KB)                   = 1615856
 
 Test 014 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_debug_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_debug_noaero_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_debug_noaero_p8
 Checking test 015 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -986,14 +986,14 @@ Checking test 015 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 386.397364
-  0: The maximum resident set size (KB)                   = 1441572
+  0: The total amount of wall time                        = 379.514708
+  0: The maximum resident set size (KB)                   = 1441508
 
 Test 015 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_noaero_p8_agrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_noaero_p8_agrid
 Checking test 016 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1055,14 +1055,14 @@ Checking test 016 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 324.821043
-  0: The maximum resident set size (KB)                   = 1478412
+  0: The total amount of wall time                        = 292.197721
+  0: The maximum resident set size (KB)                   = 1476964
 
 Test 016 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_c48
 Checking test 017 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1112,14 +1112,14 @@ Checking test 017 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 607.115574
- 0: The maximum resident set size (KB)                   = 2575280
+ 0: The total amount of wall time                        = 604.052583
+ 0: The maximum resident set size (KB)                   = 2563472
 
 Test 017 cpld_control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_warmstart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_warmstart_c48
 Checking test 018 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1169,14 +1169,14 @@ Checking test 018 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 186.810125
- 0: The maximum resident set size (KB)                   = 2588520
+ 0: The total amount of wall time                        = 159.675121
+ 0: The maximum resident set size (KB)                   = 2576564
 
 Test 018 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_warmstart_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_restart_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_restart_c48
 Checking test 019 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1226,14 +1226,14 @@ Checking test 019 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 87.032061
- 0: The maximum resident set size (KB)                   = 2007496
+ 0: The total amount of wall time                        = 83.848113
+ 0: The maximum resident set size (KB)                   = 1990276
 
 Test 019 cpld_restart_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/cpld_control_p8_faster
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/cpld_control_p8_faster
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/cpld_control_p8_faster
 Checking test 020 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1298,15 +1298,33 @@ Checking test 020 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 397.423684
-  0: The maximum resident set size (KB)                   = 1567216
+  0: The total amount of wall time                        = 352.496896
+  0: The maximum resident set size (KB)                   = 1582004
 
 Test 020 cpld_control_p8_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_CubedSphereGrid
-Checking test 021 control_CubedSphereGrid results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_flake
+Checking test 021 control_flake results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 208.862774
+  0: The maximum resident set size (KB)                   = 485444
+
+Test 021 control_flake PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_CubedSphereGrid
+Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -1332,29 +1350,29 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 145.769862
-  0: The maximum resident set size (KB)                   = 437956
+  0: The total amount of wall time                        = 136.484075
+  0: The maximum resident set size (KB)                   = 438148
 
-Test 021 control_CubedSphereGrid PASS
+Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_CubedSphereGrid_parallel
-Checking test 022 control_CubedSphereGrid_parallel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_CubedSphereGrid_parallel
+Checking test 023 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 144.154244
-  0: The maximum resident set size (KB)                   = 437772
+  0: The total amount of wall time                        = 164.470986
+  0: The maximum resident set size (KB)                   = 438480
 
-Test 022 control_CubedSphereGrid_parallel PASS
+Test 023 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_latlon
-Checking test 023 control_latlon results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_latlon
+Checking test 024 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1364,15 +1382,15 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 144.943397
-  0: The maximum resident set size (KB)                   = 437924
+  0: The total amount of wall time                        = 139.791346
+  0: The maximum resident set size (KB)                   = 438208
 
-Test 023 control_latlon PASS
+Test 024 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_wrtGauss_netcdf_parallel
-Checking test 024 control_wrtGauss_netcdf_parallel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_wrtGauss_netcdf_parallel
+Checking test 025 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1382,15 +1400,15 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 153.901595
-  0: The maximum resident set size (KB)                   = 437884
+  0: The total amount of wall time                        = 176.154512
+  0: The maximum resident set size (KB)                   = 438220
 
-Test 024 control_wrtGauss_netcdf_parallel PASS
+Test 025 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_c48
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_c48
-Checking test 025 control_c48 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_c48
+Checking test 026 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1428,15 +1446,15 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 421.266739
-0: The maximum resident set size (KB)                   = 636844
+0: The total amount of wall time                        = 418.421092
+0: The maximum resident set size (KB)                   = 638124
 
-Test 025 control_c48 PASS
+Test 026 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_c192
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_c192
-Checking test 026 control_c192 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_c192
+Checking test 027 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1446,15 +1464,15 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 578.004508
-  0: The maximum resident set size (KB)                   = 544804
+  0: The total amount of wall time                        = 572.237585
+  0: The maximum resident set size (KB)                   = 545016
 
-Test 026 control_c192 PASS
+Test 027 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_c384
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_c384
-Checking test 027 control_c384 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_c384
+Checking test 028 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1464,15 +1482,15 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1127.701420
-  0: The maximum resident set size (KB)                   = 822992
+  0: The total amount of wall time                        = 1085.277804
+  0: The maximum resident set size (KB)                   = 824172
 
-Test 027 control_c384 PASS
+Test 028 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_c384gdas
-Checking test 028 control_c384gdas results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_c384gdas
+Checking test 029 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1514,15 +1532,15 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 939.692781
-  0: The maximum resident set size (KB)                   = 954808
+  0: The total amount of wall time                        = 900.730507
+  0: The maximum resident set size (KB)                   = 955512
 
-Test 028 control_c384gdas PASS
+Test 029 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_stochy
-Checking test 029 control_stochy results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_stochy
+Checking test 030 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1532,29 +1550,29 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 97.795768
-  0: The maximum resident set size (KB)                   = 441420
+  0: The total amount of wall time                        = 92.800204
+  0: The maximum resident set size (KB)                   = 439652
 
-Test 029 control_stochy PASS
+Test 030 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_stochy_restart
-Checking test 030 control_stochy_restart results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_stochy_restart
+Checking test 031 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 60.919271
-  0: The maximum resident set size (KB)                   = 195844
+  0: The total amount of wall time                        = 50.171268
+  0: The maximum resident set size (KB)                   = 195880
 
-Test 030 control_stochy_restart PASS
+Test 031 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_lndp
-Checking test 031 control_lndp results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_lndp
+Checking test 032 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1564,15 +1582,15 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 93.460305
-  0: The maximum resident set size (KB)                   = 441036
+  0: The total amount of wall time                        = 85.610296
+  0: The maximum resident set size (KB)                   = 442892
 
-Test 031 control_lndp PASS
+Test 032 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_iovr4
-Checking test 032 control_iovr4 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_iovr4
+Checking test 033 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1586,15 +1604,15 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 145.754778
-  0: The maximum resident set size (KB)                   = 437852
+  0: The total amount of wall time                        = 141.919952
+  0: The maximum resident set size (KB)                   = 437960
 
-Test 032 control_iovr4 PASS
+Test 033 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_iovr5
-Checking test 033 control_iovr5 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_iovr5
+Checking test 034 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1608,15 +1626,15 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 148.373188
-  0: The maximum resident set size (KB)                   = 437916
+  0: The total amount of wall time                        = 141.625455
+  0: The maximum resident set size (KB)                   = 438040
 
-Test 033 control_iovr5 PASS
+Test 034 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_p8
-Checking test 034 control_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_p8
+Checking test 035 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1662,15 +1680,15 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 194.959784
-  0: The maximum resident set size (KB)                   = 1380104
+  0: The total amount of wall time                        = 175.805688
+  0: The maximum resident set size (KB)                   = 1380244
 
-Test 034 control_p8 PASS
+Test 035 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_restart_p8
-Checking test 035 control_restart_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_restart_p8
+Checking test 036 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -1708,15 +1726,15 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 114.413771
-  0: The maximum resident set size (KB)                   = 556664
+  0: The total amount of wall time                        = 92.453186
+  0: The maximum resident set size (KB)                   = 547928
 
-Test 035 control_restart_p8 PASS
+Test 036 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_qr_p8
-Checking test 036 control_qr_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_qr_p8
+Checking test 037 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1762,15 +1780,15 @@ Checking test 036 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 194.519535
-  0: The maximum resident set size (KB)                   = 1383264
+  0: The total amount of wall time                        = 176.519534
+  0: The maximum resident set size (KB)                   = 1383380
 
-Test 036 control_qr_p8 PASS
+Test 037 control_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_restart_qr_p8
-Checking test 037 control_restart_qr_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_restart_qr_p8
+Checking test 038 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -1808,15 +1826,15 @@ Checking test 037 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 111.143377
-  0: The maximum resident set size (KB)                   = 581576
+  0: The total amount of wall time                        = 93.967197
+  0: The maximum resident set size (KB)                   = 568992
 
-Test 037 control_restart_qr_p8 PASS
+Test 038 control_restart_qr_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_decomp_p8
-Checking test 038 control_decomp_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_decomp_p8
+Checking test 039 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1858,15 +1876,15 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 192.806025
-  0: The maximum resident set size (KB)                   = 1373980
+  0: The total amount of wall time                        = 182.909077
+  0: The maximum resident set size (KB)                   = 1374320
 
-Test 038 control_decomp_p8 PASS
+Test 039 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_2threads_p8
-Checking test 039 control_2threads_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_2threads_p8
+Checking test 040 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1908,15 +1926,15 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.641269
-  0: The maximum resident set size (KB)                   = 1464120
+  0: The total amount of wall time                        = 172.448131
+  0: The maximum resident set size (KB)                   = 1465452
 
-Test 039 control_2threads_p8 PASS
+Test 040 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8_lndp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_p8_lndp
-Checking test 040 control_p8_lndp results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_p8_lndp
+Checking test 041 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1934,15 +1952,15 @@ Checking test 040 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 361.347210
-  0: The maximum resident set size (KB)                   = 1381220
+  0: The total amount of wall time                        = 324.941795
+  0: The maximum resident set size (KB)                   = 1381348
 
-Test 040 control_p8_lndp PASS
+Test 041 control_p8_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8_rrtmgp
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_p8_rrtmgp
-Checking test 041 control_p8_rrtmgp results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_p8_rrtmgp
+Checking test 042 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1988,15 +2006,15 @@ Checking test 041 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 265.327983
-  0: The maximum resident set size (KB)                   = 1437540
+  0: The total amount of wall time                        = 241.825190
+  0: The maximum resident set size (KB)                   = 1437668
 
-Test 041 control_p8_rrtmgp PASS
+Test 042 control_p8_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8_mynn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_p8_mynn
-Checking test 042 control_p8_mynn results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_p8_mynn
+Checking test 043 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2042,15 +2060,15 @@ Checking test 042 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.877252
-  0: The maximum resident set size (KB)                   = 1384160
+  0: The total amount of wall time                        = 178.597941
+  0: The maximum resident set size (KB)                   = 1384404
 
-Test 042 control_p8_mynn PASS
+Test 043 control_p8_mynn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/merra2_thompson
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/merra2_thompson
-Checking test 043 merra2_thompson results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/merra2_thompson
+Checking test 044 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2096,15 +2114,15 @@ Checking test 043 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.525689
-  0: The maximum resident set size (KB)                   = 1385616
+  0: The total amount of wall time                        = 199.345641
+  0: The maximum resident set size (KB)                   = 1385696
 
-Test 043 merra2_thompson PASS
+Test 044 merra2_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_control
-Checking test 044 regional_control results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_control
+Checking test 045 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2114,29 +2132,29 @@ Checking test 044 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 345.097944
-  0: The maximum resident set size (KB)                   = 578644
+  0: The total amount of wall time                        = 329.397452
+  0: The maximum resident set size (KB)                   = 576800
 
-Test 044 regional_control PASS
+Test 045 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_restart
-Checking test 045 regional_restart results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_restart
+Checking test 046 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 194.474843
-  0: The maximum resident set size (KB)                   = 578788
+  0: The total amount of wall time                        = 174.593698
+  0: The maximum resident set size (KB)                   = 578676
 
-Test 045 regional_restart PASS
+Test 046 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_control_qr
-Checking test 046 regional_control_qr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_control_qr
+Checking test 047 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2146,29 +2164,29 @@ Checking test 046 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 352.734869
-  0: The maximum resident set size (KB)                   = 578776
+  0: The total amount of wall time                        = 327.327069
+  0: The maximum resident set size (KB)                   = 576980
 
-Test 046 regional_control_qr PASS
+Test 047 regional_control_qr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_restart_qr
-Checking test 047 regional_restart_qr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_restart_qr
+Checking test 048 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 194.138563
-  0: The maximum resident set size (KB)                   = 579088
+  0: The total amount of wall time                        = 174.624520
+  0: The maximum resident set size (KB)                   = 578620
 
-Test 047 regional_restart_qr PASS
+Test 048 regional_restart_qr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_decomp
-Checking test 048 regional_decomp results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_decomp
+Checking test 049 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2178,15 +2196,15 @@ Checking test 048 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 356.501926
-  0: The maximum resident set size (KB)                   = 580788
+  0: The total amount of wall time                        = 349.037832
+  0: The maximum resident set size (KB)                   = 580888
 
-Test 048 regional_decomp PASS
+Test 049 regional_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_2threads
-Checking test 049 regional_2threads results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_2threads
+Checking test 050 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2196,62 +2214,44 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 218.054766
-  0: The maximum resident set size (KB)                   = 586260
+  0: The total amount of wall time                        = 195.950026
+  0: The maximum resident set size (KB)                   = 586496
 
-Test 049 regional_2threads PASS
+Test 050 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_noquilt
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_noquilt
-Checking test 050 regional_noquilt results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_noquilt
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_noquilt
+Checking test 051 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 369.810544
-  0: The maximum resident set size (KB)                   = 573172
+  0: The total amount of wall time                        = 352.370746
+  0: The maximum resident set size (KB)                   = 572700
 
-Test 050 regional_noquilt PASS
+Test 051 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_netcdf_parallel
-Checking test 051 regional_netcdf_parallel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_netcdf_parallel
+Checking test 052 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 337.258126
-  0: The maximum resident set size (KB)                   = 578320
+  0: The total amount of wall time                        = 343.867159
+  0: The maximum resident set size (KB)                   = 578988
 
-Test 051 regional_netcdf_parallel PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_2dwrtdecomp
-Checking test 052 regional_2dwrtdecomp results ....
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF06 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF06 .........OK
-
-  0: The total amount of wall time                        = 343.319845
-  0: The maximum resident set size (KB)                   = 578644
-
-Test 052 regional_2dwrtdecomp PASS
+Test 052 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/fv3_regional_wofs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_wofs
-Checking test 053 regional_wofs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_2dwrtdecomp
+Checking test 053 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2261,15 +2261,33 @@ Checking test 053 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 430.611504
-  0: The maximum resident set size (KB)                   = 264000
+  0: The total amount of wall time                        = 327.875783
+  0: The maximum resident set size (KB)                   = 576832
 
-Test 053 regional_wofs PASS
+Test 053 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_control
-Checking test 054 rap_control results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/fv3_regional_wofs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_wofs
+Checking test 054 regional_wofs results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF06 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF06 .........OK
+
+  0: The total amount of wall time                        = 413.475756
+  0: The maximum resident set size (KB)                   = 264084
+
+Test 054 regional_wofs PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_control
+Checking test 055 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2315,15 +2333,15 @@ Checking test 054 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 482.144041
-  0: The maximum resident set size (KB)                   = 807820
+  0: The total amount of wall time                        = 474.406209
+  0: The maximum resident set size (KB)                   = 806844
 
-Test 054 rap_control PASS
+Test 055 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_spp_sppt_shum_skeb
-Checking test 055 regional_spp_sppt_shum_skeb results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_spp_sppt_shum_skeb
+Checking test 056 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2333,15 +2351,15 @@ Checking test 055 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 281.731456
-  0: The maximum resident set size (KB)                   = 908032
+  0: The total amount of wall time                        = 259.738400
+  0: The maximum resident set size (KB)                   = 903664
 
-Test 055 regional_spp_sppt_shum_skeb PASS
+Test 056 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_decomp
-Checking test 056 rap_decomp results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_decomp
+Checking test 057 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2387,15 +2405,15 @@ Checking test 056 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 499.176020
-  0: The maximum resident set size (KB)                   = 806368
+  0: The total amount of wall time                        = 491.209027
+  0: The maximum resident set size (KB)                   = 806768
 
-Test 056 rap_decomp PASS
+Test 057 rap_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_2threads
-Checking test 057 rap_2threads results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_2threads
+Checking test 058 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2441,15 +2459,15 @@ Checking test 057 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.572062
-  0: The maximum resident set size (KB)                   = 878372
+  0: The total amount of wall time                        = 452.900387
+  0: The maximum resident set size (KB)                   = 875668
 
-Test 057 rap_2threads PASS
+Test 058 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_restart
-Checking test 058 rap_restart results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_restart
+Checking test 059 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -2487,15 +2505,15 @@ Checking test 058 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 243.646391
-  0: The maximum resident set size (KB)                   = 553168
+  0: The total amount of wall time                        = 236.860508
+  0: The maximum resident set size (KB)                   = 553500
 
-Test 058 rap_restart PASS
+Test 059 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_sfcdiff
-Checking test 059 rap_sfcdiff results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_sfcdiff
+Checking test 060 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2541,15 +2559,15 @@ Checking test 059 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 483.549268
-  0: The maximum resident set size (KB)                   = 807900
+  0: The total amount of wall time                        = 473.380538
+  0: The maximum resident set size (KB)                   = 806672
 
-Test 059 rap_sfcdiff PASS
+Test 060 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_sfcdiff_decomp
-Checking test 060 rap_sfcdiff_decomp results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_sfcdiff_decomp
+Checking test 061 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2595,15 +2613,15 @@ Checking test 060 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 510.389983
-  0: The maximum resident set size (KB)                   = 807364
+  0: The total amount of wall time                        = 493.452906
+  0: The maximum resident set size (KB)                   = 806784
 
-Test 060 rap_sfcdiff_decomp PASS
+Test 061 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_sfcdiff_restart
-Checking test 061 rap_sfcdiff_restart results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_sfcdiff_restart
+Checking test 062 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -2641,15 +2659,191 @@ Checking test 061 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 364.698615
-  0: The maximum resident set size (KB)                   = 552368
+  0: The total amount of wall time                        = 347.769028
+  0: The maximum resident set size (KB)                   = 552896
 
-Test 061 rap_sfcdiff_restart PASS
+Test 062 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control
-Checking test 062 hrrr_control results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control
+Checking test 063 hrrr_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 434.760229
+  0: The maximum resident set size (KB)                   = 804736
+
+Test 063 hrrr_control PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_decomp
+Checking test 064 hrrr_control_decomp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 455.342368
+  0: The maximum resident set size (KB)                   = 805576
+
+Test 064 hrrr_control_decomp PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_2threads
+Checking test 065 hrrr_control_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 409.133720
+  0: The maximum resident set size (KB)                   = 877680
+
+Test 065 hrrr_control_2threads PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_restart
+Checking test 066 hrrr_control_restart results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 322.817269
+  0: The maximum resident set size (KB)                   = 550660
+
+Test 066 hrrr_control_restart PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_v1beta
+Checking test 067 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2695,223 +2889,15 @@ Checking test 062 hrrr_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 467.396448
-  0: The maximum resident set size (KB)                   = 805796
+  0: The total amount of wall time                        = 463.394181
+  0: The maximum resident set size (KB)                   = 805284
 
-Test 062 hrrr_control PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_decomp
-Checking test 063 hrrr_control_decomp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 485.806783
-  0: The maximum resident set size (KB)                   = 805200
-
-Test 063 hrrr_control_decomp PASS
+Test 067 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_2threads
-Checking test 064 hrrr_control_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 441.992143
-  0: The maximum resident set size (KB)                   = 872952
-
-Test 064 hrrr_control_2threads PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_restart
-Checking test 065 hrrr_control_restart results ....
- Comparing sfcf012.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 345.826280
-  0: The maximum resident set size (KB)                   = 547760
-
-Test 065 hrrr_control_restart PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_v1beta
-Checking test 066 rrfs_v1beta results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 482.543272
-  0: The maximum resident set size (KB)                   = 804876
-
-Test 066 rrfs_v1beta PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_v1nssl
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_v1nssl
-Checking test 067 rrfs_v1nssl results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_v1nssl
+Checking test 068 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2925,15 +2911,15 @@ Checking test 067 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 587.783735
-  0: The maximum resident set size (KB)                   = 493312
+  0: The total amount of wall time                        = 568.085090
+  0: The maximum resident set size (KB)                   = 493396
 
-Test 067 rrfs_v1nssl PASS
+Test 068 rrfs_v1nssl PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_v1nssl_nohailnoccn
-Checking test 068 rrfs_v1nssl_nohailnoccn results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_v1nssl_nohailnoccn
+Checking test 069 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2947,15 +2933,15 @@ Checking test 068 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 562.901826
-  0: The maximum resident set size (KB)                   = 486016
+  0: The total amount of wall time                        = 555.864460
+  0: The maximum resident set size (KB)                   = 486940
 
-Test 068 rrfs_v1nssl_nohailnoccn PASS
+Test 069 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_smoke_conus13km_hrrr_warm
-Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_smoke_conus13km_hrrr_warm
+Checking test 070 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2963,15 +2949,15 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 177.631407
-  0: The maximum resident set size (KB)                   = 658140
+  0: The total amount of wall time                        = 153.549074
+  0: The maximum resident set size (KB)                   = 632012
 
-Test 069 rrfs_smoke_conus13km_hrrr_warm PASS
+Test 070 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_smoke_conus13km_hrrr_warm_2threads
-Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_smoke_conus13km_hrrr_warm_2threads
+Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2979,15 +2965,15 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 126.862886
-  0: The maximum resident set size (KB)                   = 670828
+  0: The total amount of wall time                        = 94.719095
+  0: The maximum resident set size (KB)                   = 645540
 
-Test 070 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
+Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_conus13km_hrrr_warm
-Checking test 071 rrfs_conus13km_hrrr_warm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_conus13km_hrrr_warm
+Checking test 072 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2995,15 +2981,15 @@ Checking test 071 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 167.515710
-  0: The maximum resident set size (KB)                   = 634712
+  0: The total amount of wall time                        = 138.545136
+  0: The maximum resident set size (KB)                   = 649972
 
-Test 071 rrfs_conus13km_hrrr_warm PASS
+Test 072 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_smoke_conus13km_radar_tten_warm
-Checking test 072 rrfs_smoke_conus13km_radar_tten_warm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_smoke_conus13km_radar_tten_warm
+Checking test 073 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3011,27 +2997,27 @@ Checking test 072 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 185.825674
-  0: The maximum resident set size (KB)                   = 661600
+  0: The total amount of wall time                        = 154.009465
+  0: The maximum resident set size (KB)                   = 635444
 
-Test 072 rrfs_smoke_conus13km_radar_tten_warm PASS
+Test 073 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_conus13km_hrrr_warm_restart_mismatch
-Checking test 073 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_conus13km_hrrr_warm_restart_mismatch
+Checking test 074 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 86.631848
-  0: The maximum resident set size (KB)                   = 615068
+  0: The total amount of wall time                        = 74.414404
+  0: The maximum resident set size (KB)                   = 621836
 
-Test 073 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
+Test 074 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_csawmgt
-Checking test 074 control_csawmgt results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_csawmgt
+Checking test 075 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3041,15 +3027,15 @@ Checking test 074 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 392.026117
-  0: The maximum resident set size (KB)                   = 502580
+  0: The total amount of wall time                        = 373.900827
+  0: The maximum resident set size (KB)                   = 503188
 
-Test 074 control_csawmgt PASS
+Test 075 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_ras
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_ras
-Checking test 075 control_ras results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_ras
+Checking test 076 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3059,27 +3045,27 @@ Checking test 075 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 203.071382
-  0: The maximum resident set size (KB)                   = 472788
+  0: The total amount of wall time                        = 198.229352
+  0: The maximum resident set size (KB)                   = 473472
 
-Test 075 control_ras PASS
+Test 076 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_wam
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_wam
-Checking test 076 control_wam results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_wam
+Checking test 077 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 128.061276
-  0: The maximum resident set size (KB)                   = 188880
+  0: The total amount of wall time                        = 123.202512
+  0: The maximum resident set size (KB)                   = 189564
 
-Test 076 control_wam PASS
+Test 077 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8_faster
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_p8_faster
-Checking test 077 control_p8_faster results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_p8_faster
+Checking test 078 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3125,15 +3111,15 @@ Checking test 077 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 183.410881
-  0: The maximum resident set size (KB)                   = 1380108
+  0: The total amount of wall time                        = 165.354108
+  0: The maximum resident set size (KB)                   = 1380260
 
-Test 077 control_p8_faster PASS
+Test 078 control_p8_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_control_faster
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_control_faster
-Checking test 078 regional_control_faster results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_control_faster
+Checking test 079 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3143,57 +3129,57 @@ Checking test 078 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 315.715892
-  0: The maximum resident set size (KB)                   = 578428
+  0: The total amount of wall time                        = 307.335309
+  0: The maximum resident set size (KB)                   = 576848
 
-Test 078 regional_control_faster PASS
+Test 079 regional_control_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_smoke_conus13km_hrrr_warm_debug
-Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_smoke_conus13km_hrrr_warm_debug
+Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 900.257815
-  0: The maximum resident set size (KB)                   = 688176
+  0: The total amount of wall time                        = 881.785552
+  0: The maximum resident set size (KB)                   = 686620
 
-Test 079 rrfs_smoke_conus13km_hrrr_warm_debug PASS
+Test 080 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
-Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 525.871133
-  0: The maximum resident set size (KB)                   = 703548
+  0: The total amount of wall time                        = 505.724787
+  0: The maximum resident set size (KB)                   = 671228
 
-Test 080 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
+Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_conus13km_hrrr_warm_debug
-Checking test 081 rrfs_conus13km_hrrr_warm_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_conus13km_hrrr_warm_debug
+Checking test 082 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 809.198304
-  0: The maximum resident set size (KB)                   = 665148
+  0: The total amount of wall time                        = 784.896036
+  0: The maximum resident set size (KB)                   = 680836
 
-Test 081 rrfs_conus13km_hrrr_warm_debug PASS
+Test 082 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_CubedSphereGrid_debug
-Checking test 082 control_CubedSphereGrid_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_CubedSphereGrid_debug
+Checking test 083 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3219,335 +3205,349 @@ Checking test 082 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.189057
-  0: The maximum resident set size (KB)                   = 601904
+  0: The total amount of wall time                        = 151.982058
+  0: The maximum resident set size (KB)                   = 602348
 
-Test 082 control_CubedSphereGrid_debug PASS
+Test 083 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_wrtGauss_netcdf_parallel_debug
-Checking test 083 control_wrtGauss_netcdf_parallel_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_wrtGauss_netcdf_parallel_debug
+Checking test 084 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.913482
-  0: The maximum resident set size (KB)                   = 599556
+  0: The total amount of wall time                        = 201.050269
+  0: The maximum resident set size (KB)                   = 602504
 
-Test 083 control_wrtGauss_netcdf_parallel_debug PASS
+Test 084 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_stochy_debug
-Checking test 084 control_stochy_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_stochy_debug
+Checking test 085 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 177.252154
-  0: The maximum resident set size (KB)                   = 604560
+  0: The total amount of wall time                        = 172.677242
+  0: The maximum resident set size (KB)                   = 607332
 
-Test 084 control_stochy_debug PASS
+Test 085 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_lndp_debug
-Checking test 085 control_lndp_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_lndp_debug
+Checking test 086 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.490785
-  0: The maximum resident set size (KB)                   = 603940
+  0: The total amount of wall time                        = 155.203755
+  0: The maximum resident set size (KB)                   = 605288
 
-Test 085 control_lndp_debug PASS
+Test 086 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_csawmg_debug
-Checking test 086 control_csawmg_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_csawmg_debug
+Checking test 087 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 257.884852
-  0: The maximum resident set size (KB)                   = 641344
+  0: The total amount of wall time                        = 245.016484
+  0: The maximum resident set size (KB)                   = 641888
 
-Test 086 control_csawmg_debug PASS
+Test 087 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_csawmgt_debug
-Checking test 087 control_csawmgt_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_csawmgt_debug
+Checking test 088 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 252.845458
-  0: The maximum resident set size (KB)                   = 640976
+  0: The total amount of wall time                        = 241.796528
+  0: The maximum resident set size (KB)                   = 641548
 
-Test 087 control_csawmgt_debug PASS
+Test 088 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_ras_debug
-Checking test 088 control_ras_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_ras_debug
+Checking test 089 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.237697
-  0: The maximum resident set size (KB)                   = 613280
+  0: The total amount of wall time                        = 156.696209
+  0: The maximum resident set size (KB)                   = 613784
 
-Test 088 control_ras_debug PASS
+Test 089 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_diag_debug
-Checking test 089 control_diag_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_diag_debug
+Checking test 090 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.275507
-  0: The maximum resident set size (KB)                   = 659044
+  0: The total amount of wall time                        = 160.512958
+  0: The maximum resident set size (KB)                   = 658584
 
-Test 089 control_diag_debug PASS
+Test 090 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_debug_p8
-Checking test 090 control_debug_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_debug_p8
+Checking test 091 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.633583
-  0: The maximum resident set size (KB)                   = 1382788
+  0: The total amount of wall time                        = 173.253402
+  0: The maximum resident set size (KB)                   = 1383456
 
-Test 090 control_debug_p8 PASS
+Test 091 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_debug
-Checking test 091 regional_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_debug
+Checking test 092 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1052.429750
-  0: The maximum resident set size (KB)                   = 605844
+  0: The total amount of wall time                        = 1034.754983
+  0: The maximum resident set size (KB)                   = 606248
 
-Test 091 regional_debug PASS
+Test 092 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_control_debug
-Checking test 092 rap_control_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_control_debug
+Checking test 093 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.246339
-  0: The maximum resident set size (KB)                   = 970512
+  0: The total amount of wall time                        = 285.269760
+  0: The maximum resident set size (KB)                   = 970884
 
-Test 092 rap_control_debug PASS
+Test 093 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_debug
-Checking test 093 hrrr_control_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_debug
+Checking test 094 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.678901
-  0: The maximum resident set size (KB)                   = 968864
+  0: The total amount of wall time                        = 277.040584
+  0: The maximum resident set size (KB)                   = 969288
 
-Test 093 hrrr_control_debug PASS
+Test 094 hrrr_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_unified_drag_suite_debug
-Checking test 094 rap_unified_drag_suite_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_unified_drag_suite_debug
+Checking test 095 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.667941
-  0: The maximum resident set size (KB)                   = 970492
+  0: The total amount of wall time                        = 283.558740
+  0: The maximum resident set size (KB)                   = 970936
 
-Test 094 rap_unified_drag_suite_debug PASS
+Test 095 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_diag_debug
-Checking test 095 rap_diag_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_diag_debug
+Checking test 096 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 304.782781
-  0: The maximum resident set size (KB)                   = 1054084
+  0: The total amount of wall time                        = 297.675051
+  0: The maximum resident set size (KB)                   = 1054896
 
-Test 095 rap_diag_debug PASS
+Test 096 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_cires_ugwp_debug
-Checking test 096 rap_cires_ugwp_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_cires_ugwp_debug
+Checking test 097 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 305.788055
-  0: The maximum resident set size (KB)                   = 969784
+  0: The total amount of wall time                        = 289.405049
+  0: The maximum resident set size (KB)                   = 970396
 
-Test 096 rap_cires_ugwp_debug PASS
+Test 097 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_unified_ugwp_debug
-Checking test 097 rap_unified_ugwp_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_unified_ugwp_debug
+Checking test 098 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 297.520373
-  0: The maximum resident set size (KB)                   = 971756
+  0: The total amount of wall time                        = 290.178975
+  0: The maximum resident set size (KB)                   = 972360
 
-Test 097 rap_unified_ugwp_debug PASS
+Test 098 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_lndp_debug
-Checking test 098 rap_lndp_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_lndp_debug
+Checking test 099 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 297.417669
-  0: The maximum resident set size (KB)                   = 971292
+  0: The total amount of wall time                        = 285.794262
+  0: The maximum resident set size (KB)                   = 971688
 
-Test 098 rap_lndp_debug PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_flake_debug
-Checking test 099 rap_flake_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 294.676546
-  0: The maximum resident set size (KB)                   = 970532
-
-Test 099 rap_flake_debug PASS
+Test 099 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_progcld_thompson_debug
 Checking test 100 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.371042
-  0: The maximum resident set size (KB)                   = 970528
+  0: The total amount of wall time                        = 284.718837
+  0: The maximum resident set size (KB)                   = 970976
 
 Test 100 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_noah_debug
 Checking test 101 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.503960
-  0: The maximum resident set size (KB)                   = 969204
+  0: The total amount of wall time                        = 277.429345
+  0: The maximum resident set size (KB)                   = 969516
 
 Test 101 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_sfcdiff_debug
 Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.583836
-  0: The maximum resident set size (KB)                   = 970436
+  0: The total amount of wall time                        = 284.517674
+  0: The maximum resident set size (KB)                   = 970792
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 477.969334
-  0: The maximum resident set size (KB)                   = 968700
+  0: The total amount of wall time                        = 468.919963
+  0: The maximum resident set size (KB)                   = 969208
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rrfs_v1beta_debug
 Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.386447
-  0: The maximum resident set size (KB)                   = 966392
+  0: The total amount of wall time                        = 280.224406
+  0: The maximum resident set size (KB)                   = 966872
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_wam_debug
-Checking test 105 control_wam_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_clm_lake_debug
+Checking test 105 rap_clm_lake_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 356.859313
+  0: The maximum resident set size (KB)                   = 973844
+
+Test 105 rap_clm_lake_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_flake_debug
+Checking test 106 rap_flake_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 282.882222
+  0: The maximum resident set size (KB)                   = 970964
+
+Test 106 rap_flake_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_wam_debug
+Checking test 107 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 290.888582
-  0: The maximum resident set size (KB)                   = 217672
+  0: The total amount of wall time                        = 287.114621
+  0: The maximum resident set size (KB)                   = 218004
 
-Test 105 control_wam_debug PASS
+Test 107 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_spp_sppt_shum_skeb_dyn32_phy32
-Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_spp_sppt_shum_skeb_dyn32_phy32
+Checking test 108 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3557,15 +3557,15 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 260.094764
-  0: The maximum resident set size (KB)                   = 802984
+  0: The total amount of wall time                        = 248.518242
+  0: The maximum resident set size (KB)                   = 808112
 
-Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
+Test 108 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_control_dyn32_phy32
-Checking test 107 rap_control_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_control_dyn32_phy32
+Checking test 109 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3611,15 +3611,15 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 401.772542
-  0: The maximum resident set size (KB)                   = 691480
+  0: The total amount of wall time                        = 392.623352
+  0: The maximum resident set size (KB)                   = 691668
 
-Test 107 rap_control_dyn32_phy32 PASS
+Test 109 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_dyn32_phy32
-Checking test 108 hrrr_control_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_dyn32_phy32
+Checking test 110 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3632,48 +3632,48 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.180000.coupler.res .........OK
- Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.984121
-  0: The maximum resident set size (KB)                   = 689892
+  0: The total amount of wall time                        = 195.936218
+  0: The maximum resident set size (KB)                   = 690968
 
-Test 108 hrrr_control_dyn32_phy32 PASS
+Test 110 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_2threads_dyn32_phy32
-Checking test 109 rap_2threads_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_2threads_dyn32_phy32
+Checking test 111 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3719,15 +3719,15 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 383.942805
-  0: The maximum resident set size (KB)                   = 743352
+  0: The total amount of wall time                        = 378.093898
+  0: The maximum resident set size (KB)                   = 744232
 
-Test 109 rap_2threads_dyn32_phy32 PASS
+Test 111 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_2threads_dyn32_phy32
-Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_2threads_dyn32_phy32
+Checking test 112 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3740,48 +3740,48 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.180000.coupler.res .........OK
- Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.552813
-  0: The maximum resident set size (KB)                   = 740800
+  0: The total amount of wall time                        = 180.479848
+  0: The maximum resident set size (KB)                   = 739032
 
-Test 110 hrrr_control_2threads_dyn32_phy32 PASS
+Test 112 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_decomp_dyn32_phy32
-Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_decomp_dyn32_phy32
+Checking test 113 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3794,48 +3794,48 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.180000.coupler.res .........OK
- Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 221.362664
-  0: The maximum resident set size (KB)                   = 688564
+  0: The total amount of wall time                        = 208.501604
+  0: The maximum resident set size (KB)                   = 691516
 
-Test 111 hrrr_control_decomp_dyn32_phy32 PASS
+Test 113 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_restart_dyn32_phy32
-Checking test 112 rap_restart_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_restart_dyn32_phy32
+Checking test 114 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3873,61 +3873,29 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 309.093015
-  0: The maximum resident set size (KB)                   = 526372
+  0: The total amount of wall time                        = 289.502134
+  0: The maximum resident set size (KB)                   = 526936
 
-Test 112 rap_restart_dyn32_phy32 PASS
+Test 114 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_restart_dyn32_phy32
-Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_restart_dyn32_phy32
+Checking test 115 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.180000.coupler.res .........OK
- Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 115.675662
-  0: The maximum resident set size (KB)                   = 518620
+  0: The total amount of wall time                        = 99.897136
+  0: The maximum resident set size (KB)                   = 518464
 
-Test 113 hrrr_control_restart_dyn32_phy32 PASS
+Test 115 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_dyn64_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_control_dyn64_phy32
-Checking test 114 rap_control_dyn64_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_control_dyn64_phy32
+Checking test 116 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3973,82 +3941,82 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 267.694316
-  0: The maximum resident set size (KB)                   = 709544
+  0: The total amount of wall time                        = 259.543671
+  0: The maximum resident set size (KB)                   = 714324
 
-Test 114 rap_control_dyn64_phy32 PASS
+Test 116 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_control_debug_dyn32_phy32
-Checking test 115 rap_control_debug_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_control_debug_dyn32_phy32
+Checking test 117 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.587501
-  0: The maximum resident set size (KB)                   = 855412
+  0: The total amount of wall time                        = 279.799361
+  0: The maximum resident set size (KB)                   = 855992
 
-Test 115 rap_control_debug_dyn32_phy32 PASS
+Test 117 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hrrr_control_debug_dyn32_phy32
-Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hrrr_control_debug_dyn32_phy32
+Checking test 118 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.086337
-  0: The maximum resident set size (KB)                   = 852924
+  0: The total amount of wall time                        = 273.633719
+  0: The maximum resident set size (KB)                   = 854380
 
-Test 116 hrrr_control_debug_dyn32_phy32 PASS
+Test 118 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/rap_control_dyn64_phy32_debug
-Checking test 117 rap_control_dyn64_phy32_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/rap_control_dyn64_phy32_debug
+Checking test 119 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.080028
-  0: The maximum resident set size (KB)                   = 876388
+  0: The total amount of wall time                        = 287.412254
+  0: The maximum resident set size (KB)                   = 876912
 
-Test 117 rap_control_dyn64_phy32_debug PASS
+Test 119 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_atm
-Checking test 118 hafs_regional_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_atm
+Checking test 120 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 272.045454
-  0: The maximum resident set size (KB)                   = 688056
+  0: The total amount of wall time                        = 256.005150
+  0: The maximum resident set size (KB)                   = 687992
 
-Test 118 hafs_regional_atm PASS
+Test 120 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_atm_thompson_gfdlsf
-Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_atm_thompson_gfdlsf
+Checking test 121 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 309.115577
-  0: The maximum resident set size (KB)                   = 1039940
+  0: The total amount of wall time                        = 293.876406
+  0: The maximum resident set size (KB)                   = 1039560
 
-Test 119 hafs_regional_atm_thompson_gfdlsf PASS
+Test 121 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_atm_ocn
-Checking test 120 hafs_regional_atm_ocn results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_atm_ocn
+Checking test 122 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4056,15 +4024,15 @@ Checking test 120 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 454.145969
-  0: The maximum resident set size (KB)                   = 715512
+  0: The total amount of wall time                        = 427.600281
+  0: The maximum resident set size (KB)                   = 718120
 
-Test 120 hafs_regional_atm_ocn PASS
+Test 122 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_atm_wav
-Checking test 121 hafs_regional_atm_wav results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_atm_wav
+Checking test 123 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4072,15 +4040,15 @@ Checking test 121 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 938.320059
-  0: The maximum resident set size (KB)                   = 749836
+  0: The total amount of wall time                        = 933.765348
+  0: The maximum resident set size (KB)                   = 752196
 
-Test 121 hafs_regional_atm_wav PASS
+Test 123 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_atm_ocn_wav
-Checking test 122 hafs_regional_atm_ocn_wav results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_atm_ocn_wav
+Checking test 124 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4090,29 +4058,29 @@ Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1036.953381
-  0: The maximum resident set size (KB)                   = 767412
+  0: The total amount of wall time                        = 1033.772242
+  0: The maximum resident set size (KB)                   = 767096
 
-Test 122 hafs_regional_atm_ocn_wav PASS
+Test 124 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_1nest_atm
-Checking test 123 hafs_regional_1nest_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_1nest_atm
+Checking test 125 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 378.447651
-  0: The maximum resident set size (KB)                   = 279304
+  0: The total amount of wall time                        = 364.674996
+  0: The maximum resident set size (KB)                   = 279540
 
-Test 123 hafs_regional_1nest_atm PASS
+Test 125 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_telescopic_2nests_atm
-Checking test 124 hafs_regional_telescopic_2nests_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_telescopic_2nests_atm
+Checking test 126 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4120,29 +4088,29 @@ Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 436.480617
-  0: The maximum resident set size (KB)                   = 286812
+  0: The total amount of wall time                        = 417.099044
+  0: The maximum resident set size (KB)                   = 288780
 
-Test 124 hafs_regional_telescopic_2nests_atm PASS
+Test 126 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_global_1nest_atm
-Checking test 125 hafs_global_1nest_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_global_1nest_atm
+Checking test 127 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 170.622801
-  0: The maximum resident set size (KB)                   = 183944
+  0: The total amount of wall time                        = 170.310530
+  0: The maximum resident set size (KB)                   = 184848
 
-Test 125 hafs_global_1nest_atm PASS
+Test 127 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_global_multiple_4nests_atm
-Checking test 126 hafs_global_multiple_4nests_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_global_multiple_4nests_atm
+Checking test 128 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4159,15 +4127,15 @@ Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 493.740556
-  0: The maximum resident set size (KB)                   = 232972
+  0: The total amount of wall time                        = 470.463080
+  0: The maximum resident set size (KB)                   = 232908
 
-Test 126 hafs_global_multiple_4nests_atm PASS
+Test 128 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_specified_moving_1nest_atm
-Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_specified_moving_1nest_atm
+Checking test 129 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4175,29 +4143,29 @@ Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 246.683176
-  0: The maximum resident set size (KB)                   = 294296
+  0: The total amount of wall time                        = 230.480747
+  0: The maximum resident set size (KB)                   = 295400
 
-Test 127 hafs_regional_specified_moving_1nest_atm PASS
+Test 129 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_storm_following_1nest_atm
-Checking test 128 hafs_regional_storm_following_1nest_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_storm_following_1nest_atm
+Checking test 130 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 229.671114
-  0: The maximum resident set size (KB)                   = 294284
+  0: The total amount of wall time                        = 216.434333
+  0: The maximum resident set size (KB)                   = 296560
 
-Test 128 hafs_regional_storm_following_1nest_atm PASS
+Test 130 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_storm_following_1nest_atm_ocn
-Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_storm_following_1nest_atm_ocn
+Checking test 131 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4205,43 +4173,43 @@ Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 271.960186
-  0: The maximum resident set size (KB)                   = 323928
+  0: The total amount of wall time                        = 256.083514
+  0: The maximum resident set size (KB)                   = 324152
 
-Test 129 hafs_regional_storm_following_1nest_atm_ocn PASS
+Test 131 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_global_storm_following_1nest_atm
-Checking test 130 hafs_global_storm_following_1nest_atm results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_global_storm_following_1nest_atm
+Checking test 132 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 70.731540
-  0: The maximum resident set size (KB)                   = 203012
+  0: The total amount of wall time                        = 64.861003
+  0: The maximum resident set size (KB)                   = 203532
 
-Test 130 hafs_global_storm_following_1nest_atm PASS
+Test 132 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_storm_following_1nest_atm_ocn_debug
-Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_storm_following_1nest_atm_ocn_debug
+Checking test 133 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 774.454054
-  0: The maximum resident set size (KB)                   = 347768
+  0: The total amount of wall time                        = 758.554070
+  0: The maximum resident set size (KB)                   = 349648
 
-Test 131 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
+Test 133 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_storm_following_1nest_atm_ocn_wav
-Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_storm_following_1nest_atm_ocn_wav
+Checking test 134 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4251,162 +4219,162 @@ Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 716.211982
-  0: The maximum resident set size (KB)                   = 373860
+  0: The total amount of wall time                        = 695.648339
+  0: The maximum resident set size (KB)                   = 373900
 
-Test 132 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
+Test 134 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_docn
-Checking test 133 hafs_regional_docn results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_docn
+Checking test 135 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 401.542411
-  0: The maximum resident set size (KB)                   = 724724
+  0: The total amount of wall time                        = 381.756807
+  0: The maximum resident set size (KB)                   = 724668
 
-Test 133 hafs_regional_docn PASS
+Test 135 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_docn_oisst
-Checking test 134 hafs_regional_docn_oisst results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_docn_oisst
+Checking test 136 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 403.339708
-  0: The maximum resident set size (KB)                   = 713280
+  0: The total amount of wall time                        = 381.559542
+  0: The maximum resident set size (KB)                   = 711248
 
-Test 134 hafs_regional_docn_oisst PASS
+Test 136 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/hafs_regional_datm_cdeps
-Checking test 135 hafs_regional_datm_cdeps results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/hafs_regional_datm_cdeps
+Checking test 137 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1174.179061
-  0: The maximum resident set size (KB)                   = 809256
+  0: The total amount of wall time                        = 1164.987658
+  0: The maximum resident set size (KB)                   = 809132
 
-Test 135 hafs_regional_datm_cdeps PASS
+Test 137 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_control_cfsr
-Checking test 136 datm_cdeps_control_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_control_cfsr
+Checking test 138 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 169.248102
- 0: The maximum resident set size (KB)                   = 715860
+ 0: The total amount of wall time                        = 165.201128
+ 0: The maximum resident set size (KB)                   = 707424
 
-Test 136 datm_cdeps_control_cfsr PASS
+Test 138 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_restart_cfsr
-Checking test 137 datm_cdeps_restart_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_restart_cfsr
+Checking test 139 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.726801
- 0: The maximum resident set size (KB)                   = 716028
+ 0: The total amount of wall time                        = 94.508998
+ 0: The maximum resident set size (KB)                   = 694784
 
-Test 137 datm_cdeps_restart_cfsr PASS
+Test 139 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_control_gefs
-Checking test 138 datm_cdeps_control_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_control_gefs
+Checking test 140 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 168.063096
- 0: The maximum resident set size (KB)                   = 597904
+ 0: The total amount of wall time                        = 159.348899
+ 0: The maximum resident set size (KB)                   = 591260
 
-Test 138 datm_cdeps_control_gefs PASS
+Test 140 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_iau_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_iau_gefs
-Checking test 139 datm_cdeps_iau_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_iau_gefs
+Checking test 141 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.835880
- 0: The maximum resident set size (KB)                   = 598116
+ 0: The total amount of wall time                        = 160.059556
+ 0: The maximum resident set size (KB)                   = 598176
 
-Test 139 datm_cdeps_iau_gefs PASS
+Test 141 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_stochy_gefs
-Checking test 140 datm_cdeps_stochy_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_stochy_gefs
+Checking test 142 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 172.525836
- 0: The maximum resident set size (KB)                   = 599988
+ 0: The total amount of wall time                        = 159.854692
+ 0: The maximum resident set size (KB)                   = 587492
 
-Test 140 datm_cdeps_stochy_gefs PASS
+Test 142 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_ciceC_cfsr
-Checking test 141 datm_cdeps_ciceC_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_ciceC_cfsr
+Checking test 143 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 170.027301
- 0: The maximum resident set size (KB)                   = 715924
+ 0: The total amount of wall time                        = 162.008463
+ 0: The maximum resident set size (KB)                   = 707532
 
-Test 141 datm_cdeps_ciceC_cfsr PASS
+Test 143 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_bulk_cfsr
-Checking test 142 datm_cdeps_bulk_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_bulk_cfsr
+Checking test 144 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 165.533744
- 0: The maximum resident set size (KB)                   = 715944
+ 0: The total amount of wall time                        = 162.859855
+ 0: The maximum resident set size (KB)                   = 707576
 
-Test 142 datm_cdeps_bulk_cfsr PASS
+Test 144 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_bulk_gefs
-Checking test 143 datm_cdeps_bulk_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_bulk_gefs
+Checking test 145 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.838474
- 0: The maximum resident set size (KB)                   = 602136
+ 0: The total amount of wall time                        = 156.171998
+ 0: The maximum resident set size (KB)                   = 587260
 
-Test 143 datm_cdeps_bulk_gefs PASS
+Test 145 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_mx025_cfsr
-Checking test 144 datm_cdeps_mx025_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_mx025_cfsr
+Checking test 146 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4414,15 +4382,15 @@ Checking test 144 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 438.805417
-  0: The maximum resident set size (KB)                   = 494400
+  0: The total amount of wall time                        = 393.048226
+  0: The maximum resident set size (KB)                   = 496976
 
-Test 144 datm_cdeps_mx025_cfsr PASS
+Test 146 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_mx025_gefs
-Checking test 145 datm_cdeps_mx025_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_mx025_gefs
+Checking test 147 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4430,78 +4398,78 @@ Checking test 145 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 461.449192
-  0: The maximum resident set size (KB)                   = 476416
+  0: The total amount of wall time                        = 390.561867
+  0: The maximum resident set size (KB)                   = 476700
 
-Test 145 datm_cdeps_mx025_gefs PASS
+Test 147 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_multiple_files_cfsr
-Checking test 146 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_multiple_files_cfsr
+Checking test 148 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 167.688870
- 0: The maximum resident set size (KB)                   = 715728
+ 0: The total amount of wall time                        = 163.679194
+ 0: The maximum resident set size (KB)                   = 707628
 
-Test 146 datm_cdeps_multiple_files_cfsr PASS
+Test 148 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_3072x1536_cfsr
-Checking test 147 datm_cdeps_3072x1536_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_3072x1536_cfsr
+Checking test 149 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 253.573878
- 0: The maximum resident set size (KB)                   = 1947992
+ 0: The total amount of wall time                        = 252.714361
+ 0: The maximum resident set size (KB)                   = 1948532
 
-Test 147 datm_cdeps_3072x1536_cfsr PASS
+Test 149 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_gfs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_gfs
-Checking test 148 datm_cdeps_gfs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_gfs
+Checking test 150 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 256.506773
- 0: The maximum resident set size (KB)                   = 1947100
+ 0: The total amount of wall time                        = 250.703212
+ 0: The maximum resident set size (KB)                   = 1948368
 
-Test 148 datm_cdeps_gfs PASS
+Test 150 datm_cdeps_gfs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_debug_cfsr
-Checking test 149 datm_cdeps_debug_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_debug_cfsr
+Checking test 151 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 370.276170
- 0: The maximum resident set size (KB)                   = 693024
+ 0: The total amount of wall time                        = 368.547337
+ 0: The maximum resident set size (KB)                   = 693680
 
-Test 149 datm_cdeps_debug_cfsr PASS
+Test 151 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_control_cfsr_faster
-Checking test 150 datm_cdeps_control_cfsr_faster results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_control_cfsr_faster
+Checking test 152 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 165.247244
- 0: The maximum resident set size (KB)                   = 715692
+ 0: The total amount of wall time                        = 161.142346
+ 0: The maximum resident set size (KB)                   = 707516
 
-Test 150 datm_cdeps_control_cfsr_faster PASS
+Test 152 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_lnd_gswp3
-Checking test 151 datm_cdeps_lnd_gswp3 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_lnd_gswp3
+Checking test 153 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4509,15 +4477,15 @@ Checking test 151 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 14.754692
-  0: The maximum resident set size (KB)                   = 153860
+  0: The total amount of wall time                        = 9.120041
+  0: The maximum resident set size (KB)                   = 154304
 
-Test 151 datm_cdeps_lnd_gswp3 PASS
+Test 153 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/datm_cdeps_lnd_gswp3_rst
-Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/datm_cdeps_lnd_gswp3_rst
+Checking test 154 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4525,15 +4493,15 @@ Checking test 152 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 26.352968
-  0: The maximum resident set size (KB)                   = 153920
+  0: The total amount of wall time                        = 16.129212
+  0: The maximum resident set size (KB)                   = 154196
 
-Test 152 datm_cdeps_lnd_gswp3_rst PASS
+Test 154 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_p8_atmlnd_sbs
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_p8_atmlnd_sbs
-Checking test 153 control_p8_atmlnd_sbs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_p8_atmlnd_sbs
+Checking test 155 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4617,15 +4585,15 @@ Checking test 153 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 240.033312
-  0: The maximum resident set size (KB)                   = 1413364
+  0: The total amount of wall time                        = 218.978033
+  0: The maximum resident set size (KB)                   = 1413856
 
-Test 153 control_p8_atmlnd_sbs PASS
+Test 155 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/atmwav_control_noaero_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/atmwav_control_noaero_p8
-Checking test 154 atmwav_control_noaero_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmwav_control_noaero_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/atmwav_control_noaero_p8
+Checking test 156 atmwav_control_noaero_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4667,15 +4635,15 @@ Checking test 154 atmwav_control_noaero_p8 results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 106.754442
-  0: The maximum resident set size (KB)                   = 1392024
+  0: The total amount of wall time                        = 95.712707
+  0: The maximum resident set size (KB)                   = 1392344
 
-Test 154 atmwav_control_noaero_p8 PASS
+Test 156 atmwav_control_noaero_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/control_atmwav
-Checking test 155 control_atmwav results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/control_atmwav
+Checking test 157 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4718,15 +4686,15 @@ Checking test 155 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 99.714327
-  0: The maximum resident set size (KB)                   = 451636
+  0: The total amount of wall time                        = 91.608572
+  0: The maximum resident set size (KB)                   = 452344
 
-Test 155 control_atmwav PASS
+Test 157 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/atmaero_control_p8
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/atmaero_control_p8
-Checking test 156 atmaero_control_p8 results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/atmaero_control_p8
+Checking test 158 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4769,15 +4737,15 @@ Checking test 156 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 265.135700
-  0: The maximum resident set size (KB)                   = 1448264
+  0: The total amount of wall time                        = 240.444892
+  0: The maximum resident set size (KB)                   = 1461784
 
-Test 156 atmaero_control_p8 PASS
+Test 158 atmaero_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/atmaero_control_p8_rad
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/atmaero_control_p8_rad
-Checking test 157 atmaero_control_p8_rad results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/atmaero_control_p8_rad
+Checking test 159 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4820,15 +4788,15 @@ Checking test 157 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 306.513684
-  0: The maximum resident set size (KB)                   = 1469848
+  0: The total amount of wall time                        = 293.354011
+  0: The maximum resident set size (KB)                   = 1468676
 
-Test 157 atmaero_control_p8_rad PASS
+Test 159 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/atmaero_control_p8_rad_micro
-Checking test 158 atmaero_control_p8_rad_micro results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/atmaero_control_p8_rad_micro
+Checking test 160 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4871,15 +4839,15 @@ Checking test 158 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 307.804775
-  0: The maximum resident set size (KB)                   = 1473604
+  0: The total amount of wall time                        = 300.843240
+  0: The maximum resident set size (KB)                   = 1474320
 
-Test 158 atmaero_control_p8_rad_micro PASS
+Test 160 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_atmaq
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_atmaq
-Checking test 159 regional_atmaq results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_atmaq
+Checking test 161 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4894,15 +4862,15 @@ Checking test 159 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 673.819586
-  0: The maximum resident set size (KB)                   = 971720
+  0: The total amount of wall time                        = 631.476573
+  0: The maximum resident set size (KB)                   = 951572
 
-Test 159 regional_atmaq PASS
+Test 161 regional_atmaq PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230407/INTEL/regional_atmaq_faster
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_9941/regional_atmaq_faster
-Checking test 160 regional_atmaq_faster results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_faster
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_45663/regional_atmaq_faster
+Checking test 162 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4917,12 +4885,10 @@ Checking test 160 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 630.376389
-  0: The maximum resident set size (KB)                   = 962880
+  0: The total amount of wall time                        = 580.118022
+  0: The maximum resident set size (KB)                   = 951308
 
-Test 160 regional_atmaq_faster PASS
+Test 162 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Apr 10 04:15:46 EDT 2023
-Elapsed time: 07h:08m:57s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,21 +1,21 @@
-Sun May  7 00:16:40 UTC 2023
+Thu May 11 13:02:15 UTC 2023
 Start Regression test
 
 Compile 001 elapsed time 196 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 350 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 104 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 422 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 342 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 343 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 002 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 337 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 109 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 417 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 337 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 340 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 009 elapsed time 269 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 235 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 149 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 012 elapsed time 119 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 237 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 146 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 012 elapsed time 111 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_c48
 Checking test 001 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,14 +54,14 @@ Checking test 001 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 691.612942
-0: The maximum resident set size (KB)                   = 703168
+0: The total amount of wall time                        = 684.870166
+0: The maximum resident set size (KB)                   = 706504
 
 Test 001 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_stochy
 Checking test 002 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -72,14 +72,14 @@ Checking test 002 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 649.314735
-  0: The maximum resident set size (KB)                   = 479776
+  0: The total amount of wall time                        = 650.501559
+  0: The maximum resident set size (KB)                   = 482796
 
 Test 002 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_ras
 Checking test 003 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -90,14 +90,14 @@ Checking test 003 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 838.810404
-  0: The maximum resident set size (KB)                   = 490264
+  0: The total amount of wall time                        = 839.568707
+  0: The maximum resident set size (KB)                   = 486016
 
 Test 003 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_p8
 Checking test 004 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 004 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 887.666838
-  0: The maximum resident set size (KB)                   = 1235744
+  0: The total amount of wall time                        = 925.254014
+  0: The maximum resident set size (KB)                   = 1235248
 
 Test 004 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -162,14 +162,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1504.008840
-  0: The maximum resident set size (KB)                   = 526192
+  0: The total amount of wall time                        = 1533.973114
+  0: The maximum resident set size (KB)                   = 524788
 
 Test 005 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_control
 Checking test 006 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -216,14 +216,14 @@ Checking test 006 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1476.299944
-  0: The maximum resident set size (KB)                   = 824916
+  0: The total amount of wall time                        = 1443.536348
+  0: The maximum resident set size (KB)                   = 827660
 
 Test 006 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_decomp
 Checking test 007 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -270,14 +270,14 @@ Checking test 007 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1418.991380
-  0: The maximum resident set size (KB)                   = 827144
+  0: The total amount of wall time                        = 1487.477511
+  0: The maximum resident set size (KB)                   = 824544
 
 Test 007 rap_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_2threads
 Checking test 008 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -324,14 +324,14 @@ Checking test 008 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1324.485925
-  0: The maximum resident set size (KB)                   = 900040
+  0: The total amount of wall time                        = 1305.363501
+  0: The maximum resident set size (KB)                   = 898072
 
 Test 008 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_restart
 Checking test 009 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -370,14 +370,14 @@ Checking test 009 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 738.060577
-  0: The maximum resident set size (KB)                   = 546344
+  0: The total amount of wall time                        = 742.246777
+  0: The maximum resident set size (KB)                   = 548940
 
 Test 009 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_sfcdiff
 Checking test 010 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -424,14 +424,14 @@ Checking test 010 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1470.399186
-  0: The maximum resident set size (KB)                   = 828900
+  0: The total amount of wall time                        = 1468.805795
+  0: The maximum resident set size (KB)                   = 829028
 
 Test 010 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_sfcdiff_decomp
 Checking test 011 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -478,14 +478,14 @@ Checking test 011 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1446.364734
-  0: The maximum resident set size (KB)                   = 829240
+  0: The total amount of wall time                        = 1421.344790
+  0: The maximum resident set size (KB)                   = 825144
 
 Test 011 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_sfcdiff_restart
 Checking test 012 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -524,14 +524,14 @@ Checking test 012 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1088.572288
-  0: The maximum resident set size (KB)                   = 550756
+  0: The total amount of wall time                        = 1100.664144
+  0: The maximum resident set size (KB)                   = 551716
 
 Test 012 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control
 Checking test 013 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -578,14 +578,14 @@ Checking test 013 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1439.758372
-  0: The maximum resident set size (KB)                   = 828828
+  0: The total amount of wall time                        = 1427.420443
+  0: The maximum resident set size (KB)                   = 832692
 
 Test 013 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_2threads
 Checking test 014 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -632,14 +632,14 @@ Checking test 014 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1479.540867
-  0: The maximum resident set size (KB)                   = 889064
+  0: The total amount of wall time                        = 1508.262290
+  0: The maximum resident set size (KB)                   = 889100
 
 Test 014 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_decomp
 Checking test 015 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -686,28 +686,28 @@ Checking test 015 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1403.091147
-  0: The maximum resident set size (KB)                   = 827968
+  0: The total amount of wall time                        = 1430.097926
+  0: The maximum resident set size (KB)                   = 824088
 
 Test 015 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_restart
 Checking test 016 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1051.038281
-  0: The maximum resident set size (KB)                   = 546284
+  0: The total amount of wall time                        = 1053.354498
+  0: The maximum resident set size (KB)                   = 537268
 
 Test 016 hrrr_control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -754,14 +754,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1457.722590
-  0: The maximum resident set size (KB)                   = 822156
+  0: The total amount of wall time                        = 1441.785918
+  0: The maximum resident set size (KB)                   = 826556
 
 Test 017 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_smoke_conus13km_hrrr_warm
 Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -770,14 +770,14 @@ Checking test 018 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 812.446337
-  0: The maximum resident set size (KB)                   = 671196
+  0: The total amount of wall time                        = 804.261854
+  0: The maximum resident set size (KB)                   = 672556
 
 Test 018 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 019 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -786,14 +786,14 @@ Checking test 019 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1043.920675
-  0: The maximum resident set size (KB)                   = 670984
+  0: The total amount of wall time                        = 1079.738511
+  0: The maximum resident set size (KB)                   = 675480
 
 Test 019 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_conus13km_hrrr_warm
 Checking test 020 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -802,14 +802,14 @@ Checking test 020 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 794.784429
-  0: The maximum resident set size (KB)                   = 647152
+  0: The total amount of wall time                        = 750.803918
+  0: The maximum resident set size (KB)                   = 647780
 
 Test 020 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 021 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -818,262 +818,262 @@ Checking test 021 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 803.436551
-  0: The maximum resident set size (KB)                   = 668200
+  0: The total amount of wall time                        = 786.125627
+  0: The maximum resident set size (KB)                   = 673916
 
 Test 021 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 022 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 403.273780
-  0: The maximum resident set size (KB)                   = 635728
+  0: The total amount of wall time                        = 400.955493
+  0: The maximum resident set size (KB)                   = 636532
 
 Test 022 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_diag_debug
 Checking test 023 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 123.723268
-  0: The maximum resident set size (KB)                   = 533840
+  0: The total amount of wall time                        = 122.252638
+  0: The maximum resident set size (KB)                   = 525584
 
 Test 023 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/regional_debug
 Checking test 024 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 677.735811
-  0: The maximum resident set size (KB)                   = 594692
+  0: The total amount of wall time                        = 689.147647
+  0: The maximum resident set size (KB)                   = 593104
 
 Test 024 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_control_debug
 Checking test 025 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.069544
-  0: The maximum resident set size (KB)                   = 848212
+  0: The total amount of wall time                        = 176.714325
+  0: The maximum resident set size (KB)                   = 837712
 
 Test 025 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_debug
 Checking test 026 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.229655
-  0: The maximum resident set size (KB)                   = 836172
+  0: The total amount of wall time                        = 168.041220
+  0: The maximum resident set size (KB)                   = 834380
 
 Test 026 hrrr_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_diag_debug
 Checking test 027 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.267207
-  0: The maximum resident set size (KB)                   = 922652
+  0: The total amount of wall time                        = 209.630572
+  0: The maximum resident set size (KB)                   = 920052
 
 Test 027 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 028 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.617750
-  0: The maximum resident set size (KB)                   = 841744
+  0: The total amount of wall time                        = 275.276247
+  0: The maximum resident set size (KB)                   = 837960
 
 Test 028 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_progcld_thompson_debug
 Checking test 029 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.951614
-  0: The maximum resident set size (KB)                   = 844796
+  0: The total amount of wall time                        = 176.468047
+  0: The maximum resident set size (KB)                   = 841860
 
 Test 029 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_v1beta_debug
 Checking test 030 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.182619
-  0: The maximum resident set size (KB)                   = 847468
+  0: The total amount of wall time                        = 177.687052
+  0: The maximum resident set size (KB)                   = 836316
 
 Test 030 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_ras_debug
 Checking test 031 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 102.098352
-  0: The maximum resident set size (KB)                   = 485576
+  0: The total amount of wall time                        = 102.568733
+  0: The maximum resident set size (KB)                   = 478668
 
 Test 031 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_stochy_debug
 Checking test 032 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 116.409955
-  0: The maximum resident set size (KB)                   = 478296
+  0: The total amount of wall time                        = 121.270170
+  0: The maximum resident set size (KB)                   = 475136
 
 Test 032 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_debug_p8
 Checking test 033 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 116.384765
-  0: The maximum resident set size (KB)                   = 1229456
+  0: The total amount of wall time                        = 121.461728
+  0: The maximum resident set size (KB)                   = 1230264
 
 Test 033 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 034 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 630.934137
-  0: The maximum resident set size (KB)                   = 688544
+  0: The total amount of wall time                        = 621.299332
+  0: The maximum resident set size (KB)                   = 686060
 
 Test 034 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 035 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 738.145071
-  0: The maximum resident set size (KB)                   = 684368
+  0: The total amount of wall time                        = 766.733199
+  0: The maximum resident set size (KB)                   = 686156
 
 Test 035 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rrfs_conus13km_hrrr_warm_debug
 Checking test 036 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 585.768557
-  0: The maximum resident set size (KB)                   = 657144
+  0: The total amount of wall time                        = 560.532712
+  0: The maximum resident set size (KB)                   = 665912
 
 Test 036 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_flake_debug
 Checking test 037 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.401634
-  0: The maximum resident set size (KB)                   = 852008
+  0: The total amount of wall time                        = 176.328228
+  0: The maximum resident set size (KB)                   = 844284
 
 Test 037 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_clm_lake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_clm_lake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_clm_lake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_clm_lake_debug
 Checking test 038 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.179758
-  0: The maximum resident set size (KB)                   = 844748
+  0: The total amount of wall time                        = 193.325971
+  0: The maximum resident set size (KB)                   = 839220
 
 Test 038 rap_clm_lake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/control_wam_debug
 Checking test 039 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 181.538708
-  0: The maximum resident set size (KB)                   = 193268
+  0: The total amount of wall time                        = 185.348364
+  0: The maximum resident set size (KB)                   = 190996
 
 Test 039 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_control_dyn32_phy32
 Checking test 040 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1120,14 +1120,14 @@ Checking test 040 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1483.985617
-  0: The maximum resident set size (KB)                   = 680048
+  0: The total amount of wall time                        = 1454.327586
+  0: The maximum resident set size (KB)                   = 686252
 
 Test 040 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_dyn32_phy32
 Checking test 041 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1174,14 +1174,14 @@ Checking test 041 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 733.203645
-  0: The maximum resident set size (KB)                   = 677748
+  0: The total amount of wall time                        = 735.886324
+  0: The maximum resident set size (KB)                   = 681072
 
 Test 041 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_2threads_dyn32_phy32
 Checking test 042 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1228,14 +1228,14 @@ Checking test 042 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1348.846945
-  0: The maximum resident set size (KB)                   = 733752
+  0: The total amount of wall time                        = 1360.033599
+  0: The maximum resident set size (KB)                   = 735580
 
 Test 042 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_2threads_dyn32_phy32
 Checking test 043 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1282,14 +1282,14 @@ Checking test 043 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 766.729496
-  0: The maximum resident set size (KB)                   = 722460
+  0: The total amount of wall time                        = 749.923967
+  0: The maximum resident set size (KB)                   = 730624
 
 Test 043 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_decomp_dyn32_phy32
 Checking test 044 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1336,14 +1336,14 @@ Checking test 044 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 723.153026
-  0: The maximum resident set size (KB)                   = 687240
+  0: The total amount of wall time                        = 730.501683
+  0: The maximum resident set size (KB)                   = 682316
 
 Test 044 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_restart_dyn32_phy32
 Checking test 045 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1382,28 +1382,28 @@ Checking test 045 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1090.360071
-  0: The maximum resident set size (KB)                   = 511740
+  0: The total amount of wall time                        = 1091.321115
+  0: The maximum resident set size (KB)                   = 518208
 
 Test 045 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_restart_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_restart_dyn32_phy32
 Checking test 046 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 359.523102
-  0: The maximum resident set size (KB)                   = 506808
+  0: The total amount of wall time                        = 371.692801
+  0: The maximum resident set size (KB)                   = 509824
 
 Test 046 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_control_dyn64_phy32
 Checking test 047 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1450,211 +1450,57 @@ Checking test 047 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1071.730803
-  0: The maximum resident set size (KB)                   = 707532
+  0: The total amount of wall time                        = 1090.851499
+  0: The maximum resident set size (KB)                   = 706864
 
 Test 047 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_control_debug_dyn32_phy32
 Checking test 048 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.504776
-  0: The maximum resident set size (KB)                   = 698472
+  0: The total amount of wall time                        = 173.474190
+  0: The maximum resident set size (KB)                   = 694936
 
 Test 048 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/hrrr_control_debug_dyn32_phy32
 Checking test 049 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.336581
-  0: The maximum resident set size (KB)                   = 692736
+  0: The total amount of wall time                        = 170.211248
+  0: The maximum resident set size (KB)                   = 697548
 
 Test 049 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/rap_control_dyn64_phy32_debug
 Checking test 050 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 204.567054
-  0: The maximum resident set size (KB)                   = 714436
+  0: The total amount of wall time                        = 205.597260
+  0: The maximum resident set size (KB)                   = 723004
 
 Test 050 rap_control_dyn64_phy32_debug PASS
 
-Test 051 cpld_control_p8 FAIL
 
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/cpld_control_nowave_noaero_p8
-Checking test 052 cpld_control_nowave_noaero_p8 results ....
- Comparing sfcf021.tile1.nc .........OK
- Comparing sfcf021.tile2.nc .........OK
- Comparing sfcf021.tile3.nc .........OK
- Comparing sfcf021.tile4.nc .........OK
- Comparing sfcf021.tile5.nc .........OK
- Comparing sfcf021.tile6.nc .........OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
-
-  0: The total amount of wall time                        = 1225.420847
-  0: The maximum resident set size (KB)                   = 1334116
-
-Test 052 cpld_control_nowave_noaero_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/cpld_debug_p8
-Checking test 053 cpld_debug_p8 results ....
- Comparing sfcf003.tile1.nc .........OK
- Comparing sfcf003.tile2.nc .........OK
- Comparing sfcf003.tile3.nc .........OK
- Comparing sfcf003.tile4.nc .........OK
- Comparing sfcf003.tile5.nc .........OK
- Comparing sfcf003.tile6.nc .........OK
- Comparing atmf003.tile1.nc .........OK
- Comparing atmf003.tile2.nc .........OK
- Comparing atmf003.tile3.nc .........OK
- Comparing atmf003.tile4.nc .........OK
- Comparing atmf003.tile5.nc .........OK
- Comparing atmf003.tile6.nc .........OK
- Comparing gocart.inst_aod.20210322_0900z.nc4 .........OK
- Comparing RESTART/20210322.090000.coupler.res .........OK
- Comparing RESTART/20210322.090000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.090000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.090000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.090000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.090000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.090000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.090000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.090000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.090000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.090000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.090000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.090000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.090000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.090000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.090000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.090000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.090000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.090000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.090000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.090000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.090000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.090000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.090000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.090000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.090000.sfc_data.tile6.nc .........OK
- Comparing RESTART/20210322.090000.MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-22-32400.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
- Comparing 20210322.090000.out_pnt.ww3 .........OK
- Comparing 20210322.090000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 945.235437
-  0: The maximum resident set size (KB)                   = 1437376
-
-Test 053 cpld_debug_p8 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_4097/datm_cdeps_control_cfsr
-Checking test 054 datm_cdeps_control_cfsr results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 176.318780
- 0: The maximum resident set size (KB)                   = 662900
-
-Test 054 datm_cdeps_control_cfsr PASS
-
-FAILED TESTS: 
-Test cpld_control_p8 051 failed in run_test failed 
-
-REGRESSION TEST FAILED
-Sun May  7 07:16:26 UTC 2023
-Elapsed time: 06h:59m:47s. Have a nice day!
-Sun May  7 12:08:26 UTC 2023
-Start Regression test
-
-Compile 001 elapsed time 271 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/GNU/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_12317/cpld_control_p8
-Checking test 001 cpld_control_p8 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/cpld_control_p8
+Checking test 051 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -1718,12 +1564,154 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1759.336840
-  0: The maximum resident set size (KB)                   = 1429516
+  0: The total amount of wall time                        = 1738.111621
+  0: The maximum resident set size (KB)                   = 1428136
 
-Test 001 cpld_control_p8 PASS Tries: 2
+Test 051 cpld_control_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/cpld_control_nowave_noaero_p8
+Checking test 052 cpld_control_nowave_noaero_p8 results ....
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+
+  0: The total amount of wall time                        = 1225.473787
+  0: The maximum resident set size (KB)                   = 1330720
+
+Test 052 cpld_control_nowave_noaero_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/cpld_debug_p8
+Checking test 053 cpld_debug_p8 results ....
+ Comparing sfcf003.tile1.nc .........OK
+ Comparing sfcf003.tile2.nc .........OK
+ Comparing sfcf003.tile3.nc .........OK
+ Comparing sfcf003.tile4.nc .........OK
+ Comparing sfcf003.tile5.nc .........OK
+ Comparing sfcf003.tile6.nc .........OK
+ Comparing atmf003.tile1.nc .........OK
+ Comparing atmf003.tile2.nc .........OK
+ Comparing atmf003.tile3.nc .........OK
+ Comparing atmf003.tile4.nc .........OK
+ Comparing atmf003.tile5.nc .........OK
+ Comparing atmf003.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210322_0900z.nc4 .........OK
+ Comparing RESTART/20210322.090000.coupler.res .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.090000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.090000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.090000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.090000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.090000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.090000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.090000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.090000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.090000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.090000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.090000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.090000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.090000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.090000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.090000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.090000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.090000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.090000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.090000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.090000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.090000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-22-32400.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-32400.nc .........OK
+ Comparing 20210322.090000.out_pnt.ww3 .........OK
+ Comparing 20210322.090000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 814.932589
+  0: The maximum resident set size (KB)                   = 1441252
+
+Test 053 cpld_debug_p8 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_25162/datm_cdeps_control_cfsr
+Checking test 054 datm_cdeps_control_cfsr results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 179.836645
+ 0: The maximum resident set size (KB)                   = 659900
+
+Test 054 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun May  7 14:31:34 UTC 2023
-Elapsed time: 02h:23m:08s. Have a nice day!
+Thu May 11 19:21:37 UTC 2023
+Elapsed time: 06h:19m:23s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,43 +1,43 @@
-Sat May  6 22:27:18 UTC 2023
+Thu May 11 12:48:16 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 645 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 645 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 600 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 231 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 206 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 562 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 557 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 724 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 532 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 513 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 470 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 630 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 226 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 496 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 499 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 171 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 172 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 602 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 247 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 675 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 582 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 178 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 106 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 184 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 64 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 524 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 568 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 533 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 505 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 500 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 176 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 034 elapsed time 575 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 634 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 646 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 603 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 238 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 211 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 559 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 560 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 736 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 575 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 534 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 481 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 617 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 225 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 161 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 491 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 500 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 164 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 167 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 570 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 196 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 669 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 590 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 187 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 107 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 176 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 50 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 528 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 552 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 551 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 525 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 498 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 171 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 034 elapsed time 573 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_mixedmode
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_p8_mixedmode
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -102,14 +102,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 316.030188
-  0: The maximum resident set size (KB)                   = 3134584
+  0: The total amount of wall time                        = 309.521039
+  0: The maximum resident set size (KB)                   = 3138912
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_gfsv17
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_gfsv17
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_gfsv17
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -173,14 +173,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 229.299897
-  0: The maximum resident set size (KB)                   = 1710748
+  0: The total amount of wall time                        = 225.750576
+  0: The maximum resident set size (KB)                   = 1723136
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -245,14 +245,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 344.720942
-  0: The maximum resident set size (KB)                   = 3160168
+  0: The total amount of wall time                        = 341.419667
+  0: The maximum resident set size (KB)                   = 3164920
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -305,14 +305,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 196.781868
-  0: The maximum resident set size (KB)                   = 3036612
+  0: The total amount of wall time                        = 199.715554
+  0: The maximum resident set size (KB)                   = 3044588
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -377,14 +377,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 363.796427
-  0: The maximum resident set size (KB)                   = 3173820
+  0: The total amount of wall time                        = 346.336978
+  0: The maximum resident set size (KB)                   = 3122744
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_restart_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -437,14 +437,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 204.261175
-  0: The maximum resident set size (KB)                   = 3066668
+  0: The total amount of wall time                        = 202.152301
+  0: The maximum resident set size (KB)                   = 3054444
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -497,14 +497,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 359.033644
-  0: The maximum resident set size (KB)                   = 3504096
+  0: The total amount of wall time                        = 349.219387
+  0: The maximum resident set size (KB)                   = 3497980
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -557,14 +557,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 347.600009
-  0: The maximum resident set size (KB)                   = 3151644
+  0: The total amount of wall time                        = 341.434881
+  0: The maximum resident set size (KB)                   = 3144492
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -617,14 +617,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 282.874009
-  0: The maximum resident set size (KB)                   = 3006024
+  0: The total amount of wall time                        = 282.215373
+  0: The maximum resident set size (KB)                   = 3002292
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_ciceC_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_ciceC_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_ciceC_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -689,14 +689,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 350.433740
-  0: The maximum resident set size (KB)                   = 3146124
+  0: The total amount of wall time                        = 340.429672
+  0: The maximum resident set size (KB)                   = 3148216
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -749,14 +749,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 583.959711
-  0: The maximum resident set size (KB)                   = 3239904
+  0: The total amount of wall time                        = 598.468737
+  0: The maximum resident set size (KB)                   = 3240772
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -809,14 +809,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 387.630995
-  0: The maximum resident set size (KB)                   = 3163220
+  0: The total amount of wall time                        = 382.099377
+  0: The maximum resident set size (KB)                   = 3137560
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_bmark_p8
 Checking test 013 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -864,14 +864,14 @@ Checking test 013 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 736.936664
-   0: The maximum resident set size (KB)                   = 3975864
+   0: The total amount of wall time                        = 804.295467
+   0: The maximum resident set size (KB)                   = 4020352
 
 Test 013 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_restart_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_restart_bmark_p8
 Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -919,14 +919,14 @@ Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 464.445764
-   0: The maximum resident set size (KB)                   = 3957864
+   0: The total amount of wall time                        = 452.264457
+   0: The maximum resident set size (KB)                   = 3962820
 
 Test 014 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_noaero_p8
 Checking test 015 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -990,14 +990,14 @@ Checking test 015 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 266.714782
-  0: The maximum resident set size (KB)                   = 1702236
+  0: The total amount of wall time                        = 265.538979
+  0: The maximum resident set size (KB)                   = 1712996
 
 Test 015 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c96_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_nowave_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_nowave_noaero_p8
 Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1059,14 +1059,14 @@ Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 263.451496
-  0: The maximum resident set size (KB)                   = 1751580
+  0: The total amount of wall time                        = 261.304673
+  0: The maximum resident set size (KB)                   = 1757796
 
 Test 016 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_debug_p8
 Checking test 017 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1119,14 +1119,14 @@ Checking test 017 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 524.506699
-  0: The maximum resident set size (KB)                   = 3210916
+  0: The total amount of wall time                        = 518.307589
+  0: The maximum resident set size (KB)                   = 3226744
 
 Test 017 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_debug_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_debug_noaero_p8
 Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1178,14 +1178,14 @@ Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 357.523239
-  0: The maximum resident set size (KB)                   = 1714572
+  0: The total amount of wall time                        = 358.692848
+  0: The maximum resident set size (KB)                   = 1741628
 
 Test 018 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_noaero_p8_agrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_noaero_p8_agrid
 Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1247,14 +1247,14 @@ Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 274.078376
-  0: The maximum resident set size (KB)                   = 1745448
+  0: The total amount of wall time                        = 267.547426
+  0: The maximum resident set size (KB)                   = 1753120
 
 Test 019 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_c48
 Checking test 020 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1304,14 +1304,14 @@ Checking test 020 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 588.326597
- 0: The maximum resident set size (KB)                   = 2806248
+ 0: The total amount of wall time                        = 584.102031
+ 0: The maximum resident set size (KB)                   = 2803868
 
 Test 020 cpld_control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_warmstart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_warmstart_c48
 Checking test 021 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1361,14 +1361,14 @@ Checking test 021 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 156.844167
- 0: The maximum resident set size (KB)                   = 2788828
+ 0: The total amount of wall time                        = 155.598223
+ 0: The maximum resident set size (KB)                   = 2807936
 
 Test 021 cpld_warmstart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_restart_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_restart_c48
 Checking test 022 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1418,14 +1418,14 @@ Checking test 022 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 82.168910
- 0: The maximum resident set size (KB)                   = 2231568
+ 0: The total amount of wall time                        = 81.895077
+ 0: The maximum resident set size (KB)                   = 2244552
 
 Test 022 cpld_restart_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_faster
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/cpld_control_p8_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/cpld_control_p8_faster
 Checking test 023 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1490,14 +1490,14 @@ Checking test 023 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 321.571268
-  0: The maximum resident set size (KB)                   = 3153472
+  0: The total amount of wall time                        = 328.632333
+  0: The maximum resident set size (KB)                   = 3162392
 
 Test 023 cpld_control_p8_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_flake
 Checking test 024 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1508,14 +1508,14 @@ Checking test 024 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 189.114373
-  0: The maximum resident set size (KB)                   = 675364
+  0: The total amount of wall time                        = 186.762183
+  0: The maximum resident set size (KB)                   = 677816
 
 Test 024 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_CubedSphereGrid
 Checking test 025 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1542,28 +1542,28 @@ Checking test 025 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 131.918610
-  0: The maximum resident set size (KB)                   = 628388
+  0: The total amount of wall time                        = 130.451946
+  0: The maximum resident set size (KB)                   = 598768
 
 Test 025 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_CubedSphereGrid_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_CubedSphereGrid_parallel
 Checking test 026 control_CubedSphereGrid_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 128.380662
-  0: The maximum resident set size (KB)                   = 632556
+  0: The total amount of wall time                        = 127.426279
+  0: The maximum resident set size (KB)                   = 624304
 
 Test 026 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_latlon
 Checking test 027 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1574,14 +1574,14 @@ Checking test 027 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.376694
-  0: The maximum resident set size (KB)                   = 621536
+  0: The total amount of wall time                        = 132.725882
+  0: The maximum resident set size (KB)                   = 625988
 
 Test 027 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_wrtGauss_netcdf_parallel
 Checking test 028 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 028 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.499111
-  0: The maximum resident set size (KB)                   = 607696
+  0: The total amount of wall time                        = 136.911104
+  0: The maximum resident set size (KB)                   = 623144
 
 Test 028 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_c48
 Checking test 029 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1638,14 +1638,14 @@ Checking test 029 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 366.514430
-0: The maximum resident set size (KB)                   = 822892
+0: The total amount of wall time                        = 369.811784
+0: The maximum resident set size (KB)                   = 825016
 
 Test 029 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_c192
 Checking test 030 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1656,14 +1656,14 @@ Checking test 030 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 527.992750
-  0: The maximum resident set size (KB)                   = 766924
+  0: The total amount of wall time                        = 528.856857
+  0: The maximum resident set size (KB)                   = 762508
 
 Test 030 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_c384
 Checking test 031 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1674,14 +1674,14 @@ Checking test 031 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 519.102356
-  0: The maximum resident set size (KB)                   = 1257568
+  0: The total amount of wall time                        = 523.762877
+  0: The maximum resident set size (KB)                   = 1270216
 
 Test 031 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_c384gdas
 Checking test 032 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1724,14 +1724,14 @@ Checking test 032 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 457.274603
-  0: The maximum resident set size (KB)                   = 1376056
+  0: The total amount of wall time                        = 455.965386
+  0: The maximum resident set size (KB)                   = 1372656
 
 Test 032 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_stochy
 Checking test 033 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1742,28 +1742,28 @@ Checking test 033 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 87.619846
-  0: The maximum resident set size (KB)                   = 630748
+  0: The total amount of wall time                        = 88.729894
+  0: The maximum resident set size (KB)                   = 628040
 
 Test 033 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_stochy_restart
 Checking test 034 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.757237
-  0: The maximum resident set size (KB)                   = 491044
+  0: The total amount of wall time                        = 48.898794
+  0: The maximum resident set size (KB)                   = 484508
 
 Test 034 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_lndp
 Checking test 035 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1774,14 +1774,14 @@ Checking test 035 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.436482
-  0: The maximum resident set size (KB)                   = 619440
+  0: The total amount of wall time                        = 81.972383
+  0: The maximum resident set size (KB)                   = 627484
 
 Test 035 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_iovr4
 Checking test 036 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1796,14 +1796,14 @@ Checking test 036 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.366704
-  0: The maximum resident set size (KB)                   = 627192
+  0: The total amount of wall time                        = 137.050149
+  0: The maximum resident set size (KB)                   = 629556
 
 Test 036 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_iovr5
 Checking test 037 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1818,14 +1818,14 @@ Checking test 037 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.807453
-  0: The maximum resident set size (KB)                   = 630608
+  0: The total amount of wall time                        = 136.558261
+  0: The maximum resident set size (KB)                   = 627816
 
 Test 037 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_p8
 Checking test 038 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1872,14 +1872,14 @@ Checking test 038 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.861049
-  0: The maximum resident set size (KB)                   = 1589680
+  0: The total amount of wall time                        = 173.479439
+  0: The maximum resident set size (KB)                   = 1594508
 
 Test 038 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_restart_p8
 Checking test 039 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1918,14 +1918,14 @@ Checking test 039 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.227506
-  0: The maximum resident set size (KB)                   = 862372
+  0: The total amount of wall time                        = 88.137317
+  0: The maximum resident set size (KB)                   = 875832
 
 Test 039 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_qr_p8
 Checking test 040 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1972,14 +1972,14 @@ Checking test 040 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 171.376711
-  0: The maximum resident set size (KB)                   = 1593612
+  0: The total amount of wall time                        = 171.445268
+  0: The maximum resident set size (KB)                   = 1599012
 
 Test 040 control_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_restart_qr_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_restart_qr_p8
 Checking test 041 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2018,14 +2018,14 @@ Checking test 041 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 90.472501
-  0: The maximum resident set size (KB)                   = 859124
+  0: The total amount of wall time                        = 91.661888
+  0: The maximum resident set size (KB)                   = 860636
 
 Test 041 control_restart_qr_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_decomp_p8
 Checking test 042 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2068,14 +2068,14 @@ Checking test 042 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.751023
-  0: The maximum resident set size (KB)                   = 1569164
+  0: The total amount of wall time                        = 179.111692
+  0: The maximum resident set size (KB)                   = 1560064
 
 Test 042 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_2threads_p8
 Checking test 043 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2118,14 +2118,14 @@ Checking test 043 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.494115
-  0: The maximum resident set size (KB)                   = 1658144
+  0: The total amount of wall time                        = 158.536148
+  0: The maximum resident set size (KB)                   = 1686604
 
 Test 043 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_p8_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_p8_lndp
 Checking test 044 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2144,14 +2144,14 @@ Checking test 044 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 316.334324
-  0: The maximum resident set size (KB)                   = 1592908
+  0: The total amount of wall time                        = 314.932134
+  0: The maximum resident set size (KB)                   = 1597452
 
 Test 044 control_p8_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_p8_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_p8_rrtmgp
 Checking test 045 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2198,14 +2198,14 @@ Checking test 045 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.549991
-  0: The maximum resident set size (KB)                   = 1658784
+  0: The total amount of wall time                        = 228.601613
+  0: The maximum resident set size (KB)                   = 1676452
 
 Test 045 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_mynn
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_p8_mynn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_p8_mynn
 Checking test 046 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2252,14 +2252,14 @@ Checking test 046 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.591899
-  0: The maximum resident set size (KB)                   = 1597172
+  0: The total amount of wall time                        = 172.338853
+  0: The maximum resident set size (KB)                   = 1599952
 
 Test 046 control_p8_mynn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/merra2_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/merra2_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2306,14 +2306,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.997270
-  0: The maximum resident set size (KB)                   = 1601328
+  0: The total amount of wall time                        = 194.365716
+  0: The maximum resident set size (KB)                   = 1602052
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2324,28 +2324,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 298.298418
-  0: The maximum resident set size (KB)                   = 864704
+  0: The total amount of wall time                        = 297.794181
+  0: The maximum resident set size (KB)                   = 869788
 
 Test 048 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 150.673233
-  0: The maximum resident set size (KB)                   = 859896
+  0: The total amount of wall time                        = 152.590298
+  0: The maximum resident set size (KB)                   = 866248
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_control_qr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_control_qr
 Checking test 050 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2356,28 +2356,28 @@ Checking test 050 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 298.548434
-  0: The maximum resident set size (KB)                   = 868092
+  0: The total amount of wall time                        = 298.349111
+  0: The maximum resident set size (KB)                   = 863208
 
 Test 050 regional_control_qr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_restart_qr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_restart_qr
 Checking test 051 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 151.565996
-  0: The maximum resident set size (KB)                   = 857592
+  0: The total amount of wall time                        = 152.789557
+  0: The maximum resident set size (KB)                   = 868904
 
 Test 051 regional_restart_qr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_decomp
 Checking test 052 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2388,14 +2388,14 @@ Checking test 052 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 312.842080
-  0: The maximum resident set size (KB)                   = 856248
+  0: The total amount of wall time                        = 316.926464
+  0: The maximum resident set size (KB)                   = 849908
 
 Test 052 regional_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_2threads
 Checking test 053 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2406,14 +2406,14 @@ Checking test 053 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 178.871543
-  0: The maximum resident set size (KB)                   = 846636
+  0: The total amount of wall time                        = 181.595347
+  0: The maximum resident set size (KB)                   = 846304
 
 Test 053 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_noquilt
 Checking test 054 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2421,28 +2421,28 @@ Checking test 054 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 319.013248
-  0: The maximum resident set size (KB)                   = 852916
+  0: The total amount of wall time                        = 321.636831
+  0: The maximum resident set size (KB)                   = 847176
 
 Test 054 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_netcdf_parallel
 Checking test 055 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 294.682215
-  0: The maximum resident set size (KB)                   = 865484
+  0: The total amount of wall time                        = 294.302093
+  0: The maximum resident set size (KB)                   = 860652
 
 Test 055 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_2dwrtdecomp
 Checking test 056 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2453,14 +2453,14 @@ Checking test 056 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 299.267721
-  0: The maximum resident set size (KB)                   = 863724
+  0: The total amount of wall time                        = 298.162868
+  0: The maximum resident set size (KB)                   = 865912
 
 Test 056 regional_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/fv3_regional_wofs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_wofs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/fv3_regional_wofs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_wofs
 Checking test 057 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2471,744 +2471,626 @@ Checking test 057 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 375.204879
-  0: The maximum resident set size (KB)                   = 628896
+  0: The total amount of wall time                        = 374.986784
+  0: The maximum resident set size (KB)                   = 632272
 
 Test 057 regional_wofs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control
 Checking test 058 rap_control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf021.nc ............MISSING baseline
+ Comparing sfcf024.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf021.nc ............MISSING baseline
+ Comparing atmf024.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF21 ............MISSING baseline
+ Comparing GFSFLX.GrbF24 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF21 ............MISSING baseline
+ Comparing GFSPRS.GrbF24 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 459.901336
-  0: The maximum resident set size (KB)                   = 1058020
+  0: The total amount of wall time                        = 460.870467
+  0: The maximum resident set size (KB)                   = 1048092
 
-Test 058 rap_control PASS
+Test 058 rap_control FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_spp_sppt_shum_skeb
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_spp_sppt_shum_skeb
 Checking test 059 regional_spp_sppt_shum_skeb results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF01 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF01 .........OK
+ Comparing dynf000.nc ............MISSING baseline
+ Comparing dynf001.nc ............MISSING baseline
+ Comparing phyf000.nc ............MISSING baseline
+ Comparing phyf001.nc ............MISSING baseline
+ Comparing PRSLEV.GrbF00 ............MISSING baseline
+ Comparing PRSLEV.GrbF01 ............MISSING baseline
+ Comparing NATLEV.GrbF00 ............MISSING baseline
+ Comparing NATLEV.GrbF01 ............MISSING baseline
 
-  0: The total amount of wall time                        = 236.409291
-  0: The maximum resident set size (KB)                   = 1176844
+  0: The total amount of wall time                        = 231.765169
+  0: The maximum resident set size (KB)                   = 1181664
 
-Test 059 regional_spp_sppt_shum_skeb PASS
+Test 059 regional_spp_sppt_shum_skeb FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_decomp
 Checking test 060 rap_decomp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf021.nc ............MISSING baseline
+ Comparing sfcf024.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf021.nc ............MISSING baseline
+ Comparing atmf024.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF21 ............MISSING baseline
+ Comparing GFSFLX.GrbF24 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF21 ............MISSING baseline
+ Comparing GFSPRS.GrbF24 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 480.693671
-  0: The maximum resident set size (KB)                   = 997864
+  0: The total amount of wall time                        = 481.737377
+  0: The maximum resident set size (KB)                   = 992032
 
-Test 060 rap_decomp PASS
+Test 060 rap_decomp FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_2threads
 Checking test 061 rap_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf021.nc ............MISSING baseline
+ Comparing sfcf024.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf021.nc ............MISSING baseline
+ Comparing atmf024.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF21 ............MISSING baseline
+ Comparing GFSFLX.GrbF24 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF21 ............MISSING baseline
+ Comparing GFSPRS.GrbF24 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 434.737426
-  0: The maximum resident set size (KB)                   = 1138280
+  0: The total amount of wall time                        = 437.879086
+  0: The maximum resident set size (KB)                   = 1101756
 
-Test 061 rap_2threads PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_restart
-Checking test 062 rap_restart results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 232.553469
-  0: The maximum resident set size (KB)                   = 963572
-
-Test 062 rap_restart PASS
+Test 061 rap_2threads FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_sfcdiff
 Checking test 063 rap_sfcdiff results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 459.365325
-  0: The maximum resident set size (KB)                   = 1059128
+  0: The total amount of wall time                        = 460.389691
+  0: The maximum resident set size (KB)                   = 1045744
 
-Test 063 rap_sfcdiff PASS
+Test 063 rap_sfcdiff FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_sfcdiff_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_sfcdiff_decomp
 Checking test 064 rap_sfcdiff_decomp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 485.636585
-  0: The maximum resident set size (KB)                   = 967740
+  0: The total amount of wall time                        = 485.026699
+  0: The maximum resident set size (KB)                   = 997320
 
-Test 064 rap_sfcdiff_decomp PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_sfcdiff_restart
-Checking test 065 rap_sfcdiff_restart results ....
- Comparing sfcf012.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 344.468160
-  0: The maximum resident set size (KB)                   = 984276
-
-Test 065 rap_sfcdiff_restart PASS
+Test 064 rap_sfcdiff_decomp FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control
 Checking test 066 hrrr_control results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 430.284503
-  0: The maximum resident set size (KB)                   = 1048308
+  0: The total amount of wall time                        = 428.426870
+  0: The maximum resident set size (KB)                   = 1045188
 
-Test 066 hrrr_control PASS
+Test 066 hrrr_control FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_decomp
 Checking test 067 hrrr_control_decomp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 446.816368
-  0: The maximum resident set size (KB)                   = 994000
+  0: The total amount of wall time                        = 448.792812
+  0: The maximum resident set size (KB)                   = 998780
 
-Test 067 hrrr_control_decomp PASS
+Test 067 hrrr_control_decomp FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_2threads
 Checking test 068 hrrr_control_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 396.814767
-  0: The maximum resident set size (KB)                   = 1069532
+  0: The total amount of wall time                        = 395.896439
+  0: The maximum resident set size (KB)                   = 1076848
 
-Test 068 hrrr_control_2threads PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_restart
-Checking test 069 hrrr_control_restart results ....
- Comparing sfcf012.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 318.785043
-  0: The maximum resident set size (KB)                   = 972980
-
-Test 069 hrrr_control_restart PASS
+Test 068 hrrr_control_2threads FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1beta
 Checking test 070 rrfs_v1beta results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 460.236135
-  0: The maximum resident set size (KB)                   = 1051204
+  0: The total amount of wall time                        = 457.112711
+  0: The maximum resident set size (KB)                   = 1049104
 
-Test 070 rrfs_v1beta PASS
+Test 070 rrfs_v1beta FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_v1nssl
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1nssl
 Checking test 071 rrfs_v1nssl results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
 
-  0: The total amount of wall time                        = 541.354527
-  0: The maximum resident set size (KB)                   = 687248
+  0: The total amount of wall time                        = 536.557757
+  0: The maximum resident set size (KB)                   = 665360
 
-Test 071 rrfs_v1nssl PASS
+Test 071 rrfs_v1nssl FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1nssl_nohailnoccn
 Checking test 072 rrfs_v1nssl_nohailnoccn results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
 
-  0: The total amount of wall time                        = 525.662132
-  0: The maximum resident set size (KB)                   = 749976
+  0: The total amount of wall time                        = 522.726999
+  0: The maximum resident set size (KB)                   = 752812
 
-Test 072 rrfs_v1nssl_nohailnoccn PASS
+Test 072 rrfs_v1nssl_nohailnoccn FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm
 Checking test 073 rrfs_smoke_conus13km_hrrr_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing sfcf002.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
+ Comparing atmf002.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 151.071250
-  0: The maximum resident set size (KB)                   = 1023100
+  0: The total amount of wall time                        = 152.138144
+  0: The maximum resident set size (KB)                   = 1031220
 
-Test 073 rrfs_smoke_conus13km_hrrr_warm PASS
+Test 073 rrfs_smoke_conus13km_hrrr_warm FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing sfcf002.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
+ Comparing atmf002.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 90.746776
-  0: The maximum resident set size (KB)                   = 940984
+  0: The total amount of wall time                        = 92.747663
+  0: The maximum resident set size (KB)                   = 942036
 
-Test 074 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
+Test 074 rrfs_smoke_conus13km_hrrr_warm_2threads FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_conus13km_hrrr_warm
 Checking test 075 rrfs_conus13km_hrrr_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing sfcf002.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
+ Comparing atmf002.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 134.099306
-  0: The maximum resident set size (KB)                   = 984424
+  0: The total amount of wall time                        = 133.503022
+  0: The maximum resident set size (KB)                   = 979936
 
-Test 075 rrfs_conus13km_hrrr_warm PASS
+Test 075 rrfs_conus13km_hrrr_warm FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 076 rrfs_smoke_conus13km_radar_tten_warm results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing sfcf002.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
+ Comparing atmf002.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 150.957414
-  0: The maximum resident set size (KB)                   = 1029524
+  0: The total amount of wall time                        = 152.491705
+  0: The maximum resident set size (KB)                   = 1030160
 
-Test 076 rrfs_smoke_conus13km_radar_tten_warm PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_conus13km_hrrr_warm_restart_mismatch
-Checking test 077 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 73.418916
-  0: The maximum resident set size (KB)                   = 977244
-
-Test 077 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
+Test 076 rrfs_smoke_conus13km_radar_tten_warm FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_csawmg
 Checking test 078 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3219,14 +3101,14 @@ Checking test 078 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 347.002165
-  0: The maximum resident set size (KB)                   = 723644
+  0: The total amount of wall time                        = 345.949024
+  0: The maximum resident set size (KB)                   = 725720
 
 Test 078 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_csawmgt
 Checking test 079 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3237,14 +3119,14 @@ Checking test 079 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 343.072232
-  0: The maximum resident set size (KB)                   = 720404
+  0: The total amount of wall time                        = 342.203356
+  0: The maximum resident set size (KB)                   = 708328
 
 Test 079 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_ras
 Checking test 080 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3255,26 +3137,26 @@ Checking test 080 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 183.356188
-  0: The maximum resident set size (KB)                   = 720228
+  0: The total amount of wall time                        = 181.424626
+  0: The maximum resident set size (KB)                   = 714792
 
 Test 080 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_wam
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_wam
 Checking test 081 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.212275
-  0: The maximum resident set size (KB)                   = 642732
+  0: The total amount of wall time                        = 111.942145
+  0: The maximum resident set size (KB)                   = 641360
 
 Test 081 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_faster
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_p8_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_p8_faster
 Checking test 082 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3321,14 +3203,14 @@ Checking test 082 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.236405
-  0: The maximum resident set size (KB)                   = 1597528
+  0: The total amount of wall time                        = 156.092600
+  0: The maximum resident set size (KB)                   = 1590712
 
 Test 082 control_p8_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control_faster
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_control_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_control_faster
 Checking test 083 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3339,893 +3221,833 @@ Checking test 083 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 273.206661
-  0: The maximum resident set size (KB)                   = 866544
+  0: The total amount of wall time                        = 272.551503
+  0: The maximum resident set size (KB)                   = 866296
 
 Test 083 regional_control_faster PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 843.816497
-  0: The maximum resident set size (KB)                   = 1028356
+  0: The total amount of wall time                        = 832.711387
+  0: The maximum resident set size (KB)                   = 1056876
 
-Test 084 rrfs_smoke_conus13km_hrrr_warm_debug PASS
+Test 084 rrfs_smoke_conus13km_hrrr_warm_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 459.206651
-  0: The maximum resident set size (KB)                   = 973068
+  0: The total amount of wall time                        = 465.208216
+  0: The maximum resident set size (KB)                   = 967464
 
-Test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
+Test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_conus13km_hrrr_warm_debug
 Checking test 086 rrfs_conus13km_hrrr_warm_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 743.716435
-  0: The maximum resident set size (KB)                   = 1009980
+  0: The total amount of wall time                        = 745.046241
+  0: The maximum resident set size (KB)                   = 1013404
 
-Test 086 rrfs_conus13km_hrrr_warm_debug PASS
+Test 086 rrfs_conus13km_hrrr_warm_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_CubedSphereGrid_debug
 Checking test 087 control_CubedSphereGrid_debug results ....
- Comparing sfcf000.tile1.nc .........OK
- Comparing sfcf000.tile2.nc .........OK
- Comparing sfcf000.tile3.nc .........OK
- Comparing sfcf000.tile4.nc .........OK
- Comparing sfcf000.tile5.nc .........OK
- Comparing sfcf000.tile6.nc .........OK
- Comparing sfcf001.tile1.nc .........OK
- Comparing sfcf001.tile2.nc .........OK
- Comparing sfcf001.tile3.nc .........OK
- Comparing sfcf001.tile4.nc .........OK
- Comparing sfcf001.tile5.nc .........OK
- Comparing sfcf001.tile6.nc .........OK
- Comparing atmf000.tile1.nc .........OK
- Comparing atmf000.tile2.nc .........OK
- Comparing atmf000.tile3.nc .........OK
- Comparing atmf000.tile4.nc .........OK
- Comparing atmf000.tile5.nc .........OK
- Comparing atmf000.tile6.nc .........OK
- Comparing atmf001.tile1.nc .........OK
- Comparing atmf001.tile2.nc .........OK
- Comparing atmf001.tile3.nc .........OK
- Comparing atmf001.tile4.nc .........OK
- Comparing atmf001.tile5.nc .........OK
- Comparing atmf001.tile6.nc .........OK
+ Comparing sfcf000.tile1.nc ............MISSING baseline
+ Comparing sfcf000.tile2.nc ............MISSING baseline
+ Comparing sfcf000.tile3.nc ............MISSING baseline
+ Comparing sfcf000.tile4.nc ............MISSING baseline
+ Comparing sfcf000.tile5.nc ............MISSING baseline
+ Comparing sfcf000.tile6.nc ............MISSING baseline
+ Comparing sfcf001.tile1.nc ............MISSING baseline
+ Comparing sfcf001.tile2.nc ............MISSING baseline
+ Comparing sfcf001.tile3.nc ............MISSING baseline
+ Comparing sfcf001.tile4.nc ............MISSING baseline
+ Comparing sfcf001.tile5.nc ............MISSING baseline
+ Comparing sfcf001.tile6.nc ............MISSING baseline
+ Comparing atmf000.tile1.nc ............MISSING baseline
+ Comparing atmf000.tile2.nc ............MISSING baseline
+ Comparing atmf000.tile3.nc ............MISSING baseline
+ Comparing atmf000.tile4.nc ............MISSING baseline
+ Comparing atmf000.tile5.nc ............MISSING baseline
+ Comparing atmf000.tile6.nc ............MISSING baseline
+ Comparing atmf001.tile1.nc ............MISSING baseline
+ Comparing atmf001.tile2.nc ............MISSING baseline
+ Comparing atmf001.tile3.nc ............MISSING baseline
+ Comparing atmf001.tile4.nc ............MISSING baseline
+ Comparing atmf001.tile5.nc ............MISSING baseline
+ Comparing atmf001.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 145.501912
-  0: The maximum resident set size (KB)                   = 786020
+  0: The total amount of wall time                        = 150.078971
+  0: The maximum resident set size (KB)                   = 763448
 
-Test 087 control_CubedSphereGrid_debug PASS
+Test 087 control_CubedSphereGrid_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_wrtGauss_netcdf_parallel_debug
 Checking test 088 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 146.861774
-  0: The maximum resident set size (KB)                   = 789404
+  0: The total amount of wall time                        = 145.638031
+  0: The maximum resident set size (KB)                   = 786808
 
-Test 088 control_wrtGauss_netcdf_parallel_debug PASS
+Test 088 control_wrtGauss_netcdf_parallel_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_stochy_debug
 Checking test 089 control_stochy_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 165.279633
-  0: The maximum resident set size (KB)                   = 795728
+  0: The total amount of wall time                        = 165.102886
+  0: The maximum resident set size (KB)                   = 794524
 
-Test 089 control_stochy_debug PASS
+Test 089 control_stochy_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_lndp_debug
 Checking test 090 control_lndp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 147.255077
-  0: The maximum resident set size (KB)                   = 795936
+  0: The total amount of wall time                        = 146.621086
+  0: The maximum resident set size (KB)                   = 790080
 
-Test 090 control_lndp_debug PASS
+Test 090 control_lndp_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_csawmg_debug
 Checking test 091 control_csawmg_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 225.334740
-  0: The maximum resident set size (KB)                   = 842656
+  0: The total amount of wall time                        = 223.535451
+  0: The maximum resident set size (KB)                   = 838036
 
-Test 091 control_csawmg_debug PASS
+Test 091 control_csawmg_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_csawmgt_debug
 Checking test 092 control_csawmgt_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 225.065102
-  0: The maximum resident set size (KB)                   = 836344
+  0: The total amount of wall time                        = 224.238890
+  0: The maximum resident set size (KB)                   = 839484
 
-Test 092 control_csawmgt_debug PASS
+Test 092 control_csawmgt_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_ras_debug
 Checking test 093 control_ras_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 149.592536
-  0: The maximum resident set size (KB)                   = 801956
+  0: The total amount of wall time                        = 148.821949
+  0: The maximum resident set size (KB)                   = 797996
 
-Test 093 control_ras_debug PASS
+Test 093 control_ras_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_diag_debug
 Checking test 094 control_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 153.143316
-  0: The maximum resident set size (KB)                   = 847492
+  0: The total amount of wall time                        = 154.304266
+  0: The maximum resident set size (KB)                   = 846092
 
-Test 094 control_diag_debug PASS
+Test 094 control_diag_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_debug_p8
 Checking test 095 control_debug_p8 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 164.215539
-  0: The maximum resident set size (KB)                   = 1616336
+  0: The total amount of wall time                        = 161.708863
+  0: The maximum resident set size (KB)                   = 1610228
 
-Test 095 control_debug_p8 PASS
+Test 095 control_debug_p8 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_debug
 Checking test 096 regional_debug results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
+ Comparing dynf000.nc ............MISSING baseline
+ Comparing dynf001.nc ............MISSING baseline
+ Comparing phyf000.nc ............MISSING baseline
+ Comparing phyf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 971.646024
-  0: The maximum resident set size (KB)                   = 882352
+  0: The total amount of wall time                        = 980.782012
+  0: The maximum resident set size (KB)                   = 876904
 
-Test 096 regional_debug PASS
+Test 096 regional_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_debug
 Checking test 097 rap_control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 269.233461
-  0: The maximum resident set size (KB)                   = 1161664
+  0: The total amount of wall time                        = 273.890726
+  0: The maximum resident set size (KB)                   = 1163616
 
-Test 097 rap_control_debug PASS
+Test 097 rap_control_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_debug
 Checking test 098 hrrr_control_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 258.735726
-  0: The maximum resident set size (KB)                   = 1169020
+  0: The total amount of wall time                        = 264.999828
+  0: The maximum resident set size (KB)                   = 1163356
 
-Test 098 hrrr_control_debug PASS
+Test 098 hrrr_control_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_unified_drag_suite_debug
 Checking test 099 rap_unified_drag_suite_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 276.190457
-  0: The maximum resident set size (KB)                   = 1166172
+  0: The total amount of wall time                        = 271.532738
+  0: The maximum resident set size (KB)                   = 1168140
 
-Test 099 rap_unified_drag_suite_debug PASS
+Test 099 rap_unified_drag_suite_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_diag_debug
 Checking test 100 rap_diag_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 284.684578
-  0: The maximum resident set size (KB)                   = 1254856
+  0: The total amount of wall time                        = 287.003819
+  0: The maximum resident set size (KB)                   = 1254120
 
-Test 100 rap_diag_debug PASS
+Test 100 rap_diag_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_cires_ugwp_debug
 Checking test 101 rap_cires_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 275.340341
-  0: The maximum resident set size (KB)                   = 1170132
+  0: The total amount of wall time                        = 276.081259
+  0: The maximum resident set size (KB)                   = 1157092
 
-Test 101 rap_cires_ugwp_debug PASS
+Test 101 rap_cires_ugwp_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_unified_ugwp_debug
 Checking test 102 rap_unified_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 276.609439
-  0: The maximum resident set size (KB)                   = 1166984
+  0: The total amount of wall time                        = 277.518716
+  0: The maximum resident set size (KB)                   = 1174452
 
-Test 102 rap_unified_ugwp_debug PASS
+Test 102 rap_unified_ugwp_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_lndp_debug
 Checking test 103 rap_lndp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 271.418390
-  0: The maximum resident set size (KB)                   = 1171932
+  0: The total amount of wall time                        = 275.802324
+  0: The maximum resident set size (KB)                   = 1166704
 
-Test 103 rap_lndp_debug PASS
+Test 103 rap_lndp_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_progcld_thompson_debug
 Checking test 104 rap_progcld_thompson_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 266.486419
-  0: The maximum resident set size (KB)                   = 1170236
+  0: The total amount of wall time                        = 269.962379
+  0: The maximum resident set size (KB)                   = 1136576
 
-Test 104 rap_progcld_thompson_debug PASS
+Test 104 rap_progcld_thompson_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_noah_debug
 Checking test 105 rap_noah_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 266.806004
-  0: The maximum resident set size (KB)                   = 1163896
+  0: The total amount of wall time                        = 265.084765
+  0: The maximum resident set size (KB)                   = 1164764
 
-Test 105 rap_noah_debug PASS
+Test 105 rap_noah_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_sfcdiff_debug
 Checking test 106 rap_sfcdiff_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 275.152949
-  0: The maximum resident set size (KB)                   = 1167752
+  0: The total amount of wall time                        = 271.177082
+  0: The maximum resident set size (KB)                   = 1157700
 
-Test 106 rap_sfcdiff_debug PASS
+Test 106 rap_sfcdiff_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 107 rap_noah_sfcdiff_cires_ugwp_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 446.801909
-  0: The maximum resident set size (KB)                   = 1164384
+  0: The total amount of wall time                        = 456.268386
+  0: The maximum resident set size (KB)                   = 1168632
 
-Test 107 rap_noah_sfcdiff_cires_ugwp_debug PASS
+Test 107 rap_noah_sfcdiff_cires_ugwp_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1beta_debug
 Checking test 108 rrfs_v1beta_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 271.700757
-  0: The maximum resident set size (KB)                   = 1157240
+  0: The total amount of wall time                        = 265.976428
+  0: The maximum resident set size (KB)                   = 1162316
 
-Test 108 rrfs_v1beta_debug PASS
+Test 108 rrfs_v1beta_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_clm_lake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_clm_lake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_clm_lake_debug
 Checking test 109 rap_clm_lake_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 329.099858
-  0: The maximum resident set size (KB)                   = 1168656
+  0: The total amount of wall time                        = 326.041910
+  0: The maximum resident set size (KB)                   = 1171816
 
-Test 109 rap_clm_lake_debug PASS
+Test 109 rap_clm_lake_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_flake_debug
 Checking test 110 rap_flake_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 273.349411
-  0: The maximum resident set size (KB)                   = 1165956
+  0: The total amount of wall time                        = 271.298331
+  0: The maximum resident set size (KB)                   = 1167068
 
-Test 110 rap_flake_debug PASS
+Test 110 rap_flake_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_wam_debug
 Checking test 111 control_wam_debug results ....
- Comparing sfcf019.nc .........OK
- Comparing atmf019.nc .........OK
+ Comparing sfcf019.nc ............MISSING baseline
+ Comparing atmf019.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 274.652738
-  0: The maximum resident set size (KB)                   = 517376
+  0: The total amount of wall time                        = 268.602090
+  0: The maximum resident set size (KB)                   = 519324
 
-Test 111 control_wam_debug PASS
+Test 111 control_wam_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 112 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF01 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF01 .........OK
+ Comparing dynf000.nc ............MISSING baseline
+ Comparing dynf001.nc ............MISSING baseline
+ Comparing phyf000.nc ............MISSING baseline
+ Comparing phyf001.nc ............MISSING baseline
+ Comparing PRSLEV.GrbF00 ............MISSING baseline
+ Comparing PRSLEV.GrbF01 ............MISSING baseline
+ Comparing NATLEV.GrbF00 ............MISSING baseline
+ Comparing NATLEV.GrbF01 ............MISSING baseline
 
-  0: The total amount of wall time                        = 218.819864
-  0: The maximum resident set size (KB)                   = 1067320
+  0: The total amount of wall time                        = 220.599977
+  0: The maximum resident set size (KB)                   = 1079000
 
-Test 112 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
+Test 112 regional_spp_sppt_shum_skeb_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_dyn32_phy32
 Checking test 113 rap_control_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 383.398944
-  0: The maximum resident set size (KB)                   = 1000548
+  0: The total amount of wall time                        = 382.479354
+  0: The maximum resident set size (KB)                   = 994612
 
-Test 113 rap_control_dyn32_phy32 PASS
+Test 113 rap_control_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_dyn32_phy32
 Checking test 114 hrrr_control_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 190.729947
-  0: The maximum resident set size (KB)                   = 954360
+  0: The total amount of wall time                        = 191.526185
+  0: The maximum resident set size (KB)                   = 950824
 
-Test 114 hrrr_control_dyn32_phy32 PASS
+Test 114 hrrr_control_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_2threads_dyn32_phy32
 Checking test 115 rap_2threads_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210323.060000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 364.805529
-  0: The maximum resident set size (KB)                   = 1017212
+  0: The total amount of wall time                        = 372.641579
+  0: The maximum resident set size (KB)                   = 981160
 
-Test 115 rap_2threads_dyn32_phy32 PASS
+Test 115 rap_2threads_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_2threads_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_2threads_dyn32_phy32
 Checking test 116 hrrr_control_2threads_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 178.711789
-  0: The maximum resident set size (KB)                   = 924708
+  0: The total amount of wall time                        = 175.595181
+  0: The maximum resident set size (KB)                   = 914264
 
-Test 116 hrrr_control_2threads_dyn32_phy32 PASS
+Test 116 hrrr_control_2threads_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_decomp_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_decomp_dyn32_phy32
 Checking test 117 hrrr_control_decomp_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 202.546427
-  0: The maximum resident set size (KB)                   = 890920
+  0: The total amount of wall time                        = 200.452825
+  0: The maximum resident set size (KB)                   = 888824
 
-Test 117 hrrr_control_decomp_dyn32_phy32 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_restart_dyn32_phy32
-Checking test 118 rap_restart_dyn32_phy32 results ....
- Comparing sfcf012.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 285.105642
-  0: The maximum resident set size (KB)                   = 945252
-
-Test 118 rap_restart_dyn32_phy32 PASS
+Test 117 hrrr_control_decomp_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_restart_dyn32_phy32
-Checking test 119 hrrr_control_restart_dyn32_phy32 results ....
- Comparing sfcf012.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF12 .........OK
-
-  0: The total amount of wall time                        = 99.984244
-  0: The maximum resident set size (KB)                   = 859356
-
-Test 119 hrrr_control_restart_dyn32_phy32 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_control_dyn64_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_dyn64_phy32
 Checking test 120 rap_control_dyn64_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.180000.coupler.res .........OK
- Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf009.nc ............MISSING baseline
+ Comparing sfcf012.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf009.nc ............MISSING baseline
+ Comparing atmf012.nc ............MISSING baseline
+ Comparing GFSFLX.GrbF00 ............MISSING baseline
+ Comparing GFSFLX.GrbF09 ............MISSING baseline
+ Comparing GFSFLX.GrbF12 ............MISSING baseline
+ Comparing GFSPRS.GrbF00 ............MISSING baseline
+ Comparing GFSPRS.GrbF09 ............MISSING baseline
+ Comparing GFSPRS.GrbF12 ............MISSING baseline
+ Comparing RESTART/20210322.180000.coupler.res ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20210322.180000.sfc_data.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 247.280544
-  0: The maximum resident set size (KB)                   = 956992
+  0: The total amount of wall time                        = 248.091960
+  0: The maximum resident set size (KB)                   = 966532
 
-Test 120 rap_control_dyn64_phy32 PASS
+Test 120 rap_control_dyn64_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_debug_dyn32_phy32
 Checking test 121 rap_control_debug_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 268.225733
-  0: The maximum resident set size (KB)                   = 1057100
+  0: The total amount of wall time                        = 261.310953
+  0: The maximum resident set size (KB)                   = 1058124
 
-Test 121 rap_control_debug_dyn32_phy32 PASS
+Test 121 rap_control_debug_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hrrr_control_debug_dyn32_phy32
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_debug_dyn32_phy32
 Checking test 122 hrrr_control_debug_dyn32_phy32 results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 257.838533
-  0: The maximum resident set size (KB)                   = 1051200
+  0: The total amount of wall time                        = 260.285779
+  0: The maximum resident set size (KB)                   = 1050008
 
-Test 122 hrrr_control_debug_dyn32_phy32 PASS
+Test 122 hrrr_control_debug_dyn32_phy32 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/rap_control_dyn64_phy32_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_dyn64_phy32_debug
 Checking test 123 rap_control_dyn64_phy32_debug results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf001.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf001.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 273.172790
-  0: The maximum resident set size (KB)                   = 1062104
+  0: The total amount of wall time                        = 274.942910
+  0: The maximum resident set size (KB)                   = 1102260
 
-Test 123 rap_control_dyn64_phy32_debug PASS
+Test 123 rap_control_dyn64_phy32_debug FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_atm
 Checking test 124 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 234.895265
-  0: The maximum resident set size (KB)                   = 1051256
+  0: The total amount of wall time                        = 238.539041
+  0: The maximum resident set size (KB)                   = 1039188
 
 Test 124 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_atm_thompson_gfdlsf
 Checking test 125 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 320.191891
-  0: The maximum resident set size (KB)                   = 1415096
+  0: The total amount of wall time                        = 316.269277
+  0: The maximum resident set size (KB)                   = 1407328
 
 Test 125 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_atm_ocn
 Checking test 126 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4234,14 +4056,14 @@ Checking test 126 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 377.785986
-  0: The maximum resident set size (KB)                   = 1227920
+  0: The total amount of wall time                        = 379.932095
+  0: The maximum resident set size (KB)                   = 1217656
 
 Test 126 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_atm_wav
 Checking test 127 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4250,14 +4072,14 @@ Checking test 127 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 746.663158
-  0: The maximum resident set size (KB)                   = 1221788
+  0: The total amount of wall time                        = 739.194924
+  0: The maximum resident set size (KB)                   = 1260544
 
 Test 127 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_atm_ocn_wav
 Checking test 128 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4268,28 +4090,28 @@ Checking test 128 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 845.179442
-  0: The maximum resident set size (KB)                   = 1273348
+  0: The total amount of wall time                        = 848.076246
+  0: The maximum resident set size (KB)                   = 1269716
 
 Test 128 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_1nest_atm
 Checking test 129 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 318.391777
-  0: The maximum resident set size (KB)                   = 502604
+  0: The total amount of wall time                        = 317.024085
+  0: The maximum resident set size (KB)                   = 500264
 
 Test 129 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_telescopic_2nests_atm
 Checking test 130 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4298,28 +4120,28 @@ Checking test 130 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 365.642637
-  0: The maximum resident set size (KB)                   = 509916
+  0: The total amount of wall time                        = 361.377934
+  0: The maximum resident set size (KB)                   = 508168
 
 Test 130 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_global_1nest_atm
 Checking test 131 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 145.568114
-  0: The maximum resident set size (KB)                   = 348880
+  0: The total amount of wall time                        = 146.263141
+  0: The maximum resident set size (KB)                   = 350424
 
 Test 131 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_global_multiple_4nests_atm
 Checking test 132 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4337,14 +4159,14 @@ Checking test 132 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 415.228383
-  0: The maximum resident set size (KB)                   = 450384
+  0: The total amount of wall time                        = 409.451892
+  0: The maximum resident set size (KB)                   = 448784
 
 Test 132 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_specified_moving_1nest_atm
 Checking test 133 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4353,28 +4175,28 @@ Checking test 133 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 202.100103
-  0: The maximum resident set size (KB)                   = 520872
+  0: The total amount of wall time                        = 201.797469
+  0: The maximum resident set size (KB)                   = 520556
 
 Test 133 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_storm_following_1nest_atm
 Checking test 134 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 192.933637
-  0: The maximum resident set size (KB)                   = 518288
+  0: The total amount of wall time                        = 190.219556
+  0: The maximum resident set size (KB)                   = 523236
 
 Test 134 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4383,42 +4205,42 @@ Checking test 135 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 224.171361
-  0: The maximum resident set size (KB)                   = 561276
+  0: The total amount of wall time                        = 222.138055
+  0: The maximum resident set size (KB)                   = 562608
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_global_storm_following_1nest_atm
 Checking test 136 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 58.088904
-  0: The maximum resident set size (KB)                   = 370812
+  0: The total amount of wall time                        = 60.109236
+  0: The maximum resident set size (KB)                   = 371304
 
 Test 136 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 137 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 710.846789
-  0: The maximum resident set size (KB)                   = 581456
+  0: The total amount of wall time                        = 708.230226
+  0: The maximum resident set size (KB)                   = 583732
 
 Test 137 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4429,14 +4251,14 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 480.993614
-  0: The maximum resident set size (KB)                   = 617900
+  0: The total amount of wall time                        = 482.259172
+  0: The maximum resident set size (KB)                   = 620732
 
 Test 138 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_docn
 Checking test 139 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4444,14 +4266,14 @@ Checking test 139 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 357.807955
-  0: The maximum resident set size (KB)                   = 1235016
+  0: The total amount of wall time                        = 352.412101
+  0: The maximum resident set size (KB)                   = 1232524
 
 Test 139 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_docn_oisst
 Checking test 140 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4459,258 +4281,229 @@ Checking test 140 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.568212
-  0: The maximum resident set size (KB)                   = 1217064
+  0: The total amount of wall time                        = 357.689560
+  0: The maximum resident set size (KB)                   = 1215716
 
 Test 140 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hafs_regional_datm_cdeps
 Checking test 141 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 951.852748
-  0: The maximum resident set size (KB)                   = 1036716
+  0: The total amount of wall time                        = 952.588282
+  0: The maximum resident set size (KB)                   = 1044020
 
 Test 141 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_control_cfsr
 Checking test 142 datm_cdeps_control_cfsr results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 157.197818
- 0: The maximum resident set size (KB)                   = 1059736
+ 0: The total amount of wall time                        = 153.286874
+ 0: The maximum resident set size (KB)                   = 1062580
 
-Test 142 datm_cdeps_control_cfsr PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_restart_cfsr
-Checking test 143 datm_cdeps_restart_cfsr results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
- 0: The total amount of wall time                        = 95.211874
- 0: The maximum resident set size (KB)                   = 1007512
-
-Test 143 datm_cdeps_restart_cfsr PASS
+Test 142 datm_cdeps_control_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_control_gefs
 Checking test 144 datm_cdeps_control_gefs results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 153.008663
- 0: The maximum resident set size (KB)                   = 964348
+ 0: The total amount of wall time                        = 147.851364
+ 0: The maximum resident set size (KB)                   = 966652
 
-Test 144 datm_cdeps_control_gefs PASS
+Test 144 datm_cdeps_control_gefs FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_iau_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_iau_gefs
 Checking test 145 datm_cdeps_iau_gefs results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 153.685467
- 0: The maximum resident set size (KB)                   = 961332
+ 0: The total amount of wall time                        = 153.086504
+ 0: The maximum resident set size (KB)                   = 963168
 
-Test 145 datm_cdeps_iau_gefs PASS
+Test 145 datm_cdeps_iau_gefs FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_stochy_gefs
 Checking test 146 datm_cdeps_stochy_gefs results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 152.669300
- 0: The maximum resident set size (KB)                   = 964044
+ 0: The total amount of wall time                        = 151.073239
+ 0: The maximum resident set size (KB)                   = 966184
 
-Test 146 datm_cdeps_stochy_gefs PASS
+Test 146 datm_cdeps_stochy_gefs FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_ciceC_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_ciceC_cfsr
 Checking test 147 datm_cdeps_ciceC_cfsr results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 158.258610
- 0: The maximum resident set size (KB)                   = 1055764
+ 0: The total amount of wall time                        = 154.478362
+ 0: The maximum resident set size (KB)                   = 1062744
 
-Test 147 datm_cdeps_ciceC_cfsr PASS
+Test 147 datm_cdeps_ciceC_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_bulk_cfsr
 Checking test 148 datm_cdeps_bulk_cfsr results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 157.883028
- 0: The maximum resident set size (KB)                   = 1056736
+ 0: The total amount of wall time                        = 153.678352
+ 0: The maximum resident set size (KB)                   = 1065804
 
-Test 148 datm_cdeps_bulk_cfsr PASS
+Test 148 datm_cdeps_bulk_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_bulk_gefs
 Checking test 149 datm_cdeps_bulk_gefs results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 151.564626
- 0: The maximum resident set size (KB)                   = 965012
+ 0: The total amount of wall time                        = 152.308809
+ 0: The maximum resident set size (KB)                   = 961960
 
-Test 149 datm_cdeps_bulk_gefs PASS
+Test 149 datm_cdeps_bulk_gefs FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_mx025_cfsr
 Checking test 150 datm_cdeps_mx025_cfsr results ....
- Comparing RESTART/20111001.120000.MOM.res.nc .........OK
- Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
- Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
- Comparing RESTART/20111001.120000.MOM.res_3.nc .........OK
- Comparing RESTART/iced.2011-10-01-43200.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/20111001.120000.MOM.res_1.nc ............MISSING baseline
+ Comparing RESTART/20111001.120000.MOM.res_2.nc ............MISSING baseline
+ Comparing RESTART/20111001.120000.MOM.res_3.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-01-43200.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 416.095646
-  0: The maximum resident set size (KB)                   = 871376
+  0: The total amount of wall time                        = 416.023679
+  0: The maximum resident set size (KB)                   = 884160
 
-Test 150 datm_cdeps_mx025_cfsr PASS
+Test 150 datm_cdeps_mx025_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_mx025_gefs
 Checking test 151 datm_cdeps_mx025_gefs results ....
- Comparing RESTART/20111001.120000.MOM.res.nc .........OK
- Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
- Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
- Comparing RESTART/20111001.120000.MOM.res_3.nc .........OK
- Comparing RESTART/iced.2011-10-01-43200.nc .........OK
- Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/20111001.120000.MOM.res_1.nc ............MISSING baseline
+ Comparing RESTART/20111001.120000.MOM.res_2.nc ............MISSING baseline
+ Comparing RESTART/20111001.120000.MOM.res_3.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-01-43200.nc ............MISSING baseline
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 411.162821
-  0: The maximum resident set size (KB)                   = 933668
+  0: The total amount of wall time                        = 435.041871
+  0: The maximum resident set size (KB)                   = 936316
 
-Test 151 datm_cdeps_mx025_gefs PASS
+Test 151 datm_cdeps_mx025_gefs FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_multiple_files_cfsr
 Checking test 152 datm_cdeps_multiple_files_cfsr results ....
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 157.334330
- 0: The maximum resident set size (KB)                   = 1059956
+ 0: The total amount of wall time                        = 153.930114
+ 0: The maximum resident set size (KB)                   = 1058160
 
-Test 152 datm_cdeps_multiple_files_cfsr PASS
+Test 152 datm_cdeps_multiple_files_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_3072x1536_cfsr
 Checking test 153 datm_cdeps_3072x1536_cfsr results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 217.989566
- 0: The maximum resident set size (KB)                   = 2370168
+ 0: The total amount of wall time                        = 217.342050
+ 0: The maximum resident set size (KB)                   = 2360808
 
-Test 153 datm_cdeps_3072x1536_cfsr PASS
+Test 153 datm_cdeps_3072x1536_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_gfs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_gfs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_gfs
 Checking test 154 datm_cdeps_gfs results ....
- Comparing RESTART/20210323.060000.MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing RESTART/20210323.060000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2021-03-23-21600.nc ............MISSING baseline
+ Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 229.116823
- 0: The maximum resident set size (KB)                   = 2355920
+ 0: The total amount of wall time                        = 222.523263
+ 0: The maximum resident set size (KB)                   = 2366340
 
-Test 154 datm_cdeps_gfs PASS
+Test 154 datm_cdeps_gfs FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_debug_cfsr
 Checking test 155 datm_cdeps_debug_cfsr results ....
- Comparing RESTART/20111001.060000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-01-21600.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
+ Comparing RESTART/20111001.060000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-01-21600.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 357.368363
- 0: The maximum resident set size (KB)                   = 977352
+ 0: The total amount of wall time                        = 357.615414
+ 0: The maximum resident set size (KB)                   = 978028
 
-Test 155 datm_cdeps_debug_cfsr PASS
+Test 155 datm_cdeps_debug_cfsr FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_control_cfsr_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_control_cfsr_faster
 Checking test 156 datm_cdeps_control_cfsr_faster results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+ Comparing RESTART/20111002.000000.MOM.res.nc ............MISSING baseline
+ Comparing RESTART/iced.2011-10-02-00000.nc ............MISSING baseline
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc ............MISSING baseline
 
- 0: The total amount of wall time                        = 157.696734
- 0: The maximum resident set size (KB)                   = 1057400
+ 0: The total amount of wall time                        = 156.381175
+ 0: The maximum resident set size (KB)                   = 1047256
 
-Test 156 datm_cdeps_control_cfsr_faster PASS
+Test 156 datm_cdeps_control_cfsr_faster FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_lnd_gswp3
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_lnd_gswp3
 Checking test 157 datm_cdeps_lnd_gswp3 results ....
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc ............MISSING baseline
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc ............MISSING baseline
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc ............MISSING baseline
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc ............MISSING baseline
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc ............MISSING baseline
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 7.660018
-  0: The maximum resident set size (KB)                   = 260412
+  0: The total amount of wall time                        = 6.984228
+  0: The maximum resident set size (KB)                   = 258752
 
-Test 157 datm_cdeps_lnd_gswp3 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/datm_cdeps_lnd_gswp3_rst
-Checking test 158 datm_cdeps_lnd_gswp3_rst results ....
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
- Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 13.128830
-  0: The maximum resident set size (KB)                   = 258232
-
-Test 158 datm_cdeps_lnd_gswp3_rst PASS
+Test 157 datm_cdeps_lnd_gswp3 FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_atmlnd_sbs
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_p8_atmlnd_sbs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_p8_atmlnd_sbs
 Checking test 159 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4795,14 +4588,14 @@ Checking test 159 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.707979
-  0: The maximum resident set size (KB)                   = 1595292
+  0: The total amount of wall time                        = 202.621440
+  0: The maximum resident set size (KB)                   = 1598040
 
 Test 159 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmwav_control_noaero_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/atmwav_control_noaero_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmwav_control_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/atmwav_control_noaero_p8
 Checking test 160 atmwav_control_noaero_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4845,14 +4638,14 @@ Checking test 160 atmwav_control_noaero_p8 results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 94.450471
-  0: The maximum resident set size (KB)                   = 1628312
+  0: The total amount of wall time                        = 93.820722
+  0: The maximum resident set size (KB)                   = 1631716
 
 Test 160 atmwav_control_noaero_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_atmwav
 Checking test 161 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4896,14 +4689,14 @@ Checking test 161 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 89.053826
-  0: The maximum resident set size (KB)                   = 658392
+  0: The total amount of wall time                        = 87.521036
+  0: The maximum resident set size (KB)                   = 643564
 
 Test 161 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/atmaero_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/atmaero_control_p8
 Checking test 162 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4947,14 +4740,14 @@ Checking test 162 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.922653
-  0: The maximum resident set size (KB)                   = 2977600
+  0: The total amount of wall time                        = 231.325398
+  0: The maximum resident set size (KB)                   = 2969680
 
 Test 162 atmaero_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/atmaero_control_p8_rad
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/atmaero_control_p8_rad
 Checking test 163 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4998,14 +4791,14 @@ Checking test 163 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 293.423564
-  0: The maximum resident set size (KB)                   = 3035352
+  0: The total amount of wall time                        = 281.006745
+  0: The maximum resident set size (KB)                   = 3023840
 
 Test 163 atmaero_control_p8_rad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad_micro
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/atmaero_control_p8_rad_micro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/atmaero_control_p8_rad_micro
 Checking test 164 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5049,37 +4842,37 @@ Checking test 164 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 291.242830
-  0: The maximum resident set size (KB)                   = 3046684
+  0: The total amount of wall time                        = 283.338181
+  0: The maximum resident set size (KB)                   = 3057180
 
 Test 164 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_atmaq
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_atmaq
 Checking test 165 regional_atmaq results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf003.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf003.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing RESTART/20190801.180000.coupler.res .........OK
- Comparing RESTART/20190801.180000.fv_core.res.nc .........OK
- Comparing RESTART/20190801.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20190801.180000.phy_data.nc .........OK
- Comparing RESTART/20190801.180000.sfc_data.nc .........OK
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf003.nc ............MISSING baseline
+ Comparing sfcf006.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf003.nc ............MISSING baseline
+ Comparing atmf006.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.coupler.res ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.phy_data.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.sfc_data.nc ............MISSING baseline
 
-  0: The total amount of wall time                        = 649.171066
-  0: The maximum resident set size (KB)                   = 1451496
+  0: The total amount of wall time                        = 645.553947
+  0: The maximum resident set size (KB)                   = 1449952
 
-Test 165 regional_atmaq PASS
+Test 165 regional_atmaq FAIL Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_debug
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_atmaq_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_atmaq_debug
 Checking test 166 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5093,15 +4886,1655 @@ Checking test 166 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1201.947439
-  0: The maximum resident set size (KB)                   = 1374860
+  0: The total amount of wall time                        = 1198.667434
+  0: The maximum resident set size (KB)                   = 1386704
 
 Test 166 regional_atmaq_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_faster
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_27609/regional_atmaq_faster
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_atmaq_faster
 Checking test 167 regional_atmaq_faster results ....
+ Comparing sfcf000.nc ............MISSING baseline
+ Comparing sfcf003.nc ............MISSING baseline
+ Comparing sfcf006.nc ............MISSING baseline
+ Comparing atmf000.nc ............MISSING baseline
+ Comparing atmf003.nc ............MISSING baseline
+ Comparing atmf006.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.coupler.res ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.phy_data.nc ............MISSING baseline
+ Comparing RESTART/20190801.180000.sfc_data.nc ............MISSING baseline
+
+  0: The total amount of wall time                        = 560.534367
+  0: The maximum resident set size (KB)                   = 1455460
+
+Test 167 regional_atmaq_faster FAIL Tries: 2
+
+FAILED TESTS: 
+Test rap_control 058 failed in check_result failed 
+Test rap_control 058 failed in run_test failed 
+Test regional_spp_sppt_shum_skeb 059 failed in check_result failed 
+Test regional_spp_sppt_shum_skeb 059 failed in run_test failed 
+Test rap_decomp 060 failed in check_result failed 
+Test rap_decomp 060 failed in run_test failed 
+Test rap_2threads 061 failed in check_result failed 
+Test rap_2threads 061 failed in run_test failed 
+Test rap_sfcdiff 063 failed in check_result failed 
+Test rap_sfcdiff 063 failed in run_test failed 
+Test rap_sfcdiff_decomp 064 failed in check_result failed 
+Test rap_sfcdiff_decomp 064 failed in run_test failed 
+Test hrrr_control 066 failed in check_result failed 
+Test hrrr_control 066 failed in run_test failed 
+Test hrrr_control_decomp 067 failed in check_result failed 
+Test hrrr_control_decomp 067 failed in run_test failed 
+Test hrrr_control_2threads 068 failed in check_result failed 
+Test hrrr_control_2threads 068 failed in run_test failed 
+Test rrfs_v1beta 070 failed in check_result failed 
+Test rrfs_v1beta 070 failed in run_test failed 
+Test rrfs_v1nssl 071 failed in check_result failed 
+Test rrfs_v1nssl 071 failed in run_test failed 
+Test rrfs_v1nssl_nohailnoccn 072 failed in check_result failed 
+Test rrfs_v1nssl_nohailnoccn 072 failed in run_test failed 
+Test rrfs_smoke_conus13km_hrrr_warm 073 failed in check_result failed 
+Test rrfs_smoke_conus13km_hrrr_warm 073 failed in run_test failed 
+Test rrfs_smoke_conus13km_hrrr_warm_2threads 074 failed in check_result failed 
+Test rrfs_smoke_conus13km_hrrr_warm_2threads 074 failed in run_test failed 
+Test rrfs_conus13km_hrrr_warm 075 failed in check_result failed 
+Test rrfs_conus13km_hrrr_warm 075 failed in run_test failed 
+Test rrfs_smoke_conus13km_radar_tten_warm 076 failed in check_result failed 
+Test rrfs_smoke_conus13km_radar_tten_warm 076 failed in run_test failed 
+Test rrfs_smoke_conus13km_hrrr_warm_debug 084 failed in check_result failed 
+Test rrfs_smoke_conus13km_hrrr_warm_debug 084 failed in run_test failed 
+Test rrfs_smoke_conus13km_hrrr_warm_debug_2threads 085 failed in check_result failed 
+Test rrfs_smoke_conus13km_hrrr_warm_debug_2threads 085 failed in run_test failed 
+Test rrfs_conus13km_hrrr_warm_debug 086 failed in check_result failed 
+Test rrfs_conus13km_hrrr_warm_debug 086 failed in run_test failed 
+Test control_CubedSphereGrid_debug 087 failed in check_result failed 
+Test control_CubedSphereGrid_debug 087 failed in run_test failed 
+Test control_wrtGauss_netcdf_parallel_debug 088 failed in check_result failed 
+Test control_wrtGauss_netcdf_parallel_debug 088 failed in run_test failed 
+Test control_stochy_debug 089 failed in check_result failed 
+Test control_stochy_debug 089 failed in run_test failed 
+Test control_lndp_debug 090 failed in check_result failed 
+Test control_lndp_debug 090 failed in run_test failed 
+Test control_csawmg_debug 091 failed in check_result failed 
+Test control_csawmg_debug 091 failed in run_test failed 
+Test control_csawmgt_debug 092 failed in check_result failed 
+Test control_csawmgt_debug 092 failed in run_test failed 
+Test control_ras_debug 093 failed in check_result failed 
+Test control_ras_debug 093 failed in run_test failed 
+Test control_diag_debug 094 failed in check_result failed 
+Test control_diag_debug 094 failed in run_test failed 
+Test control_debug_p8 095 failed in check_result failed 
+Test control_debug_p8 095 failed in run_test failed 
+Test regional_debug 096 failed in check_result failed 
+Test regional_debug 096 failed in run_test failed 
+Test rap_control_debug 097 failed in check_result failed 
+Test rap_control_debug 097 failed in run_test failed 
+Test hrrr_control_debug 098 failed in check_result failed 
+Test hrrr_control_debug 098 failed in run_test failed 
+Test rap_unified_drag_suite_debug 099 failed in check_result failed 
+Test rap_unified_drag_suite_debug 099 failed in run_test failed 
+Test rap_diag_debug 100 failed in check_result failed 
+Test rap_diag_debug 100 failed in run_test failed 
+Test rap_cires_ugwp_debug 101 failed in check_result failed 
+Test rap_cires_ugwp_debug 101 failed in run_test failed 
+Test rap_unified_ugwp_debug 102 failed in check_result failed 
+Test rap_unified_ugwp_debug 102 failed in run_test failed 
+Test rap_lndp_debug 103 failed in check_result failed 
+Test rap_lndp_debug 103 failed in run_test failed 
+Test rap_progcld_thompson_debug 104 failed in check_result failed 
+Test rap_progcld_thompson_debug 104 failed in run_test failed 
+Test rap_noah_debug 105 failed in check_result failed 
+Test rap_noah_debug 105 failed in run_test failed 
+Test rap_sfcdiff_debug 106 failed in check_result failed 
+Test rap_sfcdiff_debug 106 failed in run_test failed 
+Test rap_noah_sfcdiff_cires_ugwp_debug 107 failed in check_result failed 
+Test rap_noah_sfcdiff_cires_ugwp_debug 107 failed in run_test failed 
+Test rrfs_v1beta_debug 108 failed in check_result failed 
+Test rrfs_v1beta_debug 108 failed in run_test failed 
+Test rap_clm_lake_debug 109 failed in check_result failed 
+Test rap_clm_lake_debug 109 failed in run_test failed 
+Test rap_flake_debug 110 failed in check_result failed 
+Test rap_flake_debug 110 failed in run_test failed 
+Test control_wam_debug 111 failed in check_result failed 
+Test control_wam_debug 111 failed in run_test failed 
+Test regional_spp_sppt_shum_skeb_dyn32_phy32 112 failed in check_result failed 
+Test regional_spp_sppt_shum_skeb_dyn32_phy32 112 failed in run_test failed 
+Test rap_control_dyn32_phy32 113 failed in check_result failed 
+Test rap_control_dyn32_phy32 113 failed in run_test failed 
+Test hrrr_control_dyn32_phy32 114 failed in check_result failed 
+Test hrrr_control_dyn32_phy32 114 failed in run_test failed 
+Test rap_2threads_dyn32_phy32 115 failed in check_result failed 
+Test rap_2threads_dyn32_phy32 115 failed in run_test failed 
+Test hrrr_control_2threads_dyn32_phy32 116 failed in check_result failed 
+Test hrrr_control_2threads_dyn32_phy32 116 failed in run_test failed 
+Test hrrr_control_decomp_dyn32_phy32 117 failed in check_result failed 
+Test hrrr_control_decomp_dyn32_phy32 117 failed in run_test failed 
+Test rap_control_dyn64_phy32 120 failed in check_result failed 
+Test rap_control_dyn64_phy32 120 failed in run_test failed 
+Test rap_control_debug_dyn32_phy32 121 failed in check_result failed 
+Test rap_control_debug_dyn32_phy32 121 failed in run_test failed 
+Test hrrr_control_debug_dyn32_phy32 122 failed in check_result failed 
+Test hrrr_control_debug_dyn32_phy32 122 failed in run_test failed 
+Test rap_control_dyn64_phy32_debug 123 failed in check_result failed 
+Test rap_control_dyn64_phy32_debug 123 failed in run_test failed 
+Test datm_cdeps_control_cfsr 142 failed in check_result failed 
+Test datm_cdeps_control_cfsr 142 failed in run_test failed 
+Test datm_cdeps_control_gefs 144 failed in check_result failed 
+Test datm_cdeps_control_gefs 144 failed in run_test failed 
+Test datm_cdeps_iau_gefs 145 failed in check_result failed 
+Test datm_cdeps_iau_gefs 145 failed in run_test failed 
+Test datm_cdeps_stochy_gefs 146 failed in check_result failed 
+Test datm_cdeps_stochy_gefs 146 failed in run_test failed 
+Test datm_cdeps_ciceC_cfsr 147 failed in check_result failed 
+Test datm_cdeps_ciceC_cfsr 147 failed in run_test failed 
+Test datm_cdeps_bulk_cfsr 148 failed in check_result failed 
+Test datm_cdeps_bulk_cfsr 148 failed in run_test failed 
+Test datm_cdeps_bulk_gefs 149 failed in check_result failed 
+Test datm_cdeps_bulk_gefs 149 failed in run_test failed 
+Test datm_cdeps_mx025_cfsr 150 failed in check_result failed 
+Test datm_cdeps_mx025_cfsr 150 failed in run_test failed 
+Test datm_cdeps_mx025_gefs 151 failed in check_result failed 
+Test datm_cdeps_mx025_gefs 151 failed in run_test failed 
+Test datm_cdeps_multiple_files_cfsr 152 failed in check_result failed 
+Test datm_cdeps_multiple_files_cfsr 152 failed in run_test failed 
+Test datm_cdeps_3072x1536_cfsr 153 failed in check_result failed 
+Test datm_cdeps_3072x1536_cfsr 153 failed in run_test failed 
+Test datm_cdeps_gfs 154 failed in check_result failed 
+Test datm_cdeps_gfs 154 failed in run_test failed 
+Test datm_cdeps_debug_cfsr 155 failed in check_result failed 
+Test datm_cdeps_debug_cfsr 155 failed in run_test failed 
+Test datm_cdeps_control_cfsr_faster 156 failed in check_result failed 
+Test datm_cdeps_control_cfsr_faster 156 failed in run_test failed 
+Test datm_cdeps_lnd_gswp3 157 failed in check_result failed 
+Test datm_cdeps_lnd_gswp3 157 failed in run_test failed 
+Test regional_atmaq 165 failed in check_result failed 
+Test regional_atmaq 165 failed in run_test failed 
+Test regional_atmaq_faster 167 failed in check_result failed 
+Test regional_atmaq_faster 167 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Fri May 12 07:23:50 UTC 2023
+Elapsed time: 18h:35m:35s. Have a nice day!
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control
+Checking test 01 rap_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 460.870467
+  0: The maximum resident set size (KB)                   = 1048092
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_spp_sppt_shum_skeb
+Checking test 2 regional_spp_sppt_shum_skeb results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF01 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF01 .........OK
+
+  0: The total amount of wall time                        = 231.765169
+  0: The maximum resident set size (KB)                   = 1181664
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_decomp
+Checking test 3 rap_decomp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 481.737377
+  0: The maximum resident set size (KB)                   = 992032
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_2threads
+Checking test 4 rap_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 437.879086
+  0: The maximum resident set size (KB)                   = 1101756
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_sfcdiff
+Checking test 5 rap_sfcdiff results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 460.389691
+  0: The maximum resident set size (KB)                   = 1045744
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_sfcdiff_decomp
+Checking test 6 rap_sfcdiff_decomp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 485.026699
+  0: The maximum resident set size (KB)                   = 997320
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control
+Checking test 7 hrrr_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 428.426870
+  0: The maximum resident set size (KB)                   = 1045188
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_decomp
+Checking test 8 hrrr_control_decomp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 448.792812
+  0: The maximum resident set size (KB)                   = 998780
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_2threads
+Checking test 9 hrrr_control_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 395.896439
+  0: The maximum resident set size (KB)                   = 1076848
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1beta
+Checking test 10 rrfs_v1beta results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 457.112711
+  0: The maximum resident set size (KB)                   = 1049104
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1nssl
+Checking test 11 rrfs_v1nssl results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 536.557757
+  0: The maximum resident set size (KB)                   = 665360
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1nssl_nohailnoccn
+Checking test 12 rrfs_v1nssl_nohailnoccn results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 522.726999
+  0: The maximum resident set size (KB)                   = 752812
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm
+Checking test 13 rrfs_smoke_conus13km_hrrr_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 152.138144
+  0: The maximum resident set size (KB)                   = 1031220
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm_2threads
+Checking test 14 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 92.747663
+  0: The maximum resident set size (KB)                   = 942036
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_conus13km_hrrr_warm
+Checking test 15 rrfs_conus13km_hrrr_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 133.503022
+  0: The maximum resident set size (KB)                   = 979936
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_radar_tten_warm
+Checking test 16 rrfs_smoke_conus13km_radar_tten_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 152.491705
+  0: The maximum resident set size (KB)                   = 1030160
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm_debug
+Checking test 17 rrfs_smoke_conus13km_hrrr_warm_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 832.711387
+  0: The maximum resident set size (KB)                   = 1056876
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+Checking test 18 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 465.208216
+  0: The maximum resident set size (KB)                   = 967464
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_conus13km_hrrr_warm_debug
+Checking test 19 rrfs_conus13km_hrrr_warm_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 745.046241
+  0: The maximum resident set size (KB)                   = 1013404
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_CubedSphereGrid_debug
+Checking test 20 control_CubedSphereGrid_debug results ....
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf001.tile1.nc .........OK
+ Comparing sfcf001.tile2.nc .........OK
+ Comparing sfcf001.tile3.nc .........OK
+ Comparing sfcf001.tile4.nc .........OK
+ Comparing sfcf001.tile5.nc .........OK
+ Comparing sfcf001.tile6.nc .........OK
+ Comparing atmf000.tile1.nc .........OK
+ Comparing atmf000.tile2.nc .........OK
+ Comparing atmf000.tile3.nc .........OK
+ Comparing atmf000.tile4.nc .........OK
+ Comparing atmf000.tile5.nc .........OK
+ Comparing atmf000.tile6.nc .........OK
+ Comparing atmf001.tile1.nc .........OK
+ Comparing atmf001.tile2.nc .........OK
+ Comparing atmf001.tile3.nc .........OK
+ Comparing atmf001.tile4.nc .........OK
+ Comparing atmf001.tile5.nc .........OK
+ Comparing atmf001.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 150.078971
+  0: The maximum resident set size (KB)                   = 763448
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_wrtGauss_netcdf_parallel_debug
+Checking test 21 control_wrtGauss_netcdf_parallel_debug results ....
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 145.638031
+  0: The maximum resident set size (KB)                   = 786808
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_stochy_debug
+Checking test 22 control_stochy_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 165.102886
+  0: The maximum resident set size (KB)                   = 794524
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_lndp_debug
+Checking test 23 control_lndp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 146.621086
+  0: The maximum resident set size (KB)                   = 790080
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_csawmg_debug
+Checking test 24 control_csawmg_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 223.535451
+  0: The maximum resident set size (KB)                   = 838036
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_csawmgt_debug
+Checking test 25 control_csawmgt_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 224.238890
+  0: The maximum resident set size (KB)                   = 839484
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_ras_debug
+Checking test 26 control_ras_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 148.821949
+  0: The maximum resident set size (KB)                   = 797996
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_diag_debug
+Checking test 27 control_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 154.304266
+  0: The maximum resident set size (KB)                   = 846092
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_debug_p8
+Checking test 28 control_debug_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 161.708863
+  0: The maximum resident set size (KB)                   = 1610228
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_debug
+Checking test 29 regional_debug results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+
+  0: The total amount of wall time                        = 980.782012
+  0: The maximum resident set size (KB)                   = 876904
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_debug
+Checking test 30 rap_control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 273.890726
+  0: The maximum resident set size (KB)                   = 1163616
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_debug
+Checking test 31 hrrr_control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 264.999828
+  0: The maximum resident set size (KB)                   = 1163356
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_unified_drag_suite_debug
+Checking test 32 rap_unified_drag_suite_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 271.532738
+  0: The maximum resident set size (KB)                   = 1168140
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_diag_debug
+Checking test 33 rap_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 287.003819
+  0: The maximum resident set size (KB)                   = 1254120
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_cires_ugwp_debug
+Checking test 34 rap_cires_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 276.081259
+  0: The maximum resident set size (KB)                   = 1157092
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_unified_ugwp_debug
+Checking test 35 rap_unified_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 277.518716
+  0: The maximum resident set size (KB)                   = 1174452
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_lndp_debug
+Checking test 36 rap_lndp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 275.802324
+  0: The maximum resident set size (KB)                   = 1166704
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_progcld_thompson_debug
+Checking test 37 rap_progcld_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 269.962379
+  0: The maximum resident set size (KB)                   = 1136576
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_noah_debug
+Checking test 38 rap_noah_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 265.084765
+  0: The maximum resident set size (KB)                   = 1164764
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_sfcdiff_debug
+Checking test 39 rap_sfcdiff_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 271.177082
+  0: The maximum resident set size (KB)                   = 1157700
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 40 rap_noah_sfcdiff_cires_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 456.268386
+  0: The maximum resident set size (KB)                   = 1168632
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rrfs_v1beta_debug
+Checking test 41 rrfs_v1beta_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 265.976428
+  0: The maximum resident set size (KB)                   = 1162316
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_clm_lake_debug
+Checking test 42 rap_clm_lake_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 326.041910
+  0: The maximum resident set size (KB)                   = 1171816
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_flake_debug
+Checking test 43 rap_flake_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 271.298331
+  0: The maximum resident set size (KB)                   = 1167068
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/control_wam_debug
+Checking test 44 control_wam_debug results ....
+ Comparing sfcf019.nc .........OK
+ Comparing atmf019.nc .........OK
+
+  0: The total amount of wall time                        = 268.602090
+  0: The maximum resident set size (KB)                   = 519324
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_spp_sppt_shum_skeb_dyn32_phy32
+Checking test 45 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF01 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF01 .........OK
+
+  0: The total amount of wall time                        = 220.599977
+  0: The maximum resident set size (KB)                   = 1079000
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_dyn32_phy32
+Checking test 46 rap_control_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 382.479354
+  0: The maximum resident set size (KB)                   = 994612
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_dyn32_phy32
+Checking test 47 hrrr_control_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 191.526185
+  0: The maximum resident set size (KB)                   = 950824
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_2threads_dyn32_phy32
+Checking test 48 rap_2threads_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 372.641579
+  0: The maximum resident set size (KB)                   = 981160
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_2threads_dyn32_phy32
+Checking test 49 hrrr_control_2threads_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 175.595181
+  0: The maximum resident set size (KB)                   = 914264
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_decomp_dyn32_phy32
+Checking test 50 hrrr_control_decomp_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 200.452825
+  0: The maximum resident set size (KB)                   = 888824
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_dyn64_phy32
+Checking test 51 rap_control_dyn64_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.180000.coupler.res .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 248.091960
+  0: The maximum resident set size (KB)                   = 966532
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_debug_dyn32_phy32
+Checking test 52 rap_control_debug_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 261.310953
+  0: The maximum resident set size (KB)                   = 1058124
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/hrrr_control_debug_dyn32_phy32
+Checking test 53 hrrr_control_debug_dyn32_phy32 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 260.285779
+  0: The maximum resident set size (KB)                   = 1050008
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/rap_control_dyn64_phy32_debug
+Checking test 54 rap_control_dyn64_phy32_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 274.942910
+  0: The maximum resident set size (KB)                   = 1102260
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_control_cfsr
+Checking test 55 datm_cdeps_control_cfsr results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 153.286874
+ 0: The maximum resident set size (KB)                   = 1062580
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_control_gefs
+Checking test 56 datm_cdeps_control_gefs results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 147.851364
+ 0: The maximum resident set size (KB)                   = 966652
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_iau_gefs
+Checking test 57 datm_cdeps_iau_gefs results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 153.086504
+ 0: The maximum resident set size (KB)                   = 963168
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_stochy_gefs
+Checking test 58 datm_cdeps_stochy_gefs results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 151.073239
+ 0: The maximum resident set size (KB)                   = 966184
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_ciceC_cfsr
+Checking test 59 datm_cdeps_ciceC_cfsr results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 154.478362
+ 0: The maximum resident set size (KB)                   = 1062744
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_bulk_cfsr
+Checking test 60 datm_cdeps_bulk_cfsr results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 153.678352
+ 0: The maximum resident set size (KB)                   = 1065804
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_bulk_gefs
+Checking test 61 datm_cdeps_bulk_gefs results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 152.308809
+ 0: The maximum resident set size (KB)                   = 961960
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_mx025_cfsr
+Checking test 62 datm_cdeps_mx025_cfsr results ....
+ Comparing RESTART/20111001.120000.MOM.res.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2011-10-01-43200.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
+
+  0: The total amount of wall time                        = 416.023679
+  0: The maximum resident set size (KB)                   = 884160
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_mx025_gefs
+Checking test 63 datm_cdeps_mx025_gefs results ....
+ Comparing RESTART/20111001.120000.MOM.res.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
+ Comparing RESTART/20111001.120000.MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2011-10-01-43200.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
+
+  0: The total amount of wall time                        = 435.041871
+  0: The maximum resident set size (KB)                   = 936316
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_multiple_files_cfsr
+Checking test 64 datm_cdeps_multiple_files_cfsr results ....
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 153.930114
+ 0: The maximum resident set size (KB)                   = 1058160
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_3072x1536_cfsr
+Checking test 65 datm_cdeps_3072x1536_cfsr results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 217.342050
+ 0: The maximum resident set size (KB)                   = 2360808
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_gfs
+Checking test 66 datm_cdeps_gfs results ....
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
+
+ 0: The total amount of wall time                        = 222.523263
+ 0: The maximum resident set size (KB)                   = 2366340
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_debug_cfsr
+Checking test 67 datm_cdeps_debug_cfsr results ....
+ Comparing RESTART/20111001.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-01-21600.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
+
+ 0: The total amount of wall time                        = 357.615414
+ 0: The maximum resident set size (KB)                   = 978028
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_control_cfsr_faster
+Checking test 68 datm_cdeps_control_cfsr_faster results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 156.381175
+ 0: The maximum resident set size (KB)                   = 1047256
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/datm_cdeps_lnd_gswp3
+Checking test 69 datm_cdeps_lnd_gswp3 results ....
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile4.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
+ Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 6.984228
+  0: The maximum resident set size (KB)                   = 258752
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_atmaq
+Checking test 70 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5116,12 +6549,27 @@ Checking test 167 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 567.633953
-  0: The maximum resident set size (KB)                   = 1456756
-
-Test 167 regional_atmaq_faster PASS
+  0: The total amount of wall time                        = 645.553947
+  0: The maximum resident set size (KB)                   = 1449952
 
 
-REGRESSION TEST WAS SUCCESSFUL
-Sun May  7 07:18:09 UTC 2023
-Elapsed time: 08h:50m:51s. Have a nice day!
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_faster
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10677/regional_atmaq_faster
+Checking test 71 regional_atmaq_faster results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing RESTART/20190801.180000.coupler.res .........OK
+ Comparing RESTART/20190801.180000.fv_core.res.nc .........OK
+ Comparing RESTART/20190801.180000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20190801.180000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20190801.180000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20190801.180000.phy_data.nc .........OK
+ Comparing RESTART/20190801.180000.sfc_data.nc .........OK
+
+  0: The total amount of wall time                        = 560.534367
+  0: The maximum resident set size (KB)                   = 1455460
+

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,43 +1,43 @@
-Fri May  5 19:03:44 UTC 2023
+Wed May 10 22:26:52 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 1942 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 2049 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 1877 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 004 elapsed time 313 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 288 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1707 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 007 elapsed time 1758 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 008 elapsed time 3352 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 009 elapsed time 1840 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 010 elapsed time 1751 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1701 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 1542 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 013 elapsed time 2150 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 306 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 1582 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 017 elapsed time 1615 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 018 elapsed time 251 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 281 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 1713 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 021 elapsed time 248 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 2238 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 023 elapsed time 1702 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 024 elapsed time 286 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 025 elapsed time 149 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 267 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 027 elapsed time 81 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 028 elapsed time 1681 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 029 elapsed time 1673 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 030 elapsed time 1644 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 031 elapsed time 1593 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 032 elapsed time 1553 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 033 elapsed time 217 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 034 elapsed time 2034 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 2006 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2003 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 1850 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 004 elapsed time 350 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 309 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1691 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1737 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 008 elapsed time 3388 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 009 elapsed time 1796 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 010 elapsed time 1724 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1728 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 1608 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 2148 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 344 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 277 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 1629 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 017 elapsed time 1681 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 018 elapsed time 217 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 294 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 1761 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 021 elapsed time 341 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 2290 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 023 elapsed time 1735 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 024 elapsed time 304 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 025 elapsed time 173 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 331 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 027 elapsed time 133 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 028 elapsed time 1725 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 029 elapsed time 1711 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 030 elapsed time 1713 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 031 elapsed time 1647 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 032 elapsed time 1600 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 033 elapsed time 297 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 034 elapsed time 1989 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_p8_mixedmode
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -102,14 +102,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 456.506094
-  0: The maximum resident set size (KB)                   = 1741260
+  0: The total amount of wall time                        = 475.932787
+  0: The maximum resident set size (KB)                   = 1742280
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_gfsv17
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_gfsv17
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_gfsv17
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -173,14 +173,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 313.957534
-  0: The maximum resident set size (KB)                   = 1641600
+  0: The total amount of wall time                        = 346.988488
+  0: The maximum resident set size (KB)                   = 1642620
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -245,14 +245,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 460.913635
-  0: The maximum resident set size (KB)                   = 1802564
+  0: The total amount of wall time                        = 517.405113
+  0: The maximum resident set size (KB)                   = 1794868
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_restart_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -305,14 +305,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 274.416982
-  0: The maximum resident set size (KB)                   = 1482348
+  0: The total amount of wall time                        = 294.934858
+  0: The maximum resident set size (KB)                   = 1502548
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_qr_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -377,14 +377,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 472.350530
-  0: The maximum resident set size (KB)                   = 1788456
+  0: The total amount of wall time                        = 525.354246
+  0: The maximum resident set size (KB)                   = 1789712
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_restart_qr_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -437,14 +437,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 283.341672
-  0: The maximum resident set size (KB)                   = 1505968
+  0: The total amount of wall time                        = 320.467184
+  0: The maximum resident set size (KB)                   = 1521720
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_2threads_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -497,14 +497,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 482.317559
-  0: The maximum resident set size (KB)                   = 1991852
+  0: The total amount of wall time                        = 557.627319
+  0: The maximum resident set size (KB)                   = 1999088
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_decomp_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -557,14 +557,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 463.551854
-  0: The maximum resident set size (KB)                   = 1759360
+  0: The total amount of wall time                        = 521.532980
+  0: The maximum resident set size (KB)                   = 1792032
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_mpi_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -617,14 +617,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 393.221188
-  0: The maximum resident set size (KB)                   = 1721512
+  0: The total amount of wall time                        = 433.921670
+  0: The maximum resident set size (KB)                   = 1750316
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_ciceC_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -689,14 +689,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 462.649180
-  0: The maximum resident set size (KB)                   = 1766824
+  0: The total amount of wall time                        = 522.104153
+  0: The maximum resident set size (KB)                   = 1795828
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_noaero_p8
 Checking test 011 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -760,14 +760,14 @@ Checking test 011 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 382.759394
-  0: The maximum resident set size (KB)                   = 1618992
+  0: The total amount of wall time                        = 378.359819
+  0: The maximum resident set size (KB)                   = 1633980
 
 Test 011 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_nowave_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_nowave_noaero_p8
 Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -829,14 +829,14 @@ Checking test 012 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 393.506939
-  0: The maximum resident set size (KB)                   = 1672668
+  0: The total amount of wall time                        = 376.083820
+  0: The maximum resident set size (KB)                   = 1692480
 
 Test 012 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_debug_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_debug_p8
 Checking test 013 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -889,14 +889,14 @@ Checking test 013 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 678.276501
-  0: The maximum resident set size (KB)                   = 1834784
+  0: The total amount of wall time                        = 709.956525
+  0: The maximum resident set size (KB)                   = 1828024
 
 Test 013 cpld_debug_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_debug_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_debug_noaero_p8
 Checking test 014 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -948,14 +948,14 @@ Checking test 014 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 471.936474
-  0: The maximum resident set size (KB)                   = 1651300
+  0: The total amount of wall time                        = 501.742266
+  0: The maximum resident set size (KB)                   = 1642868
 
 Test 014 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_noaero_p8_agrid
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_noaero_p8_agrid
 Checking test 015 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1017,14 +1017,14 @@ Checking test 015 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 372.090163
-  0: The maximum resident set size (KB)                   = 1676432
+  0: The total amount of wall time                        = 435.565688
+  0: The maximum resident set size (KB)                   = 1686672
 
 Test 015 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c48
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_c48
 Checking test 016 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1074,14 +1074,14 @@ Checking test 016 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 809.775799
- 0: The maximum resident set size (KB)                   = 2768872
+ 0: The total amount of wall time                        = 817.942954
+ 0: The maximum resident set size (KB)                   = 2779684
 
 Test 016 cpld_control_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_warmstart_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_warmstart_c48
 Checking test 017 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1131,14 +1131,14 @@ Checking test 017 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 214.065719
- 0: The maximum resident set size (KB)                   = 2772904
+ 0: The total amount of wall time                        = 228.254645
+ 0: The maximum resident set size (KB)                   = 2775904
 
 Test 017 cpld_warmstart_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_restart_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_restart_c48
 Checking test 018 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1188,14 +1188,14 @@ Checking test 018 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 111.850337
- 0: The maximum resident set size (KB)                   = 2212920
+ 0: The total amount of wall time                        = 141.593667
+ 0: The maximum resident set size (KB)                   = 2207092
 
 Test 018 cpld_restart_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_faster
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/cpld_control_p8_faster
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/cpld_control_p8_faster
 Checking test 019 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1260,14 +1260,14 @@ Checking test 019 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 435.936189
-  0: The maximum resident set size (KB)                   = 1771464
+  0: The total amount of wall time                        = 497.858858
+  0: The maximum resident set size (KB)                   = 1802124
 
 Test 019 cpld_control_p8_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_flake
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_flake
 Checking test 020 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1278,14 +1278,14 @@ Checking test 020 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 262.794645
-  0: The maximum resident set size (KB)                   = 621368
+  0: The total amount of wall time                        = 283.287610
+  0: The maximum resident set size (KB)                   = 619928
 
 Test 020 control_flake PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_CubedSphereGrid
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1312,28 +1312,28 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 183.325936
-  0: The maximum resident set size (KB)                   = 572088
+  0: The total amount of wall time                        = 193.275261
+  0: The maximum resident set size (KB)                   = 572096
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_parallel
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_CubedSphereGrid_parallel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_CubedSphereGrid_parallel
 Checking test 022 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 181.001583
-  0: The maximum resident set size (KB)                   = 569440
+  0: The total amount of wall time                        = 204.634061
+  0: The maximum resident set size (KB)                   = 568640
 
 Test 022 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_latlon
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1344,14 +1344,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.445730
-  0: The maximum resident set size (KB)                   = 569700
+  0: The total amount of wall time                        = 210.966707
+  0: The maximum resident set size (KB)                   = 569512
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_wrtGauss_netcdf_parallel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1362,14 +1362,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 192.067737
-  0: The maximum resident set size (KB)                   = 574104
+  0: The total amount of wall time                        = 213.313669
+  0: The maximum resident set size (KB)                   = 571360
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_c48
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1408,14 +1408,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 600.300134
-0: The maximum resident set size (KB)                   = 797164
+0: The total amount of wall time                        = 597.657548
+0: The maximum resident set size (KB)                   = 789424
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_c192
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1426,14 +1426,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 729.495494
-  0: The maximum resident set size (KB)                   = 689280
+  0: The total amount of wall time                        = 766.330778
+  0: The maximum resident set size (KB)                   = 696540
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_c384
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1444,14 +1444,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 953.364552
-  0: The maximum resident set size (KB)                   = 1056632
+  0: The total amount of wall time                        = 961.664217
+  0: The maximum resident set size (KB)                   = 1052652
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_c384gdas
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1494,14 +1494,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 806.882990
-  0: The maximum resident set size (KB)                   = 1195812
+  0: The total amount of wall time                        = 917.914747
+  0: The maximum resident set size (KB)                   = 1195872
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_stochy
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1512,28 +1512,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 124.996708
-  0: The maximum resident set size (KB)                   = 577528
+  0: The total amount of wall time                        = 132.079132
+  0: The maximum resident set size (KB)                   = 577368
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_stochy_restart
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 67.167234
-  0: The maximum resident set size (KB)                   = 395624
+  0: The total amount of wall time                        = 70.778949
+  0: The maximum resident set size (KB)                   = 388592
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_lndp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1544,14 +1544,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.783949
-  0: The maximum resident set size (KB)                   = 576644
+  0: The total amount of wall time                        = 131.193705
+  0: The maximum resident set size (KB)                   = 580092
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_iovr4
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1566,14 +1566,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 191.858341
-  0: The maximum resident set size (KB)                   = 574056
+  0: The total amount of wall time                        = 218.555812
+  0: The maximum resident set size (KB)                   = 570856
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_iovr5
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1588,14 +1588,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.486048
-  0: The maximum resident set size (KB)                   = 568776
+  0: The total amount of wall time                        = 207.223942
+  0: The maximum resident set size (KB)                   = 575760
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1642,14 +1642,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.333284
-  0: The maximum resident set size (KB)                   = 1535172
+  0: The total amount of wall time                        = 245.600969
+  0: The maximum resident set size (KB)                   = 1549288
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_restart_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1688,14 +1688,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.936812
-  0: The maximum resident set size (KB)                   = 775480
+  0: The total amount of wall time                        = 125.606028
+  0: The maximum resident set size (KB)                   = 774268
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_qr_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_qr_p8
 Checking test 036 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1742,14 +1742,14 @@ Checking test 036 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 227.698323
-  0: The maximum resident set size (KB)                   = 1553428
+  0: The total amount of wall time                        = 249.968478
+  0: The maximum resident set size (KB)                   = 1549856
 
 Test 036 control_qr_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_restart_qr_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_restart_qr_p8
 Checking test 037 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1788,14 +1788,14 @@ Checking test 037 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 128.248671
-  0: The maximum resident set size (KB)                   = 786000
+  0: The total amount of wall time                        = 137.024450
+  0: The maximum resident set size (KB)                   = 786128
 
 Test 037 control_restart_qr_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_decomp_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_decomp_p8
 Checking test 038 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1838,14 +1838,14 @@ Checking test 038 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 242.843766
-  0: The maximum resident set size (KB)                   = 1520276
+  0: The total amount of wall time                        = 247.713086
+  0: The maximum resident set size (KB)                   = 1535616
 
 Test 038 control_decomp_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_2threads_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_2threads_p8
 Checking test 039 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1888,14 +1888,14 @@ Checking test 039 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 220.709903
-  0: The maximum resident set size (KB)                   = 1618580
+  0: The total amount of wall time                        = 233.184918
+  0: The maximum resident set size (KB)                   = 1637468
 
 Test 039 control_2threads_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_lndp
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_p8_lndp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_p8_lndp
 Checking test 040 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1914,14 +1914,14 @@ Checking test 040 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 433.201606
-  0: The maximum resident set size (KB)                   = 1538092
+  0: The total amount of wall time                        = 467.679592
+  0: The maximum resident set size (KB)                   = 1535716
 
 Test 040 control_p8_lndp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_p8_rrtmgp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_p8_rrtmgp
 Checking test 041 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1968,14 +1968,14 @@ Checking test 041 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 312.953683
-  0: The maximum resident set size (KB)                   = 1603052
+  0: The total amount of wall time                        = 326.877007
+  0: The maximum resident set size (KB)                   = 1603700
 
 Test 041 control_p8_rrtmgp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_mynn
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_p8_mynn
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_p8_mynn
 Checking test 042 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2022,14 +2022,14 @@ Checking test 042 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.441628
-  0: The maximum resident set size (KB)                   = 1547556
+  0: The total amount of wall time                        = 257.830354
+  0: The maximum resident set size (KB)                   = 1551728
 
 Test 042 control_p8_mynn PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/merra2_thompson
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/merra2_thompson
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/merra2_thompson
 Checking test 043 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2076,14 +2076,14 @@ Checking test 043 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 263.249363
-  0: The maximum resident set size (KB)                   = 1553672
+  0: The total amount of wall time                        = 282.638634
+  0: The maximum resident set size (KB)                   = 1557664
 
 Test 043 merra2_thompson PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_control
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_control
 Checking test 044 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2094,28 +2094,28 @@ Checking test 044 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 413.360810
-  0: The maximum resident set size (KB)                   = 788412
+  0: The total amount of wall time                        = 452.638046
+  0: The maximum resident set size (KB)                   = 789792
 
 Test 044 regional_control PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_restart
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_restart
 Checking test 045 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 209.555979
-  0: The maximum resident set size (KB)                   = 779272
+  0: The total amount of wall time                        = 218.834215
+  0: The maximum resident set size (KB)                   = 776552
 
 Test 045 regional_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_control_qr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_control_qr
 Checking test 046 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2126,28 +2126,28 @@ Checking test 046 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 416.605911
-  0: The maximum resident set size (KB)                   = 785212
+  0: The total amount of wall time                        = 433.579958
+  0: The maximum resident set size (KB)                   = 787060
 
 Test 046 regional_control_qr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_restart_qr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_restart_qr
 Checking test 047 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 208.411704
-  0: The maximum resident set size (KB)                   = 777100
+  0: The total amount of wall time                        = 219.895042
+  0: The maximum resident set size (KB)                   = 780284
 
 Test 047 regional_restart_qr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_decomp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_decomp
 Checking test 048 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2158,14 +2158,14 @@ Checking test 048 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 427.909093
-  0: The maximum resident set size (KB)                   = 785824
+  0: The total amount of wall time                        = 477.833754
+  0: The maximum resident set size (KB)                   = 781792
 
 Test 048 regional_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_2threads
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_2threads
 Checking test 049 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2176,28 +2176,28 @@ Checking test 049 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 249.469019
-  0: The maximum resident set size (KB)                   = 772600
+  0: The total amount of wall time                        = 283.848116
+  0: The maximum resident set size (KB)                   = 770964
 
 Test 049 regional_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_netcdf_parallel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_netcdf_parallel
 Checking test 050 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 404.865096
-  0: The maximum resident set size (KB)                   = 782088
+  0: The total amount of wall time                        = 439.942055
+  0: The maximum resident set size (KB)                   = 786240
 
 Test 050 regional_netcdf_parallel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_2dwrtdecomp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_2dwrtdecomp
 Checking test 051 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2208,14 +2208,14 @@ Checking test 051 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 414.605749
-  0: The maximum resident set size (KB)                   = 787940
+  0: The total amount of wall time                        = 456.301976
+  0: The maximum resident set size (KB)                   = 790376
 
 Test 051 regional_2dwrtdecomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_control
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_control
 Checking test 052 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2262,14 +2262,14 @@ Checking test 052 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 610.288167
-  0: The maximum resident set size (KB)                   = 942148
+  0: The total amount of wall time                        = 633.041396
+  0: The maximum resident set size (KB)                   = 950208
 
 Test 052 rap_control PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_spp_sppt_shum_skeb
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_spp_sppt_shum_skeb
 Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2280,14 +2280,14 @@ Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 324.336886
-  0: The maximum resident set size (KB)                   = 1091312
+  0: The total amount of wall time                        = 355.096451
+  0: The maximum resident set size (KB)                   = 1095472
 
 Test 053 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_decomp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_decomp
 Checking test 054 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2334,14 +2334,14 @@ Checking test 054 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 644.454018
-  0: The maximum resident set size (KB)                   = 951332
+  0: The total amount of wall time                        = 687.563899
+  0: The maximum resident set size (KB)                   = 935764
 
 Test 054 rap_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_2threads
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_2threads
 Checking test 055 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2388,14 +2388,14 @@ Checking test 055 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 586.540054
-  0: The maximum resident set size (KB)                   = 1019756
+  0: The total amount of wall time                        = 633.261298
+  0: The maximum resident set size (KB)                   = 1025840
 
 Test 055 rap_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_restart
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_restart
 Checking test 056 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2434,14 +2434,14 @@ Checking test 056 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 306.966396
-  0: The maximum resident set size (KB)                   = 837916
+  0: The total amount of wall time                        = 331.002332
+  0: The maximum resident set size (KB)                   = 838564
 
 Test 056 rap_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_sfcdiff
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_sfcdiff
 Checking test 057 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2488,14 +2488,14 @@ Checking test 057 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 629.828883
-  0: The maximum resident set size (KB)                   = 952908
+  0: The total amount of wall time                        = 662.833009
+  0: The maximum resident set size (KB)                   = 952248
 
 Test 057 rap_sfcdiff PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_sfcdiff_decomp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_sfcdiff_decomp
 Checking test 058 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2542,14 +2542,14 @@ Checking test 058 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 663.902491
-  0: The maximum resident set size (KB)                   = 935340
+  0: The total amount of wall time                        = 707.154680
+  0: The maximum resident set size (KB)                   = 935908
 
 Test 058 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_sfcdiff_restart
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_sfcdiff_restart
 Checking test 059 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2588,14 +2588,14 @@ Checking test 059 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.380583
-  0: The maximum resident set size (KB)                   = 840504
+  0: The total amount of wall time                        = 477.232329
+  0: The maximum resident set size (KB)                   = 844148
 
 Test 059 rap_sfcdiff_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control
 Checking test 060 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2642,14 +2642,14 @@ Checking test 060 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 575.856688
-  0: The maximum resident set size (KB)                   = 948880
+  0: The total amount of wall time                        = 612.289474
+  0: The maximum resident set size (KB)                   = 951708
 
 Test 060 hrrr_control PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_decomp
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_decomp
 Checking test 061 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2696,14 +2696,14 @@ Checking test 061 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 597.698194
-  0: The maximum resident set size (KB)                   = 947104
+  0: The total amount of wall time                        = 655.192143
+  0: The maximum resident set size (KB)                   = 938196
 
 Test 061 hrrr_control_decomp PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_2threads
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_2threads
 Checking test 062 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2750,28 +2750,28 @@ Checking test 062 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 529.676992
-  0: The maximum resident set size (KB)                   = 1014204
+  0: The total amount of wall time                        = 607.939414
+  0: The maximum resident set size (KB)                   = 1016512
 
 Test 062 hrrr_control_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_restart
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_restart
 Checking test 063 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 419.873279
-  0: The maximum resident set size (KB)                   = 835348
+  0: The total amount of wall time                        = 454.015040
+  0: The maximum resident set size (KB)                   = 844476
 
 Test 063 hrrr_control_restart PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_v1beta
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_v1beta
 Checking test 064 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2818,14 +2818,14 @@ Checking test 064 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 616.627808
-  0: The maximum resident set size (KB)                   = 941236
+  0: The total amount of wall time                        = 670.108467
+  0: The maximum resident set size (KB)                   = 946864
 
 Test 064 rrfs_v1beta PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_v1nssl
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_v1nssl
 Checking test 065 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2840,14 +2840,14 @@ Checking test 065 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 731.701665
-  0: The maximum resident set size (KB)                   = 640248
+  0: The total amount of wall time                        = 783.915014
+  0: The maximum resident set size (KB)                   = 638752
 
 Test 065 rrfs_v1nssl PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_v1nssl_nohailnoccn
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_v1nssl_nohailnoccn
 Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2862,14 +2862,14 @@ Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 724.724002
-  0: The maximum resident set size (KB)                   = 625836
+  0: The total amount of wall time                        = 748.073273
+  0: The maximum resident set size (KB)                   = 634500
 
 Test 066 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_smoke_conus13km_hrrr_warm
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2878,14 +2878,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 213.398197
-  0: The maximum resident set size (KB)                   = 899744
+  0: The total amount of wall time                        = 212.098558
+  0: The maximum resident set size (KB)                   = 902596
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 068 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2894,14 +2894,14 @@ Checking test 068 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 138.430038
-  0: The maximum resident set size (KB)                   = 855772
+  0: The total amount of wall time                        = 152.440972
+  0: The maximum resident set size (KB)                   = 863364
 
 Test 068 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_conus13km_hrrr_warm
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_conus13km_hrrr_warm
 Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2910,14 +2910,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 181.042822
-  0: The maximum resident set size (KB)                   = 870856
+  0: The total amount of wall time                        = 192.524864
+  0: The maximum resident set size (KB)                   = 880424
 
 Test 069 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 070 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2926,26 +2926,26 @@ Checking test 070 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 215.534797
-  0: The maximum resident set size (KB)                   = 908076
+  0: The total amount of wall time                        = 208.642215
+  0: The maximum resident set size (KB)                   = 903612
 
 Test 070 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 071 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 104.518373
-  0: The maximum resident set size (KB)                   = 858292
+  0: The total amount of wall time                        = 100.670222
+  0: The maximum resident set size (KB)                   = 850668
 
 Test 071 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_csawmg
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_csawmg
 Checking test 072 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2956,14 +2956,14 @@ Checking test 072 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 467.070903
-  0: The maximum resident set size (KB)                   = 668676
+  0: The total amount of wall time                        = 497.830202
+  0: The maximum resident set size (KB)                   = 670060
 
 Test 072 control_csawmg PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_csawmgt
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_csawmgt
 Checking test 073 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2974,14 +2974,14 @@ Checking test 073 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 460.767667
-  0: The maximum resident set size (KB)                   = 662396
+  0: The total amount of wall time                        = 497.064119
+  0: The maximum resident set size (KB)                   = 661804
 
 Test 073 control_csawmgt PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_ras
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_ras
 Checking test 074 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2992,26 +2992,26 @@ Checking test 074 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 253.575558
-  0: The maximum resident set size (KB)                   = 636076
+  0: The total amount of wall time                        = 264.960320
+  0: The maximum resident set size (KB)                   = 633856
 
 Test 074 control_ras PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_wam
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_wam
 Checking test 075 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 151.348297
-  0: The maximum resident set size (KB)                   = 485644
+  0: The total amount of wall time                        = 172.367358
+  0: The maximum resident set size (KB)                   = 484880
 
 Test 075 control_wam PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_faster
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_p8_faster
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_p8_faster
 Checking test 076 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3058,14 +3058,14 @@ Checking test 076 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 210.848508
-  0: The maximum resident set size (KB)                   = 1533292
+  0: The total amount of wall time                        = 233.954892
+  0: The maximum resident set size (KB)                   = 1547484
 
 Test 076 control_p8_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control_faster
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_control_faster
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_control_faster
 Checking test 077 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3076,56 +3076,56 @@ Checking test 077 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 376.500598
-  0: The maximum resident set size (KB)                   = 782416
+  0: The total amount of wall time                        = 419.520822
+  0: The maximum resident set size (KB)                   = 786100
 
 Test 077 regional_control_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 078 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 1094.435311
-  0: The maximum resident set size (KB)                   = 926044
+  0: The total amount of wall time                        = 1090.825240
+  0: The maximum resident set size (KB)                   = 933652
 
 Test 078 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 646.322837
-  0: The maximum resident set size (KB)                   = 901468
+  0: The total amount of wall time                        = 642.720381
+  0: The maximum resident set size (KB)                   = 891784
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_conus13km_hrrr_warm_debug
 Checking test 080 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 970.520617
-  0: The maximum resident set size (KB)                   = 911488
+  0: The total amount of wall time                        = 978.823953
+  0: The maximum resident set size (KB)                   = 913008
 
 Test 080 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_CubedSphereGrid_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_CubedSphereGrid_debug
 Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3152,348 +3152,348 @@ Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 188.845445
-  0: The maximum resident set size (KB)                   = 740128
+  0: The total amount of wall time                        = 199.137380
+  0: The maximum resident set size (KB)                   = 732456
 
 Test 081 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_wrtGauss_netcdf_parallel_debug
 Checking test 082 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 190.609655
-  0: The maximum resident set size (KB)                   = 734212
+  0: The total amount of wall time                        = 195.187046
+  0: The maximum resident set size (KB)                   = 730108
 
 Test 082 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_stochy_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_stochy_debug
 Checking test 083 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 220.909971
-  0: The maximum resident set size (KB)                   = 737848
+  0: The total amount of wall time                        = 214.332489
+  0: The maximum resident set size (KB)                   = 738380
 
 Test 083 control_stochy_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_lndp_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_lndp_debug
 Checking test 084 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.280409
-  0: The maximum resident set size (KB)                   = 738424
+  0: The total amount of wall time                        = 195.234133
+  0: The maximum resident set size (KB)                   = 737364
 
 Test 084 control_lndp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_csawmg_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_csawmg_debug
 Checking test 085 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.656157
-  0: The maximum resident set size (KB)                   = 784196
+  0: The total amount of wall time                        = 302.728825
+  0: The maximum resident set size (KB)                   = 788156
 
 Test 085 control_csawmg_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_csawmgt_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_csawmgt_debug
 Checking test 086 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.448162
-  0: The maximum resident set size (KB)                   = 784136
+  0: The total amount of wall time                        = 302.261076
+  0: The maximum resident set size (KB)                   = 779096
 
 Test 086 control_csawmgt_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_ras_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_ras_debug
 Checking test 087 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.307540
-  0: The maximum resident set size (KB)                   = 747840
+  0: The total amount of wall time                        = 194.456006
+  0: The maximum resident set size (KB)                   = 746788
 
 Test 087 control_ras_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_diag_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_diag_debug
 Checking test 088 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 198.662418
-  0: The maximum resident set size (KB)                   = 796572
+  0: The total amount of wall time                        = 204.262274
+  0: The maximum resident set size (KB)                   = 794556
 
 Test 088 control_diag_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_debug_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_debug_p8
 Checking test 089 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.242562
-  0: The maximum resident set size (KB)                   = 1563108
+  0: The total amount of wall time                        = 217.779676
+  0: The maximum resident set size (KB)                   = 1569732
 
 Test 089 control_debug_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1283.124413
-  0: The maximum resident set size (KB)                   = 803428
+  0: The total amount of wall time                        = 1283.390631
+  0: The maximum resident set size (KB)                   = 805176
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_control_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.688578
-  0: The maximum resident set size (KB)                   = 1107312
+  0: The total amount of wall time                        = 349.944240
+  0: The maximum resident set size (KB)                   = 1112380
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_debug
 Checking test 092 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 337.048780
-  0: The maximum resident set size (KB)                   = 1115648
+  0: The total amount of wall time                        = 345.863243
+  0: The maximum resident set size (KB)                   = 1111204
 
 Test 092 hrrr_control_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_unified_drag_suite_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_unified_drag_suite_debug
 Checking test 093 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.034688
-  0: The maximum resident set size (KB)                   = 1118700
+  0: The total amount of wall time                        = 349.429692
+  0: The maximum resident set size (KB)                   = 1115456
 
 Test 093 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_diag_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_diag_debug
 Checking test 094 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 367.564277
-  0: The maximum resident set size (KB)                   = 1188504
+  0: The total amount of wall time                        = 382.698280
+  0: The maximum resident set size (KB)                   = 1188020
 
 Test 094 rap_diag_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_cires_ugwp_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_cires_ugwp_debug
 Checking test 095 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 358.310261
-  0: The maximum resident set size (KB)                   = 1108016
+  0: The total amount of wall time                        = 371.445420
+  0: The maximum resident set size (KB)                   = 1105492
 
 Test 095 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_unified_ugwp_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_unified_ugwp_debug
 Checking test 096 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 355.508233
-  0: The maximum resident set size (KB)                   = 1118208
+  0: The total amount of wall time                        = 357.830961
+  0: The maximum resident set size (KB)                   = 1116236
 
 Test 096 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_lndp_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_lndp_debug
 Checking test 097 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 353.643465
-  0: The maximum resident set size (KB)                   = 1118112
+  0: The total amount of wall time                        = 352.095331
+  0: The maximum resident set size (KB)                   = 1115556
 
 Test 097 rap_lndp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_progcld_thompson_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_progcld_thompson_debug
 Checking test 098 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 353.535793
-  0: The maximum resident set size (KB)                   = 1112304
+  0: The total amount of wall time                        = 353.818127
+  0: The maximum resident set size (KB)                   = 1118488
 
 Test 098 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_noah_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_noah_debug
 Checking test 099 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 346.075932
-  0: The maximum resident set size (KB)                   = 1107892
+  0: The total amount of wall time                        = 341.267022
+  0: The maximum resident set size (KB)                   = 1115288
 
 Test 099 rap_noah_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_sfcdiff_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_sfcdiff_debug
 Checking test 100 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.787850
-  0: The maximum resident set size (KB)                   = 1112908
+  0: The total amount of wall time                        = 357.920119
+  0: The maximum resident set size (KB)                   = 1109100
 
 Test 100 rap_sfcdiff_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 101 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 574.978417
-  0: The maximum resident set size (KB)                   = 1110800
+  0: The total amount of wall time                        = 591.054065
+  0: The maximum resident set size (KB)                   = 1115656
 
 Test 101 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rrfs_v1beta_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rrfs_v1beta_debug
 Checking test 102 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 345.180218
-  0: The maximum resident set size (KB)                   = 1112588
+  0: The total amount of wall time                        = 349.498801
+  0: The maximum resident set size (KB)                   = 1105944
 
 Test 102 rrfs_v1beta_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_clm_lake_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_clm_lake_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_clm_lake_debug
 Checking test 103 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 430.576959
-  0: The maximum resident set size (KB)                   = 1108728
+  0: The total amount of wall time                        = 426.212923
+  0: The maximum resident set size (KB)                   = 1117824
 
 Test 103 rap_clm_lake_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_flake_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_flake_debug
 Checking test 104 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.949057
-  0: The maximum resident set size (KB)                   = 1114896
+  0: The total amount of wall time                        = 361.638407
+  0: The maximum resident set size (KB)                   = 1104652
 
 Test 104 rap_flake_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_wam_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 357.278859
-  0: The maximum resident set size (KB)                   = 431760
+  0: The total amount of wall time                        = 362.444727
+  0: The maximum resident set size (KB)                   = 438436
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3504,14 +3504,14 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 303.593187
-  0: The maximum resident set size (KB)                   = 982856
+  0: The total amount of wall time                        = 313.087911
+  0: The maximum resident set size (KB)                   = 989660
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_control_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_control_dyn32_phy32
 Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3558,14 +3558,14 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 521.934805
-  0: The maximum resident set size (KB)                   = 842400
+  0: The total amount of wall time                        = 558.361398
+  0: The maximum resident set size (KB)                   = 851680
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_dyn32_phy32
 Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3612,14 +3612,14 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.376551
-  0: The maximum resident set size (KB)                   = 837404
+  0: The total amount of wall time                        = 271.495415
+  0: The maximum resident set size (KB)                   = 826040
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_2threads_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_2threads_dyn32_phy32
 Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3666,14 +3666,14 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 507.916355
-  0: The maximum resident set size (KB)                   = 887188
+  0: The total amount of wall time                        = 534.849164
+  0: The maximum resident set size (KB)                   = 888856
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_2threads_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_2threads_dyn32_phy32
 Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3720,14 +3720,14 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.524657
-  0: The maximum resident set size (KB)                   = 875692
+  0: The total amount of wall time                        = 276.089020
+  0: The maximum resident set size (KB)                   = 872812
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_decomp_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_decomp_dyn32_phy32
 Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3774,14 +3774,14 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 266.245197
-  0: The maximum resident set size (KB)                   = 830620
+  0: The total amount of wall time                        = 301.610242
+  0: The maximum resident set size (KB)                   = 830692
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_restart_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_restart_dyn32_phy32
 Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3820,28 +3820,28 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 369.406964
-  0: The maximum resident set size (KB)                   = 802484
+  0: The total amount of wall time                        = 412.353729
+  0: The maximum resident set size (KB)                   = 816296
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_restart_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_restart_dyn32_phy32
 Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 131.231682
-  0: The maximum resident set size (KB)                   = 765968
+  0: The total amount of wall time                        = 141.235264
+  0: The maximum resident set size (KB)                   = 769964
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_control_dyn64_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_control_dyn64_phy32
 Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3888,81 +3888,81 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 326.945626
-  0: The maximum resident set size (KB)                   = 860840
+  0: The total amount of wall time                        = 361.444578
+  0: The maximum resident set size (KB)                   = 870852
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_control_debug_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_control_debug_dyn32_phy32
 Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 343.497872
-  0: The maximum resident set size (KB)                   = 1002776
+  0: The total amount of wall time                        = 346.452959
+  0: The maximum resident set size (KB)                   = 1004128
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hrrr_control_debug_dyn32_phy32
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hrrr_control_debug_dyn32_phy32
 Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 336.339484
-  0: The maximum resident set size (KB)                   = 996172
+  0: The total amount of wall time                        = 342.990211
+  0: The maximum resident set size (KB)                   = 995632
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/rap_control_dyn64_phy32_debug
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/rap_control_dyn64_phy32_debug
 Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.995564
-  0: The maximum resident set size (KB)                   = 1033404
+  0: The total amount of wall time                        = 357.541362
+  0: The maximum resident set size (KB)                   = 1030012
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_atm
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_atm
 Checking test 118 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 347.296756
-  0: The maximum resident set size (KB)                   = 1215948
+  0: The total amount of wall time                        = 379.711247
+  0: The maximum resident set size (KB)                   = 1210420
 
 Test 118 hafs_regional_atm PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_atm_thompson_gfdlsf
 Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 421.390908
-  0: The maximum resident set size (KB)                   = 1501860
+  0: The total amount of wall time                        = 624.106546
+  0: The maximum resident set size (KB)                   = 1582660
 
 Test 119 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_atm_ocn
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_atm_ocn
 Checking test 120 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3971,14 +3971,14 @@ Checking test 120 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 520.581187
-  0: The maximum resident set size (KB)                   = 1295728
+  0: The total amount of wall time                        = 574.704082
+  0: The maximum resident set size (KB)                   = 1293420
 
 Test 120 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_atm_wav
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_atm_wav
 Checking test 121 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3987,14 +3987,14 @@ Checking test 121 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 938.823522
-  0: The maximum resident set size (KB)                   = 1329032
+  0: The total amount of wall time                        = 1009.359355
+  0: The maximum resident set size (KB)                   = 1324368
 
 Test 121 hafs_regional_atm_wav PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_atm_ocn_wav
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_atm_ocn_wav
 Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4005,14 +4005,14 @@ Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1051.824401
-  0: The maximum resident set size (KB)                   = 1344376
+  0: The total amount of wall time                        = 1119.573803
+  0: The maximum resident set size (KB)                   = 1367592
 
 Test 122 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_docn
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_docn
 Checking test 123 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4020,14 +4020,14 @@ Checking test 123 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 495.646533
-  0: The maximum resident set size (KB)                   = 1304332
+  0: The total amount of wall time                        = 564.743252
+  0: The maximum resident set size (KB)                   = 1312780
 
 Test 123 hafs_regional_docn PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/hafs_regional_docn_oisst
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/hafs_regional_docn_oisst
 Checking test 124 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4035,118 +4035,118 @@ Checking test 124 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 498.988962
-  0: The maximum resident set size (KB)                   = 1294684
+  0: The total amount of wall time                        = 591.793717
+  0: The maximum resident set size (KB)                   = 1254356
 
 Test 124 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_control_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_control_cfsr
 Checking test 125 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 212.663901
- 0: The maximum resident set size (KB)                   = 958292
+ 0: The total amount of wall time                        = 231.812946
+ 0: The maximum resident set size (KB)                   = 957852
 
 Test 125 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_restart_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_restart_cfsr
 Checking test 126 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 127.258548
- 0: The maximum resident set size (KB)                   = 934296
+ 0: The total amount of wall time                        = 136.750067
+ 0: The maximum resident set size (KB)                   = 931568
 
 Test 126 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_control_gefs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_control_gefs
 Checking test 127 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 206.392628
- 0: The maximum resident set size (KB)                   = 858296
+ 0: The total amount of wall time                        = 228.749126
+ 0: The maximum resident set size (KB)                   = 870160
 
 Test 127 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_iau_gefs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_iau_gefs
 Checking test 128 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 208.407964
- 0: The maximum resident set size (KB)                   = 858852
+ 0: The total amount of wall time                        = 232.512475
+ 0: The maximum resident set size (KB)                   = 864664
 
 Test 128 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_stochy_gefs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_stochy_gefs
 Checking test 129 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 209.977541
- 0: The maximum resident set size (KB)                   = 857884
+ 0: The total amount of wall time                        = 226.582106
+ 0: The maximum resident set size (KB)                   = 863728
 
 Test 129 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_ciceC_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_ciceC_cfsr
 Checking test 130 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 212.994436
- 0: The maximum resident set size (KB)                   = 966324
+ 0: The total amount of wall time                        = 220.983498
+ 0: The maximum resident set size (KB)                   = 962308
 
 Test 130 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_bulk_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_bulk_cfsr
 Checking test 131 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 212.812762
- 0: The maximum resident set size (KB)                   = 972908
+ 0: The total amount of wall time                        = 235.659184
+ 0: The maximum resident set size (KB)                   = 963828
 
 Test 131 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_bulk_gefs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_bulk_gefs
 Checking test 132 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 206.959867
- 0: The maximum resident set size (KB)                   = 863416
+ 0: The total amount of wall time                        = 221.018029
+ 0: The maximum resident set size (KB)                   = 861728
 
 Test 132 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_mx025_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_mx025_cfsr
 Checking test 133 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4155,14 +4155,14 @@ Checking test 133 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 565.061457
-  0: The maximum resident set size (KB)                   = 759928
+  0: The total amount of wall time                        = 593.589931
+  0: The maximum resident set size (KB)                   = 764252
 
 Test 133 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_mx025_gefs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_mx025_gefs
 Checking test 134 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4171,77 +4171,77 @@ Checking test 134 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 560.479713
-  0: The maximum resident set size (KB)                   = 733920
+  0: The total amount of wall time                        = 578.709366
+  0: The maximum resident set size (KB)                   = 734056
 
 Test 134 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_multiple_files_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_multiple_files_cfsr
 Checking test 135 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 210.775143
- 0: The maximum resident set size (KB)                   = 975596
+ 0: The total amount of wall time                        = 244.504062
+ 0: The maximum resident set size (KB)                   = 964732
 
 Test 135 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_3072x1536_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_3072x1536_cfsr
 Checking test 136 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 285.275057
- 0: The maximum resident set size (KB)                   = 2257540
+ 0: The total amount of wall time                        = 368.595582
+ 0: The maximum resident set size (KB)                   = 2197032
 
 Test 136 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_gfs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_gfs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_gfs
 Checking test 137 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 286.896573
- 0: The maximum resident set size (KB)                   = 2251288
+ 0: The total amount of wall time                        = 350.333371
+ 0: The maximum resident set size (KB)                   = 2247944
 
 Test 137 datm_cdeps_gfs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_debug_cfsr
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_debug_cfsr
 Checking test 138 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 465.978073
- 0: The maximum resident set size (KB)                   = 910692
+ 0: The total amount of wall time                        = 465.212073
+ 0: The maximum resident set size (KB)                   = 921776
 
 Test 138 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_control_cfsr_faster
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_control_cfsr_faster
 Checking test 139 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 215.326588
- 0: The maximum resident set size (KB)                   = 964060
+ 0: The total amount of wall time                        = 243.328336
+ 0: The maximum resident set size (KB)                   = 970052
 
 Test 139 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_lnd_gswp3
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_lnd_gswp3
 Checking test 140 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4250,14 +4250,14 @@ Checking test 140 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 13.941528
-  0: The maximum resident set size (KB)                   = 246064
+  0: The total amount of wall time                        = 24.762284
+  0: The maximum resident set size (KB)                   = 247500
 
 Test 140 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/datm_cdeps_lnd_gswp3_rst
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/datm_cdeps_lnd_gswp3_rst
 Checking test 141 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4266,14 +4266,14 @@ Checking test 141 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 19.761578
-  0: The maximum resident set size (KB)                   = 243624
+  0: The total amount of wall time                        = 32.783523
+  0: The maximum resident set size (KB)                   = 250072
 
 Test 141 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_p8_atmlnd_sbs
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_p8_atmlnd_sbs
 Checking test 142 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4358,14 +4358,14 @@ Checking test 142 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 290.219215
-  0: The maximum resident set size (KB)                   = 1584776
+  0: The total amount of wall time                        = 338.483756
+  0: The maximum resident set size (KB)                   = 1592584
 
 Test 142 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/atmwav_control_noaero_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/atmwav_control_noaero_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/atmwav_control_noaero_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/atmwav_control_noaero_p8
 Checking test 143 atmwav_control_noaero_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4408,14 +4408,14 @@ Checking test 143 atmwav_control_noaero_p8 results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 130.869141
-  0: The maximum resident set size (KB)                   = 1556860
+  0: The total amount of wall time                        = 133.450504
+  0: The maximum resident set size (KB)                   = 1565248
 
 Test 143 atmwav_control_noaero_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/control_atmwav
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/control_atmwav
 Checking test 144 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4459,14 +4459,14 @@ Checking test 144 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 120.965962
-  0: The maximum resident set size (KB)                   = 598244
+  0: The total amount of wall time                        = 124.797638
+  0: The maximum resident set size (KB)                   = 596796
 
 Test 144 control_atmwav PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/atmaero_control_p8
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/atmaero_control_p8
 Checking test 145 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4510,14 +4510,14 @@ Checking test 145 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 310.451822
-  0: The maximum resident set size (KB)                   = 1636900
+  0: The total amount of wall time                        = 387.358303
+  0: The maximum resident set size (KB)                   = 1654788
 
 Test 145 atmaero_control_p8 PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/atmaero_control_p8_rad
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/atmaero_control_p8_rad
 Checking test 146 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4561,14 +4561,14 @@ Checking test 146 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 374.059363
-  0: The maximum resident set size (KB)                   = 1682180
+  0: The total amount of wall time                        = 447.647854
+  0: The maximum resident set size (KB)                   = 1661176
 
 Test 146 atmaero_control_p8_rad PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_254165/atmaero_control_p8_rad_micro
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs4/HFIP/h-nems/Jong.Kim/RT_RUNDIRS/Jong.Kim/FV3_RT/rt_298933/atmaero_control_p8_rad_micro
 Checking test 147 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4612,12 +4612,12 @@ Checking test 147 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 381.022397
-  0: The maximum resident set size (KB)                   = 1684424
+  0: The total amount of wall time                        = 447.623830
+  0: The maximum resident set size (KB)                   = 1687464
 
 Test 147 atmaero_control_p8_rad_micro PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  5 22:02:09 UTC 2023
-Elapsed time: 02h:58m:26s. Have a nice day!
+Thu May 11 01:34:59 UTC 2023
+Elapsed time: 03h:08m:09s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,43 +1,43 @@
-Fri May  5 07:52:08 CDT 2023
+Wed May 10 18:27:30 CDT 2023
 Start Regression test
 
-Compile 001 elapsed time 727 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 784 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 737 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 252 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 231 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 672 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 678 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 848 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 697 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 659 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 591 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 579 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 789 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 806 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 739 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 298 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 259 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 632 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 715 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 889 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 693 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 665 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 610 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 609 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 013 elapsed time 744 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 234 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 015 elapsed time 222 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 016 elapsed time 610 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 240 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 015 elapsed time 217 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 016 elapsed time 579 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 017 elapsed time 576 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 228 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 230 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 655 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 213 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 768 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 642 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 202 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 025 elapsed time 124 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 026 elapsed time 207 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 027 elapsed time 52 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 028 elapsed time 615 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 029 elapsed time 644 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 030 elapsed time 620 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 552 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 582 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 224 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 034 elapsed time 673 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 211 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 212 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 582 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 260 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 742 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 651 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 232 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 025 elapsed time 131 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 026 elapsed time 190 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 027 elapsed time 55 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 028 elapsed time 620 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 029 elapsed time 628 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 030 elapsed time 621 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 596 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 592 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 172 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 034 elapsed time 624 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_mixedmode
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_p8_mixedmode
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -102,14 +102,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 307.548649
-  0: The maximum resident set size (KB)                   = 3139896
+  0: The total amount of wall time                        = 304.783444
+  0: The maximum resident set size (KB)                   = 3138032
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_gfsv17
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_gfsv17
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_gfsv17
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_gfsv17
 Checking test 002 cpld_control_gfsv17 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -173,14 +173,14 @@ Checking test 002 cpld_control_gfsv17 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 232.241227
-  0: The maximum resident set size (KB)                   = 1720856
+  0: The total amount of wall time                        = 226.117366
+  0: The maximum resident set size (KB)                   = 1729428
 
 Test 002 cpld_control_gfsv17 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_p8
 Checking test 003 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -245,14 +245,14 @@ Checking test 003 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 357.914099
-  0: The maximum resident set size (KB)                   = 3177288
+  0: The total amount of wall time                        = 342.728577
+  0: The maximum resident set size (KB)                   = 3178920
 
 Test 003 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_restart_p8
 Checking test 004 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -305,14 +305,14 @@ Checking test 004 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 202.296976
-  0: The maximum resident set size (KB)                   = 3047632
+  0: The total amount of wall time                        = 201.357250
+  0: The maximum resident set size (KB)                   = 3043440
 
 Test 004 cpld_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_qr_p8
 Checking test 005 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -377,14 +377,14 @@ Checking test 005 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 360.179599
-  0: The maximum resident set size (KB)                   = 3188064
+  0: The total amount of wall time                        = 347.144214
+  0: The maximum resident set size (KB)                   = 3192532
 
 Test 005 cpld_control_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_restart_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_restart_qr_p8
 Checking test 006 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -437,14 +437,14 @@ Checking test 006 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 208.385827
-  0: The maximum resident set size (KB)                   = 3058176
+  0: The total amount of wall time                        = 209.595476
+  0: The maximum resident set size (KB)                   = 3060468
 
 Test 006 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_2threads_p8
 Checking test 007 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -497,14 +497,14 @@ Checking test 007 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 409.268482
-  0: The maximum resident set size (KB)                   = 3520716
+  0: The total amount of wall time                        = 399.097572
+  0: The maximum resident set size (KB)                   = 3508500
 
 Test 007 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_decomp_p8
 Checking test 008 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -557,14 +557,14 @@ Checking test 008 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 355.210028
-  0: The maximum resident set size (KB)                   = 3173276
+  0: The total amount of wall time                        = 344.196890
+  0: The maximum resident set size (KB)                   = 3167584
 
 Test 008 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_mpi_p8
 Checking test 009 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -617,14 +617,14 @@ Checking test 009 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 300.078595
-  0: The maximum resident set size (KB)                   = 3014876
+  0: The total amount of wall time                        = 286.305768
+  0: The maximum resident set size (KB)                   = 3027836
 
 Test 009 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_ciceC_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_ciceC_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_ciceC_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_ciceC_p8
 Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -689,14 +689,14 @@ Checking test 010 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 356.780353
-  0: The maximum resident set size (KB)                   = 3188632
+  0: The total amount of wall time                        = 341.148062
+  0: The maximum resident set size (KB)                   = 3175780
 
 Test 010 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -749,14 +749,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 647.009273
-  0: The maximum resident set size (KB)                   = 3263292
+  0: The total amount of wall time                        = 633.885372
+  0: The maximum resident set size (KB)                   = 3260216
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -809,14 +809,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 468.804715
-  0: The maximum resident set size (KB)                   = 3158964
+  0: The total amount of wall time                        = 439.684514
+  0: The maximum resident set size (KB)                   = 3165200
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_bmark_p8
 Checking test 013 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -864,14 +864,14 @@ Checking test 013 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 873.910371
-   0: The maximum resident set size (KB)                   = 4028124
+   0: The total amount of wall time                        = 869.455527
+   0: The maximum resident set size (KB)                   = 4040208
 
 Test 013 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_restart_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_restart_bmark_p8
 Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -919,14 +919,14 @@ Checking test 014 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 558.280717
-   0: The maximum resident set size (KB)                   = 3977876
+   0: The total amount of wall time                        = 554.528805
+   0: The maximum resident set size (KB)                   = 3974708
 
 Test 014 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_noaero_p8
 Checking test 015 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -990,14 +990,14 @@ Checking test 015 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 257.305183
-  0: The maximum resident set size (KB)                   = 1720788
+  0: The total amount of wall time                        = 257.114752
+  0: The maximum resident set size (KB)                   = 1729680
 
 Test 015 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c96_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_nowave_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_nowave_noaero_p8
 Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1059,14 +1059,14 @@ Checking test 016 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 260.432685
-  0: The maximum resident set size (KB)                   = 1760224
+  0: The total amount of wall time                        = 258.990910
+  0: The maximum resident set size (KB)                   = 1772120
 
 Test 016 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_debug_p8
 Checking test 017 cpld_debug_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1119,14 +1119,14 @@ Checking test 017 cpld_debug_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 555.601098
-  0: The maximum resident set size (KB)                   = 3240692
+  0: The total amount of wall time                        = 556.966036
+  0: The maximum resident set size (KB)                   = 3242056
 
 Test 017 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_debug_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_debug_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_debug_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_debug_noaero_p8
 Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1178,14 +1178,14 @@ Checking test 018 cpld_debug_noaero_p8 results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 377.061931
-  0: The maximum resident set size (KB)                   = 1744384
+  0: The total amount of wall time                        = 380.998458
+  0: The maximum resident set size (KB)                   = 1741760
 
 Test 018 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_noaero_p8_agrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_noaero_p8_agrid
 Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1247,14 +1247,14 @@ Checking test 019 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 270.702443
-  0: The maximum resident set size (KB)                   = 1759696
+  0: The total amount of wall time                        = 268.288870
+  0: The maximum resident set size (KB)                   = 1766896
 
 Test 019 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_c48
 Checking test 020 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1304,14 +1304,14 @@ Checking test 020 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 506.490802
- 0: The maximum resident set size (KB)                   = 2812488
+ 0: The total amount of wall time                        = 507.619710
+ 0: The maximum resident set size (KB)                   = 2750000
 
 Test 020 cpld_control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_warmstart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_warmstart_c48
 Checking test 021 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1361,14 +1361,14 @@ Checking test 021 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 139.360241
- 0: The maximum resident set size (KB)                   = 2809168
+ 0: The total amount of wall time                        = 140.884138
+ 0: The maximum resident set size (KB)                   = 2800672
 
 Test 021 cpld_warmstart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_restart_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_restart_c48
 Checking test 022 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1418,14 +1418,14 @@ Checking test 022 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 76.010560
- 0: The maximum resident set size (KB)                   = 2250096
+ 0: The total amount of wall time                        = 78.571464
+ 0: The maximum resident set size (KB)                   = 2186136
 
 Test 022 cpld_restart_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_faster
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/cpld_control_p8_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/cpld_control_p8_faster
 Checking test 023 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1490,14 +1490,14 @@ Checking test 023 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 327.169150
-  0: The maximum resident set size (KB)                   = 3184968
+  0: The total amount of wall time                        = 324.852593
+  0: The maximum resident set size (KB)                   = 3190676
 
 Test 023 cpld_control_p8_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_flake
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_flake
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_flake
 Checking test 024 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1508,14 +1508,14 @@ Checking test 024 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 197.381963
-  0: The maximum resident set size (KB)                   = 682792
+  0: The total amount of wall time                        = 193.680674
+  0: The maximum resident set size (KB)                   = 680176
 
 Test 024 control_flake PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_CubedSphereGrid
 Checking test 025 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1542,28 +1542,28 @@ Checking test 025 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 132.555403
-  0: The maximum resident set size (KB)                   = 638180
+  0: The total amount of wall time                        = 131.602900
+  0: The maximum resident set size (KB)                   = 634836
 
 Test 025 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_CubedSphereGrid_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_CubedSphereGrid_parallel
 Checking test 026 control_CubedSphereGrid_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 129.343668
-  0: The maximum resident set size (KB)                   = 628436
+  0: The total amount of wall time                        = 128.035564
+  0: The maximum resident set size (KB)                   = 632468
 
 Test 026 control_CubedSphereGrid_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_latlon
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_latlon
 Checking test 027 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1574,14 +1574,14 @@ Checking test 027 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.839770
-  0: The maximum resident set size (KB)                   = 632208
+  0: The total amount of wall time                        = 135.521712
+  0: The maximum resident set size (KB)                   = 631084
 
 Test 027 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_wrtGauss_netcdf_parallel
 Checking test 028 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1592,14 +1592,14 @@ Checking test 028 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.458043
-  0: The maximum resident set size (KB)                   = 628664
+  0: The total amount of wall time                        = 137.496390
+  0: The maximum resident set size (KB)                   = 634172
 
 Test 028 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c48
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_c48
 Checking test 029 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1638,14 +1638,14 @@ Checking test 029 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 344.387035
-0: The maximum resident set size (KB)                   = 826364
+0: The total amount of wall time                        = 347.311052
+0: The maximum resident set size (KB)                   = 819488
 
 Test 029 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c192
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_c192
 Checking test 030 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1656,14 +1656,14 @@ Checking test 030 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 527.800311
-  0: The maximum resident set size (KB)                   = 765032
+  0: The total amount of wall time                        = 524.307000
+  0: The maximum resident set size (KB)                   = 762468
 
 Test 030 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_c384
 Checking test 031 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1674,14 +1674,14 @@ Checking test 031 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 631.923186
-  0: The maximum resident set size (KB)                   = 1235784
+  0: The total amount of wall time                        = 576.098833
+  0: The maximum resident set size (KB)                   = 1236168
 
 Test 031 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384gdas
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_c384gdas
 Checking test 032 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1724,14 +1724,14 @@ Checking test 032 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 563.613496
-  0: The maximum resident set size (KB)                   = 1344236
+  0: The total amount of wall time                        = 508.039881
+  0: The maximum resident set size (KB)                   = 1338172
 
 Test 032 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_stochy
 Checking test 033 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1742,28 +1742,28 @@ Checking test 033 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 89.376188
-  0: The maximum resident set size (KB)                   = 633812
+  0: The total amount of wall time                        = 88.560396
+  0: The maximum resident set size (KB)                   = 636520
 
 Test 033 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_stochy_restart
 Checking test 034 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.065242
-  0: The maximum resident set size (KB)                   = 481184
+  0: The total amount of wall time                        = 47.662982
+  0: The maximum resident set size (KB)                   = 487224
 
 Test 034 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_lndp
 Checking test 035 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1774,14 +1774,14 @@ Checking test 035 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.396312
-  0: The maximum resident set size (KB)                   = 633560
+  0: The total amount of wall time                        = 82.219534
+  0: The maximum resident set size (KB)                   = 634300
 
 Test 035 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr4
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_iovr4
 Checking test 036 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1796,14 +1796,14 @@ Checking test 036 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.397578
-  0: The maximum resident set size (KB)                   = 631192
+  0: The total amount of wall time                        = 136.043330
+  0: The maximum resident set size (KB)                   = 633416
 
 Test 036 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr5
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_iovr5
 Checking test 037 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1818,14 +1818,14 @@ Checking test 037 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.675043
-  0: The maximum resident set size (KB)                   = 634052
+  0: The total amount of wall time                        = 136.516053
+  0: The maximum resident set size (KB)                   = 633660
 
 Test 037 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_p8
 Checking test 038 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1872,14 +1872,14 @@ Checking test 038 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 173.210018
-  0: The maximum resident set size (KB)                   = 1599508
+  0: The total amount of wall time                        = 168.584653
+  0: The maximum resident set size (KB)                   = 1603736
 
 Test 038 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_restart_p8
 Checking test 039 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1918,14 +1918,14 @@ Checking test 039 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.870671
-  0: The maximum resident set size (KB)                   = 882340
+  0: The total amount of wall time                        = 89.698370
+  0: The maximum resident set size (KB)                   = 875464
 
 Test 039 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_qr_p8
 Checking test 040 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1972,14 +1972,14 @@ Checking test 040 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 173.289049
-  0: The maximum resident set size (KB)                   = 1608020
+  0: The total amount of wall time                        = 168.289973
+  0: The maximum resident set size (KB)                   = 1613960
 
 Test 040 control_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_restart_qr_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_restart_qr_p8
 Checking test 041 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2018,14 +2018,14 @@ Checking test 041 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 91.708427
-  0: The maximum resident set size (KB)                   = 874988
+  0: The total amount of wall time                        = 91.122871
+  0: The maximum resident set size (KB)                   = 866400
 
 Test 041 control_restart_qr_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_decomp_p8
 Checking test 042 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2068,14 +2068,14 @@ Checking test 042 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 178.654045
-  0: The maximum resident set size (KB)                   = 1597396
+  0: The total amount of wall time                        = 175.274627
+  0: The maximum resident set size (KB)                   = 1589308
 
 Test 042 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_2threads_p8
 Checking test 043 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2118,14 +2118,14 @@ Checking test 043 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.308877
-  0: The maximum resident set size (KB)                   = 1701376
+  0: The total amount of wall time                        = 176.512441
+  0: The maximum resident set size (KB)                   = 1697292
 
 Test 043 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_lndp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_p8_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_p8_lndp
 Checking test 044 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2144,14 +2144,14 @@ Checking test 044 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 311.614121
-  0: The maximum resident set size (KB)                   = 1613840
+  0: The total amount of wall time                        = 313.563192
+  0: The maximum resident set size (KB)                   = 1596964
 
 Test 044 control_p8_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_rrtmgp
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_p8_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_p8_rrtmgp
 Checking test 045 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2198,14 +2198,14 @@ Checking test 045 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.532895
-  0: The maximum resident set size (KB)                   = 1679000
+  0: The total amount of wall time                        = 228.091853
+  0: The maximum resident set size (KB)                   = 1671420
 
 Test 045 control_p8_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_mynn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_p8_mynn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_p8_mynn
 Checking test 046 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2252,14 +2252,14 @@ Checking test 046 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.067298
-  0: The maximum resident set size (KB)                   = 1608360
+  0: The total amount of wall time                        = 170.963104
+  0: The maximum resident set size (KB)                   = 1609112
 
 Test 046 control_p8_mynn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/merra2_thompson
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/merra2_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/merra2_thompson
 Checking test 047 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2306,14 +2306,14 @@ Checking test 047 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.554459
-  0: The maximum resident set size (KB)                   = 1615092
+  0: The total amount of wall time                        = 190.082642
+  0: The maximum resident set size (KB)                   = 1617172
 
 Test 047 merra2_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_control
 Checking test 048 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2324,28 +2324,28 @@ Checking test 048 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 298.280553
-  0: The maximum resident set size (KB)                   = 872800
+  0: The total amount of wall time                        = 296.189199
+  0: The maximum resident set size (KB)                   = 870364
 
 Test 048 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_restart
 Checking test 049 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 152.991268
-  0: The maximum resident set size (KB)                   = 864688
+  0: The total amount of wall time                        = 152.240385
+  0: The maximum resident set size (KB)                   = 866668
 
 Test 049 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_control_qr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_control_qr
 Checking test 050 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2356,28 +2356,28 @@ Checking test 050 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 299.385670
-  0: The maximum resident set size (KB)                   = 871728
+  0: The total amount of wall time                        = 297.388733
+  0: The maximum resident set size (KB)                   = 870316
 
 Test 050 regional_control_qr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_restart_qr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_restart_qr
 Checking test 051 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 152.305174
-  0: The maximum resident set size (KB)                   = 863752
+  0: The total amount of wall time                        = 151.383685
+  0: The maximum resident set size (KB)                   = 865768
 
 Test 051 regional_restart_qr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_decomp
 Checking test 052 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2388,14 +2388,14 @@ Checking test 052 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 315.880143
-  0: The maximum resident set size (KB)                   = 864372
+  0: The total amount of wall time                        = 313.666154
+  0: The maximum resident set size (KB)                   = 866664
 
 Test 052 regional_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_2threads
 Checking test 053 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2406,14 +2406,14 @@ Checking test 053 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 207.590165
-  0: The maximum resident set size (KB)                   = 851968
+  0: The total amount of wall time                        = 206.972686
+  0: The maximum resident set size (KB)                   = 850944
 
 Test 053 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_noquilt
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_noquilt
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_noquilt
 Checking test 054 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2421,28 +2421,28 @@ Checking test 054 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 317.554266
-  0: The maximum resident set size (KB)                   = 861256
+  0: The total amount of wall time                        = 315.453502
+  0: The maximum resident set size (KB)                   = 857224
 
 Test 054 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_netcdf_parallel
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_netcdf_parallel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_netcdf_parallel
 Checking test 055 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf006.nc .........OK
+ Comparing phyf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 295.690273
-  0: The maximum resident set size (KB)                   = 864824
+  0: The total amount of wall time                        = 291.076687
+  0: The maximum resident set size (KB)                   = 865256
 
 Test 055 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_2dwrtdecomp
 Checking test 056 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2453,14 +2453,14 @@ Checking test 056 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 295.887629
-  0: The maximum resident set size (KB)                   = 871872
+  0: The total amount of wall time                        = 295.177026
+  0: The maximum resident set size (KB)                   = 871084
 
 Test 056 regional_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/fv3_regional_wofs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_wofs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/fv3_regional_wofs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_wofs
 Checking test 057 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2471,14 +2471,14 @@ Checking test 057 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 374.714638
-  0: The maximum resident set size (KB)                   = 630480
+  0: The total amount of wall time                        = 373.537564
+  0: The maximum resident set size (KB)                   = 630584
 
 Test 057 regional_wofs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_control
 Checking test 058 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2525,14 +2525,14 @@ Checking test 058 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.895601
-  0: The maximum resident set size (KB)                   = 1061504
+  0: The total amount of wall time                        = 461.660675
+  0: The maximum resident set size (KB)                   = 1016048
 
 Test 058 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_spp_sppt_shum_skeb
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_spp_sppt_shum_skeb
 Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2543,14 +2543,14 @@ Checking test 059 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 269.806506
-  0: The maximum resident set size (KB)                   = 1195036
+  0: The total amount of wall time                        = 269.022009
+  0: The maximum resident set size (KB)                   = 1180944
 
 Test 059 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_decomp
 Checking test 060 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2597,14 +2597,14 @@ Checking test 060 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 486.889317
-  0: The maximum resident set size (KB)                   = 1001408
+  0: The total amount of wall time                        = 478.279357
+  0: The maximum resident set size (KB)                   = 1000272
 
 Test 060 rap_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_2threads
 Checking test 061 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2651,14 +2651,14 @@ Checking test 061 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 470.925786
-  0: The maximum resident set size (KB)                   = 1140860
+  0: The total amount of wall time                        = 471.316427
+  0: The maximum resident set size (KB)                   = 1145936
 
 Test 061 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_restart
 Checking test 062 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2697,14 +2697,14 @@ Checking test 062 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.984834
-  0: The maximum resident set size (KB)                   = 964600
+  0: The total amount of wall time                        = 232.309970
+  0: The maximum resident set size (KB)                   = 967232
 
 Test 062 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_sfcdiff
 Checking test 063 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2751,14 +2751,14 @@ Checking test 063 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.907947
-  0: The maximum resident set size (KB)                   = 1056936
+  0: The total amount of wall time                        = 459.624943
+  0: The maximum resident set size (KB)                   = 1058996
 
 Test 063 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_sfcdiff_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_sfcdiff_decomp
 Checking test 064 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2805,14 +2805,14 @@ Checking test 064 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 484.870987
-  0: The maximum resident set size (KB)                   = 1001776
+  0: The total amount of wall time                        = 484.349158
+  0: The maximum resident set size (KB)                   = 1001944
 
 Test 064 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_sfcdiff_restart
 Checking test 065 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2851,14 +2851,14 @@ Checking test 065 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 341.602714
-  0: The maximum resident set size (KB)                   = 985628
+  0: The total amount of wall time                        = 340.413741
+  0: The maximum resident set size (KB)                   = 986568
 
 Test 065 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control
 Checking test 066 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2905,14 +2905,14 @@ Checking test 066 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 427.895376
-  0: The maximum resident set size (KB)                   = 1061528
+  0: The total amount of wall time                        = 428.778457
+  0: The maximum resident set size (KB)                   = 1057804
 
 Test 066 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_decomp
 Checking test 067 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2959,14 +2959,14 @@ Checking test 067 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 451.023666
-  0: The maximum resident set size (KB)                   = 1000320
+  0: The total amount of wall time                        = 449.446011
+  0: The maximum resident set size (KB)                   = 1002220
 
 Test 067 hrrr_control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_2threads
 Checking test 068 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3013,28 +3013,28 @@ Checking test 068 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 363.360954
-  0: The maximum resident set size (KB)                   = 1081184
+  0: The total amount of wall time                        = 362.025996
+  0: The maximum resident set size (KB)                   = 1080208
 
 Test 068 hrrr_control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_restart
 Checking test 069 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 317.470174
-  0: The maximum resident set size (KB)                   = 986840
+  0: The total amount of wall time                        = 318.459651
+  0: The maximum resident set size (KB)                   = 993084
 
 Test 069 hrrr_control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_v1beta
 Checking test 070 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3081,14 +3081,14 @@ Checking test 070 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.890847
-  0: The maximum resident set size (KB)                   = 1052904
+  0: The total amount of wall time                        = 453.819290
+  0: The maximum resident set size (KB)                   = 1058680
 
 Test 070 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_v1nssl
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_v1nssl
 Checking test 071 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3103,14 +3103,14 @@ Checking test 071 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 539.516662
-  0: The maximum resident set size (KB)                   = 692356
+  0: The total amount of wall time                        = 536.274042
+  0: The maximum resident set size (KB)                   = 695472
 
 Test 071 rrfs_v1nssl PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_v1nssl_nohailnoccn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_v1nssl_nohailnoccn
 Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3125,14 +3125,14 @@ Checking test 072 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 524.216888
-  0: The maximum resident set size (KB)                   = 756668
+  0: The total amount of wall time                        = 524.350976
+  0: The maximum resident set size (KB)                   = 757424
 
 Test 072 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_smoke_conus13km_hrrr_warm
 Checking test 073 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3141,14 +3141,14 @@ Checking test 073 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 153.538731
-  0: The maximum resident set size (KB)                   = 1038772
+  0: The total amount of wall time                        = 151.948227
+  0: The maximum resident set size (KB)                   = 1027112
 
 Test 073 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3157,14 +3157,14 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 100.793474
-  0: The maximum resident set size (KB)                   = 942900
+  0: The total amount of wall time                        = 98.056488
+  0: The maximum resident set size (KB)                   = 944072
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_conus13km_hrrr_warm
 Checking test 075 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3173,14 +3173,14 @@ Checking test 075 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 134.821108
-  0: The maximum resident set size (KB)                   = 990864
+  0: The total amount of wall time                        = 131.756414
+  0: The maximum resident set size (KB)                   = 991664
 
 Test 075 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 076 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3189,26 +3189,26 @@ Checking test 076 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 153.938614
-  0: The maximum resident set size (KB)                   = 1035368
+  0: The total amount of wall time                        = 149.315254
+  0: The maximum resident set size (KB)                   = 1037500
 
 Test 076 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 077 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 70.428764
-  0: The maximum resident set size (KB)                   = 976392
+  0: The total amount of wall time                        = 70.372633
+  0: The maximum resident set size (KB)                   = 981920
 
 Test 077 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_csawmg
 Checking test 078 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3219,14 +3219,14 @@ Checking test 078 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 340.238892
-  0: The maximum resident set size (KB)                   = 725100
+  0: The total amount of wall time                        = 340.276044
+  0: The maximum resident set size (KB)                   = 727356
 
 Test 078 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_csawmgt
 Checking test 079 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3237,14 +3237,14 @@ Checking test 079 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 336.681337
-  0: The maximum resident set size (KB)                   = 728808
+  0: The total amount of wall time                        = 336.104645
+  0: The maximum resident set size (KB)                   = 729180
 
 Test 079 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_ras
 Checking test 080 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3255,26 +3255,26 @@ Checking test 080 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 180.969201
-  0: The maximum resident set size (KB)                   = 723840
+  0: The total amount of wall time                        = 181.822423
+  0: The maximum resident set size (KB)                   = 722972
 
 Test 080 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_wam
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_wam
 Checking test 081 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 112.684297
-  0: The maximum resident set size (KB)                   = 648476
+  0: The total amount of wall time                        = 111.402664
+  0: The maximum resident set size (KB)                   = 642956
 
 Test 081 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_faster
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_p8_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_p8_faster
 Checking test 082 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3321,14 +3321,14 @@ Checking test 082 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.228930
-  0: The maximum resident set size (KB)                   = 1606244
+  0: The total amount of wall time                        = 153.663414
+  0: The maximum resident set size (KB)                   = 1605324
 
 Test 082 control_p8_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control_faster
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_control_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_control_faster
 Checking test 083 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3339,56 +3339,56 @@ Checking test 083 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 269.397706
-  0: The maximum resident set size (KB)                   = 875092
+  0: The total amount of wall time                        = 269.708525
+  0: The maximum resident set size (KB)                   = 873092
 
 Test 083 regional_control_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 861.862194
-  0: The maximum resident set size (KB)                   = 1060576
+  0: The total amount of wall time                        = 842.240252
+  0: The maximum resident set size (KB)                   = 1058068
 
 Test 084 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 482.121075
-  0: The maximum resident set size (KB)                   = 973464
+  0: The total amount of wall time                        = 481.154905
+  0: The maximum resident set size (KB)                   = 980192
 
 Test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_conus13km_hrrr_warm_debug
 Checking test 086 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 755.813607
-  0: The maximum resident set size (KB)                   = 1021672
+  0: The total amount of wall time                        = 762.267815
+  0: The maximum resident set size (KB)                   = 1014328
 
 Test 086 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_CubedSphereGrid_debug
 Checking test 087 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3415,348 +3415,348 @@ Checking test 087 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 151.546177
-  0: The maximum resident set size (KB)                   = 788608
+  0: The total amount of wall time                        = 147.981857
+  0: The maximum resident set size (KB)                   = 796336
 
 Test 087 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_wrtGauss_netcdf_parallel_debug
 Checking test 088 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.571962
-  0: The maximum resident set size (KB)                   = 789040
+  0: The total amount of wall time                        = 151.160277
+  0: The maximum resident set size (KB)                   = 794992
 
 Test 088 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_stochy_debug
 Checking test 089 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.984955
-  0: The maximum resident set size (KB)                   = 802700
+  0: The total amount of wall time                        = 176.432635
+  0: The maximum resident set size (KB)                   = 766396
 
 Test 089 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_lndp_debug
 Checking test 090 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.047219
-  0: The maximum resident set size (KB)                   = 797284
+  0: The total amount of wall time                        = 151.870081
+  0: The maximum resident set size (KB)                   = 797916
 
 Test 090 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_csawmg_debug
 Checking test 091 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.427728
-  0: The maximum resident set size (KB)                   = 841196
+  0: The total amount of wall time                        = 230.710758
+  0: The maximum resident set size (KB)                   = 839100
 
 Test 091 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_csawmgt_debug
 Checking test 092 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.848874
-  0: The maximum resident set size (KB)                   = 841652
+  0: The total amount of wall time                        = 232.745460
+  0: The maximum resident set size (KB)                   = 845884
 
 Test 092 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_ras_debug
 Checking test 093 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.826275
-  0: The maximum resident set size (KB)                   = 801220
+  0: The total amount of wall time                        = 153.646515
+  0: The maximum resident set size (KB)                   = 806488
 
 Test 093 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_diag_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_diag_debug
 Checking test 094 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.382737
-  0: The maximum resident set size (KB)                   = 852888
+  0: The total amount of wall time                        = 158.302553
+  0: The maximum resident set size (KB)                   = 854548
 
 Test 094 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_debug_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_debug_p8
 Checking test 095 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.103079
-  0: The maximum resident set size (KB)                   = 1622220
+  0: The total amount of wall time                        = 169.925049
+  0: The maximum resident set size (KB)                   = 1618872
 
 Test 095 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_debug
 Checking test 096 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 990.838393
-  0: The maximum resident set size (KB)                   = 881360
+  0: The total amount of wall time                        = 1000.480690
+  0: The maximum resident set size (KB)                   = 877500
 
 Test 096 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_control_debug
 Checking test 097 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.305433
-  0: The maximum resident set size (KB)                   = 1178580
+  0: The total amount of wall time                        = 280.340279
+  0: The maximum resident set size (KB)                   = 1174328
 
 Test 097 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_debug
 Checking test 098 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.143827
-  0: The maximum resident set size (KB)                   = 1167300
+  0: The total amount of wall time                        = 270.221344
+  0: The maximum resident set size (KB)                   = 1170976
 
 Test 098 hrrr_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_unified_drag_suite_debug
 Checking test 099 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.229206
-  0: The maximum resident set size (KB)                   = 1173984
+  0: The total amount of wall time                        = 283.883072
+  0: The maximum resident set size (KB)                   = 1169168
 
 Test 099 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_diag_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_diag_debug
 Checking test 100 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.974158
-  0: The maximum resident set size (KB)                   = 1258732
+  0: The total amount of wall time                        = 289.246877
+  0: The maximum resident set size (KB)                   = 1252252
 
 Test 100 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_cires_ugwp_debug
 Checking test 101 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.329736
-  0: The maximum resident set size (KB)                   = 1170752
+  0: The total amount of wall time                        = 275.106297
+  0: The maximum resident set size (KB)                   = 1168500
 
 Test 101 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_unified_ugwp_debug
 Checking test 102 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.056311
-  0: The maximum resident set size (KB)                   = 1172572
+  0: The total amount of wall time                        = 290.052547
+  0: The maximum resident set size (KB)                   = 1167980
 
 Test 102 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_lndp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_lndp_debug
 Checking test 103 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.325403
-  0: The maximum resident set size (KB)                   = 1171596
+  0: The total amount of wall time                        = 290.914734
+  0: The maximum resident set size (KB)                   = 1131588
 
 Test 103 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_progcld_thompson_debug
 Checking test 104 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.948007
-  0: The maximum resident set size (KB)                   = 1173772
+  0: The total amount of wall time                        = 284.239099
+  0: The maximum resident set size (KB)                   = 1171016
 
 Test 104 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_noah_debug
 Checking test 105 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.197805
-  0: The maximum resident set size (KB)                   = 1167008
+  0: The total amount of wall time                        = 272.099758
+  0: The maximum resident set size (KB)                   = 1171724
 
 Test 105 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_sfcdiff_debug
 Checking test 106 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.406909
-  0: The maximum resident set size (KB)                   = 1171700
+  0: The total amount of wall time                        = 285.812125
+  0: The maximum resident set size (KB)                   = 1174276
 
 Test 106 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 107 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 470.800425
-  0: The maximum resident set size (KB)                   = 1167152
+  0: The total amount of wall time                        = 463.602744
+  0: The maximum resident set size (KB)                   = 1172284
 
 Test 107 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rrfs_v1beta_debug
 Checking test 108 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.637038
-  0: The maximum resident set size (KB)                   = 1169412
+  0: The total amount of wall time                        = 275.273713
+  0: The maximum resident set size (KB)                   = 1168396
 
 Test 108 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_clm_lake_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_clm_lake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_clm_lake_debug
 Checking test 109 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.315082
-  0: The maximum resident set size (KB)                   = 1170124
+  0: The total amount of wall time                        = 346.736994
+  0: The maximum resident set size (KB)                   = 1177116
 
 Test 109 rap_clm_lake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_flake_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_flake_debug
 Checking test 110 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.378905
-  0: The maximum resident set size (KB)                   = 1171508
+  0: The total amount of wall time                        = 278.037885
+  0: The maximum resident set size (KB)                   = 1167432
 
 Test 110 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_wam_debug
 Checking test 111 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 282.596882
-  0: The maximum resident set size (KB)                   = 533312
+  0: The total amount of wall time                        = 291.412202
+  0: The maximum resident set size (KB)                   = 522304
 
 Test 111 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 112 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3767,14 +3767,14 @@ Checking test 112 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 274.528373
-  0: The maximum resident set size (KB)                   = 1081404
+  0: The total amount of wall time                        = 253.782045
+  0: The maximum resident set size (KB)                   = 1070816
 
 Test 112 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_control_dyn32_phy32
 Checking test 113 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3821,14 +3821,14 @@ Checking test 113 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 388.347261
-  0: The maximum resident set size (KB)                   = 998352
+  0: The total amount of wall time                        = 383.693297
+  0: The maximum resident set size (KB)                   = 1006656
 
 Test 113 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_dyn32_phy32
 Checking test 114 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3875,14 +3875,14 @@ Checking test 114 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.713580
-  0: The maximum resident set size (KB)                   = 961340
+  0: The total amount of wall time                        = 189.323552
+  0: The maximum resident set size (KB)                   = 953728
 
 Test 114 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_2threads_dyn32_phy32
 Checking test 115 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3929,14 +3929,14 @@ Checking test 115 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 402.556923
-  0: The maximum resident set size (KB)                   = 1020248
+  0: The total amount of wall time                        = 396.535002
+  0: The maximum resident set size (KB)                   = 1017732
 
 Test 115 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_2threads_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_2threads_dyn32_phy32
 Checking test 116 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3983,14 +3983,14 @@ Checking test 116 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.204011
-  0: The maximum resident set size (KB)                   = 933068
+  0: The total amount of wall time                        = 162.733031
+  0: The maximum resident set size (KB)                   = 932904
 
 Test 116 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_decomp_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_decomp_dyn32_phy32
 Checking test 117 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4037,14 +4037,14 @@ Checking test 117 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 220.935373
-  0: The maximum resident set size (KB)                   = 910912
+  0: The total amount of wall time                        = 199.464128
+  0: The maximum resident set size (KB)                   = 903816
 
 Test 117 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_restart_dyn32_phy32
 Checking test 118 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4083,28 +4083,28 @@ Checking test 118 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 282.232777
-  0: The maximum resident set size (KB)                   = 944588
+  0: The total amount of wall time                        = 285.220827
+  0: The maximum resident set size (KB)                   = 951888
 
 Test 118 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_restart_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_restart_dyn32_phy32
 Checking test 119 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 99.475187
-  0: The maximum resident set size (KB)                   = 867708
+  0: The total amount of wall time                        = 99.787600
+  0: The maximum resident set size (KB)                   = 872504
 
 Test 119 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn64_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_control_dyn64_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_control_dyn64_phy32
 Checking test 120 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4151,81 +4151,81 @@ Checking test 120 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 252.735257
-  0: The maximum resident set size (KB)                   = 967712
+  0: The total amount of wall time                        = 245.107224
+  0: The maximum resident set size (KB)                   = 976300
 
 Test 120 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_control_debug_dyn32_phy32
 Checking test 121 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.909213
-  0: The maximum resident set size (KB)                   = 1058588
+  0: The total amount of wall time                        = 276.688227
+  0: The maximum resident set size (KB)                   = 1062464
 
 Test 121 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hrrr_control_debug_dyn32_phy32
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hrrr_control_debug_dyn32_phy32
 Checking test 122 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.710847
-  0: The maximum resident set size (KB)                   = 1052336
+  0: The total amount of wall time                        = 277.016229
+  0: The maximum resident set size (KB)                   = 1018332
 
 Test 122 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/rap_control_dyn64_phy32_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/rap_control_dyn64_phy32_debug
 Checking test 123 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.836778
-  0: The maximum resident set size (KB)                   = 1102768
+  0: The total amount of wall time                        = 284.564661
+  0: The maximum resident set size (KB)                   = 1100416
 
 Test 123 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_atm
 Checking test 124 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 266.202547
-  0: The maximum resident set size (KB)                   = 1055256
+  0: The total amount of wall time                        = 267.300961
+  0: The maximum resident set size (KB)                   = 1055936
 
 Test 124 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_atm_thompson_gfdlsf
 Checking test 125 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 408.334220
-  0: The maximum resident set size (KB)                   = 1425220
+  0: The total amount of wall time                        = 397.539753
+  0: The maximum resident set size (KB)                   = 1417812
 
 Test 125 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_atm_ocn
 Checking test 126 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4234,14 +4234,14 @@ Checking test 126 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 386.297913
-  0: The maximum resident set size (KB)                   = 1230368
+  0: The total amount of wall time                        = 379.551953
+  0: The maximum resident set size (KB)                   = 1227196
 
 Test 126 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_atm_wav
 Checking test 127 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4250,14 +4250,14 @@ Checking test 127 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 744.574718
-  0: The maximum resident set size (KB)                   = 1258544
+  0: The total amount of wall time                        = 737.412930
+  0: The maximum resident set size (KB)                   = 1255004
 
 Test 127 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_atm_ocn_wav
 Checking test 128 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4268,28 +4268,28 @@ Checking test 128 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 861.853464
-  0: The maximum resident set size (KB)                   = 1275480
+  0: The total amount of wall time                        = 832.896397
+  0: The maximum resident set size (KB)                   = 1280360
 
 Test 128 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_1nest_atm
 Checking test 129 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 361.681654
-  0: The maximum resident set size (KB)                   = 469024
+  0: The total amount of wall time                        = 365.710577
+  0: The maximum resident set size (KB)                   = 506340
 
 Test 129 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_telescopic_2nests_atm
 Checking test 130 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4298,28 +4298,28 @@ Checking test 130 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 411.880648
-  0: The maximum resident set size (KB)                   = 515116
+  0: The total amount of wall time                        = 414.680934
+  0: The maximum resident set size (KB)                   = 518796
 
 Test 130 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_global_1nest_atm
 Checking test 131 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 174.005311
-  0: The maximum resident set size (KB)                   = 355988
+  0: The total amount of wall time                        = 172.890927
+  0: The maximum resident set size (KB)                   = 358560
 
 Test 131 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_global_multiple_4nests_atm
 Checking test 132 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4337,14 +4337,14 @@ Checking test 132 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-  0: The total amount of wall time                        = 463.524626
-  0: The maximum resident set size (KB)                   = 426944
+  0: The total amount of wall time                        = 462.789962
+  0: The maximum resident set size (KB)                   = 426804
 
 Test 132 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_specified_moving_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_specified_moving_1nest_atm
 Checking test 133 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4353,28 +4353,28 @@ Checking test 133 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 230.952308
-  0: The maximum resident set size (KB)                   = 524468
+  0: The total amount of wall time                        = 227.661081
+  0: The maximum resident set size (KB)                   = 519100
 
 Test 133 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_storm_following_1nest_atm
 Checking test 134 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 217.489868
-  0: The maximum resident set size (KB)                   = 521412
+  0: The total amount of wall time                        = 216.531660
+  0: The maximum resident set size (KB)                   = 518116
 
 Test 134 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 135 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4383,42 +4383,42 @@ Checking test 135 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 287.473977
-  0: The maximum resident set size (KB)                   = 573524
+  0: The total amount of wall time                        = 292.161615
+  0: The maximum resident set size (KB)                   = 567684
 
 Test 135 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_global_storm_following_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_global_storm_following_1nest_atm
 Checking test 136 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 67.959181
-  0: The maximum resident set size (KB)                   = 375876
+  0: The total amount of wall time                        = 69.084094
+  0: The maximum resident set size (KB)                   = 376040
 
 Test 136 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 137 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 767.583989
-  0: The maximum resident set size (KB)                   = 591864
+  0: The total amount of wall time                        = 752.147650
+  0: The maximum resident set size (KB)                   = 590652
 
 Test 137 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4429,14 +4429,14 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 563.877845
-  0: The maximum resident set size (KB)                   = 626444
+  0: The total amount of wall time                        = 535.261890
+  0: The maximum resident set size (KB)                   = 624460
 
 Test 138 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_docn
 Checking test 139 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4444,14 +4444,14 @@ Checking test 139 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 356.934013
-  0: The maximum resident set size (KB)                   = 1235900
+  0: The total amount of wall time                        = 363.517440
+  0: The maximum resident set size (KB)                   = 1236368
 
 Test 139 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_docn_oisst
 Checking test 140 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4459,131 +4459,131 @@ Checking test 140 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 363.225906
-  0: The maximum resident set size (KB)                   = 1225252
+  0: The total amount of wall time                        = 359.685450
+  0: The maximum resident set size (KB)                   = 1221832
 
 Test 140 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/hafs_regional_datm_cdeps
 Checking test 141 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 951.555736
-  0: The maximum resident set size (KB)                   = 1040996
+  0: The total amount of wall time                        = 929.652799
+  0: The maximum resident set size (KB)                   = 1044524
 
 Test 141 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_control_cfsr
 Checking test 142 datm_cdeps_control_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.955534
- 0: The maximum resident set size (KB)                   = 1065512
+ 0: The total amount of wall time                        = 147.698649
+ 0: The maximum resident set size (KB)                   = 1036616
 
 Test 142 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_restart_cfsr
 Checking test 143 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 89.270381
- 0: The maximum resident set size (KB)                   = 1016460
+ 0: The total amount of wall time                        = 92.264789
+ 0: The maximum resident set size (KB)                   = 978700
 
 Test 143 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_control_gefs
 Checking test 144 datm_cdeps_control_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.664027
- 0: The maximum resident set size (KB)                   = 976100
+ 0: The total amount of wall time                        = 143.718759
+ 0: The maximum resident set size (KB)                   = 919324
 
 Test 144 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_iau_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_iau_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_iau_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_iau_gefs
 Checking test 145 datm_cdeps_iau_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.715440
- 0: The maximum resident set size (KB)                   = 964232
+ 0: The total amount of wall time                        = 146.154230
+ 0: The maximum resident set size (KB)                   = 932516
 
 Test 145 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_stochy_gefs
 Checking test 146 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.150206
- 0: The maximum resident set size (KB)                   = 929328
+ 0: The total amount of wall time                        = 146.863912
+ 0: The maximum resident set size (KB)                   = 928316
 
 Test 146 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_ciceC_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_ciceC_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_ciceC_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_ciceC_cfsr
 Checking test 147 datm_cdeps_ciceC_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.396475
- 0: The maximum resident set size (KB)                   = 1070740
+ 0: The total amount of wall time                        = 149.666778
+ 0: The maximum resident set size (KB)                   = 1032228
 
 Test 147 datm_cdeps_ciceC_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_bulk_cfsr
 Checking test 148 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.802324
- 0: The maximum resident set size (KB)                   = 1054756
+ 0: The total amount of wall time                        = 150.309627
+ 0: The maximum resident set size (KB)                   = 1047520
 
 Test 148 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_bulk_gefs
 Checking test 149 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.692049
- 0: The maximum resident set size (KB)                   = 976860
+ 0: The total amount of wall time                        = 142.731611
+ 0: The maximum resident set size (KB)                   = 963320
 
 Test 149 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_mx025_cfsr
 Checking test 150 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4592,14 +4592,14 @@ Checking test 150 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 444.133428
-  0: The maximum resident set size (KB)                   = 870464
+  0: The total amount of wall time                        = 438.827774
+  0: The maximum resident set size (KB)                   = 876336
 
 Test 150 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_mx025_gefs
 Checking test 151 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4608,77 +4608,77 @@ Checking test 151 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 454.602074
-  0: The maximum resident set size (KB)                   = 931384
+  0: The total amount of wall time                        = 442.381244
+  0: The maximum resident set size (KB)                   = 929388
 
 Test 151 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_multiple_files_cfsr
 Checking test 152 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.105293
- 0: The maximum resident set size (KB)                   = 1058260
+ 0: The total amount of wall time                        = 144.731025
+ 0: The maximum resident set size (KB)                   = 1062020
 
 Test 152 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_3072x1536_cfsr
 Checking test 153 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.791488
- 0: The maximum resident set size (KB)                   = 2366548
+ 0: The total amount of wall time                        = 198.718340
+ 0: The maximum resident set size (KB)                   = 2355400
 
 Test 153 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_gfs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_gfs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_gfs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_gfs
 Checking test 154 datm_cdeps_gfs results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 199.955753
- 0: The maximum resident set size (KB)                   = 2297492
+ 0: The total amount of wall time                        = 195.904698
+ 0: The maximum resident set size (KB)                   = 2299984
 
 Test 154 datm_cdeps_gfs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_debug_cfsr
 Checking test 155 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 360.055743
- 0: The maximum resident set size (KB)                   = 995636
+ 0: The total amount of wall time                        = 361.350480
+ 0: The maximum resident set size (KB)                   = 964560
 
 Test 155 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_control_cfsr_faster
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_control_cfsr_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_control_cfsr_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_control_cfsr_faster
 Checking test 156 datm_cdeps_control_cfsr_faster results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 159.630534
- 0: The maximum resident set size (KB)                   = 1063276
+ 0: The total amount of wall time                        = 146.158010
+ 0: The maximum resident set size (KB)                   = 1043056
 
 Test 156 datm_cdeps_control_cfsr_faster PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_lnd_gswp3
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_lnd_gswp3
 Checking test 157 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4687,14 +4687,14 @@ Checking test 157 datm_cdeps_lnd_gswp3 results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 8.049735
-  0: The maximum resident set size (KB)                   = 268000
+  0: The total amount of wall time                        = 7.571587
+  0: The maximum resident set size (KB)                   = 263084
 
 Test 157 datm_cdeps_lnd_gswp3 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/datm_cdeps_lnd_gswp3
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/datm_cdeps_lnd_gswp3_rst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/datm_cdeps_lnd_gswp3
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/datm_cdeps_lnd_gswp3_rst
 Checking test 158 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4703,14 +4703,14 @@ Checking test 158 datm_cdeps_lnd_gswp3_rst results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 13.436463
-  0: The maximum resident set size (KB)                   = 248580
+  0: The total amount of wall time                        = 13.069816
+  0: The maximum resident set size (KB)                   = 260276
 
 Test 158 datm_cdeps_lnd_gswp3_rst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_atmlnd_sbs
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_p8_atmlnd_sbs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_p8_atmlnd_sbs
 Checking test 159 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4795,14 +4795,14 @@ Checking test 159 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.902223
-  0: The maximum resident set size (KB)                   = 1603756
+  0: The total amount of wall time                        = 204.005200
+  0: The maximum resident set size (KB)                   = 1612356
 
 Test 159 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmwav_control_noaero_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/atmwav_control_noaero_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmwav_control_noaero_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/atmwav_control_noaero_p8
 Checking test 160 atmwav_control_noaero_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4845,14 +4845,14 @@ Checking test 160 atmwav_control_noaero_p8 results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 114.910781
-  0: The maximum resident set size (KB)                   = 1647360
+  0: The total amount of wall time                        = 95.325391
+  0: The maximum resident set size (KB)                   = 1641220
 
 Test 160 atmwav_control_noaero_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/control_atmwav
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/control_atmwav
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/control_atmwav
 Checking test 161 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4896,14 +4896,14 @@ Checking test 161 control_atmwav results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 103.135697
-  0: The maximum resident set size (KB)                   = 663632
+  0: The total amount of wall time                        = 86.904689
+  0: The maximum resident set size (KB)                   = 661332
 
 Test 161 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/atmaero_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/atmaero_control_p8
 Checking test 162 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4947,14 +4947,14 @@ Checking test 162 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 259.757023
-  0: The maximum resident set size (KB)                   = 2976196
+  0: The total amount of wall time                        = 227.912970
+  0: The maximum resident set size (KB)                   = 2983364
 
 Test 162 atmaero_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/atmaero_control_p8_rad
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/atmaero_control_p8_rad
 Checking test 163 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4998,14 +4998,14 @@ Checking test 163 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 302.212441
-  0: The maximum resident set size (KB)                   = 3059968
+  0: The total amount of wall time                        = 283.962729
+  0: The maximum resident set size (KB)                   = 3055620
 
 Test 163 atmaero_control_p8_rad PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad_micro
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/atmaero_control_p8_rad_micro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/atmaero_control_p8_rad_micro
 Checking test 164 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5049,14 +5049,14 @@ Checking test 164 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 310.272817
-  0: The maximum resident set size (KB)                   = 3059764
+  0: The total amount of wall time                        = 286.233167
+  0: The maximum resident set size (KB)                   = 2992332
 
 Test 164 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_atmaq
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_atmaq
 Checking test 165 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5072,14 +5072,14 @@ Checking test 165 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 653.681345
-  0: The maximum resident set size (KB)                   = 1482260
+  0: The total amount of wall time                        = 617.933122
+  0: The maximum resident set size (KB)                   = 1473440
 
 Test 165 regional_atmaq PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_debug
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_atmaq_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_debug
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_atmaq_debug
 Checking test 166 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5093,14 +5093,14 @@ Checking test 166 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1255.495440
-  0: The maximum resident set size (KB)                   = 1405172
+  0: The total amount of wall time                        = 1245.343907
+  0: The maximum resident set size (KB)                   = 1406208
 
 Test 166 regional_atmaq_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_faster
-working dir  = /work/noaa/epic-ps/jongkim/rt-1731/stmp/jongkim/FV3_RT/rt_58340/regional_atmaq_faster
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_faster
+working dir  = /work/noaa/epic-ps/jongkim/rt-1749/stmp/jongkim/FV3_RT/rt_170826/regional_atmaq_faster
 Checking test 167 regional_atmaq_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5116,12 +5116,12 @@ Checking test 167 regional_atmaq_faster results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 601.114723
-  0: The maximum resident set size (KB)                   = 1477764
+  0: The total amount of wall time                        = 540.027228
+  0: The maximum resident set size (KB)                   = 1473000
 
 Test 167 regional_atmaq_faster PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  5 09:06:51 CDT 2023
-Elapsed time: 01h:14m:44s. Have a nice day!
+Wed May 10 19:40:57 CDT 2023
+Elapsed time: 01h:13m:28s. Have a nice day!

--- a/tests/RegressionTests_wcoss2.intel.log
+++ b/tests/RegressionTests_wcoss2.intel.log
@@ -1,34 +1,34 @@
-Mon May  8 23:19:08 UTC 2023
+Thu May 11 11:06:28 UTC 2023
 Start Regression test
 
-Compile 001 elapsed time 623 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1134 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1674 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 537 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 005 elapsed time 536 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 765 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1261 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 1062 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 1035 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 010 elapsed time 1052 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 951 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 1069 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 453 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 014 elapsed time 1196 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 496 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 493 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 017 elapsed time 790 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 709 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 019 elapsed time 710 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 020 elapsed time 649 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 779 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 022 elapsed time 559 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 023 elapsed time 924 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 445 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 750 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1342 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1139 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1086 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 548 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 005 elapsed time 1015 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 742 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 602 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 2006 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 977 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 490 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 983 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 833 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 731 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 014 elapsed time 899 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 999 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 272 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 017 elapsed time 851 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 821 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 019 elapsed time 1061 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 020 elapsed time 687 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 1118 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 022 elapsed time 1051 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 023 elapsed time 986 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 466 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 797 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_mixedmode
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_p8_mixedmode
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_mixedmode
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_p8_mixedmode
 Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -93,14 +93,14 @@ Checking test 001 cpld_control_p8_mixedmode results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 343.864803
-The maximum resident set size (KB)                   = 2953872
+The total amount of wall time                        = 347.732480
+The maximum resident set size (KB)                   = 2955540
 
 Test 001 cpld_control_p8_mixedmode PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_p8
 Checking test 002 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -165,14 +165,14 @@ Checking test 002 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 390.146929
-The maximum resident set size (KB)                   = 2986756
+The total amount of wall time                        = 396.669799
+The maximum resident set size (KB)                   = 2985180
 
 Test 002 cpld_control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_restart_p8
 Checking test 003 cpld_restart_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -225,14 +225,14 @@ Checking test 003 cpld_restart_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 238.615239
-The maximum resident set size (KB)                   = 2872064
+The total amount of wall time                        = 268.659978
+The maximum resident set size (KB)                   = 2872708
 
 Test 003 cpld_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_qr_p8
 Checking test 004 cpld_control_qr_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -297,14 +297,14 @@ Checking test 004 cpld_control_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 397.760025
-The maximum resident set size (KB)                   = 2995624
+The total amount of wall time                        = 397.555918
+The maximum resident set size (KB)                   = 2995856
 
 Test 004 cpld_control_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_restart_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_restart_qr_p8
 Checking test 005 cpld_restart_qr_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -357,14 +357,14 @@ Checking test 005 cpld_restart_qr_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 239.848171
-The maximum resident set size (KB)                   = 2884552
+The total amount of wall time                        = 257.270568
+The maximum resident set size (KB)                   = 2883184
 
 Test 005 cpld_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_2threads_p8
 Checking test 006 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -417,14 +417,14 @@ Checking test 006 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 372.763329
-The maximum resident set size (KB)                   = 3287172
+The total amount of wall time                        = 375.782851
+The maximum resident set size (KB)                   = 3290904
 
 Test 006 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_decomp_p8
 Checking test 007 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -477,14 +477,14 @@ Checking test 007 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.482338
-The maximum resident set size (KB)                   = 2981820
+The total amount of wall time                        = 388.141965
+The maximum resident set size (KB)                   = 2983764
 
 Test 007 cpld_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_mpi_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_mpi_p8
 Checking test 008 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -537,14 +537,14 @@ Checking test 008 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 321.498746
-The maximum resident set size (KB)                   = 2910552
+The total amount of wall time                        = 324.703980
+The maximum resident set size (KB)                   = 2912112
 
 Test 008 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_ciceC_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_ciceC_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_ciceC_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_ciceC_p8
 Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -609,14 +609,14 @@ Checking test 009 cpld_control_ciceC_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 392.591687
-The maximum resident set size (KB)                   = 2986704
+The total amount of wall time                        = 396.110755
+The maximum resident set size (KB)                   = 2986844
 
 Test 009 cpld_control_ciceC_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_bmark_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_bmark_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_bmark_p8
 Checking test 010 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -664,14 +664,14 @@ Checking test 010 cpld_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 967.594271
-The maximum resident set size (KB)                   = 3925048
+The total amount of wall time                        = 988.600548
+The maximum resident set size (KB)                   = 3931080
 
 Test 010 cpld_bmark_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_bmark_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_restart_bmark_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_bmark_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_restart_bmark_p8
 Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -719,14 +719,14 @@ Checking test 011 cpld_restart_bmark_p8 results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 661.248536
-The maximum resident set size (KB)                   = 3896804
+The total amount of wall time                        = 671.299865
+The maximum resident set size (KB)                   = 3888792
 
 Test 011 cpld_restart_bmark_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_noaero_p8
 Checking test 012 cpld_control_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -790,14 +790,14 @@ Checking test 012 cpld_control_noaero_p8 results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 291.020896
-The maximum resident set size (KB)                   = 1568036
+The total amount of wall time                        = 290.876103
+The maximum resident set size (KB)                   = 1576268
 
 Test 012 cpld_control_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c96_noaero_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_nowave_noaero_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c96_noaero_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_nowave_noaero_p8
 Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -859,14 +859,14 @@ Checking test 013 cpld_control_nowave_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 303.620718
-The maximum resident set size (KB)                   = 1623544
+The total amount of wall time                        = 305.970135
+The maximum resident set size (KB)                   = 1633844
 
 Test 013 cpld_control_nowave_noaero_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_noaero_p8_agrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_noaero_p8_agrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_noaero_p8_agrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_noaero_p8_agrid
 Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -928,14 +928,14 @@ Checking test 014 cpld_control_noaero_p8_agrid results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 317.154399
-The maximum resident set size (KB)                   = 1629136
+The total amount of wall time                        = 314.411805
+The maximum resident set size (KB)                   = 1629736
 
 Test 014 cpld_control_noaero_p8_agrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_c48
 Checking test 015 cpld_control_c48 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -985,14 +985,14 @@ Checking test 015 cpld_control_c48 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 445.954087
-The maximum resident set size (KB)                   = 2644544
+The total amount of wall time                        = 443.455864
+The maximum resident set size (KB)                   = 2641388
 
 Test 015 cpld_control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_warmstart_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_warmstart_c48
 Checking test 016 cpld_warmstart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1042,14 +1042,14 @@ Checking test 016 cpld_warmstart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 130.772757
-The maximum resident set size (KB)                   = 2655572
+The total amount of wall time                        = 130.141238
+The maximum resident set size (KB)                   = 2658848
 
 Test 016 cpld_warmstart_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_warmstart_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_restart_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_warmstart_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_restart_c48
 Checking test 017 cpld_restart_c48 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1099,14 +1099,14 @@ Checking test 017 cpld_restart_c48 results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 73.123090
-The maximum resident set size (KB)                   = 2075904
+The total amount of wall time                        = 75.101264
+The maximum resident set size (KB)                   = 2076552
 
 Test 017 cpld_restart_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/cpld_control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/cpld_control_p8_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/cpld_control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/cpld_control_p8_faster
 Checking test 018 cpld_control_p8_faster results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1171,14 +1171,14 @@ Checking test 018 cpld_control_p8_faster results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 383.251467
-The maximum resident set size (KB)                   = 2984280
+The total amount of wall time                        = 384.908853
+The maximum resident set size (KB)                   = 2980152
 
 Test 018 cpld_control_p8_faster PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_flake
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_flake
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_flake
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_flake
 Checking test 019 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1189,14 +1189,14 @@ Checking test 019 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 218.126691
-The maximum resident set size (KB)                   = 569676
+The total amount of wall time                        = 215.606182
+The maximum resident set size (KB)                   = 570736
 
 Test 019 control_flake PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_CubedSphereGrid
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1223,14 +1223,14 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 132.231996
-The maximum resident set size (KB)                   = 519576
+The total amount of wall time                        = 129.967822
+The maximum resident set size (KB)                   = 521684
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_latlon
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_latlon
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_latlon
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_latlon
 Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1241,14 +1241,14 @@ Checking test 021 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.106371
-The maximum resident set size (KB)                   = 519736
+The total amount of wall time                        = 132.949985
+The maximum resident set size (KB)                   = 519824
 
 Test 021 control_latlon PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1259,14 +1259,14 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.722213
-The maximum resident set size (KB)                   = 521348
+The total amount of wall time                        = 135.460168
+The maximum resident set size (KB)                   = 520360
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c48
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_c48
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c48
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1305,14 +1305,14 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 327.140923
-The maximum resident set size (KB)                   = 682428
+The total amount of wall time                        = 327.623715
+The maximum resident set size (KB)                   = 679392
 
 Test 023 control_c48 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c192
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_c192
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c192
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1323,14 +1323,14 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 530.849784
-The maximum resident set size (KB)                   = 621068
+The total amount of wall time                        = 529.705093
+The maximum resident set size (KB)                   = 621472
 
 Test 024 control_c192 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_c384
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 569.984168
-The maximum resident set size (KB)                   = 931620
+The total amount of wall time                        = 569.633566
+The maximum resident set size (KB)                   = 928588
 
 Test 025 control_c384 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_c384gdas
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_c384gdas
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_c384gdas
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 502.516761
-The maximum resident set size (KB)                   = 1063596
+The total amount of wall time                        = 502.720485
+The maximum resident set size (KB)                   = 1067152
 
 Test 026 control_c384gdas PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_stochy
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1409,28 +1409,28 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 91.462604
-The maximum resident set size (KB)                   = 526084
+The total amount of wall time                        = 91.140117
+The maximum resident set size (KB)                   = 523568
 
 Test 027 control_stochy PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_stochy_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 57.280421
-The maximum resident set size (KB)                   = 294440
+The total amount of wall time                        = 49.708003
+The maximum resident set size (KB)                   = 295356
 
 Test 028 control_stochy_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1441,14 +1441,14 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 85.208701
-The maximum resident set size (KB)                   = 524608
+The total amount of wall time                        = 84.375033
+The maximum resident set size (KB)                   = 526048
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr4
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_iovr4
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr4
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_iovr4
 Checking test 030 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1463,14 +1463,14 @@ Checking test 030 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 138.760184
-The maximum resident set size (KB)                   = 521348
+The total amount of wall time                        = 135.639326
+The maximum resident set size (KB)                   = 521992
 
 Test 030 control_iovr4 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_iovr5
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_iovr5
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_iovr5
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_iovr5
 Checking test 031 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1485,14 +1485,14 @@ Checking test 031 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.679707
-The maximum resident set size (KB)                   = 519936
+The total amount of wall time                        = 136.429241
+The maximum resident set size (KB)                   = 518440
 
 Test 031 control_iovr5 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_p8
 Checking test 032 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1539,14 +1539,14 @@ Checking test 032 control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 186.523552
-The maximum resident set size (KB)                   = 1487616
+The total amount of wall time                        = 182.837300
+The maximum resident set size (KB)                   = 1486432
 
 Test 032 control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_restart_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 103.986888
-The maximum resident set size (KB)                   = 661276
+The total amount of wall time                        = 105.660917
+The maximum resident set size (KB)                   = 659896
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_qr_p8
 Checking test 034 control_qr_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1639,14 +1639,14 @@ Checking test 034 control_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 188.057445
-The maximum resident set size (KB)                   = 1500460
+The total amount of wall time                        = 181.543679
+The maximum resident set size (KB)                   = 1501052
 
 Test 034 control_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_restart_qr_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_restart_qr_p8
 Checking test 035 control_restart_qr_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1685,14 +1685,14 @@ Checking test 035 control_restart_qr_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 105.539492
-The maximum resident set size (KB)                   = 672584
+The total amount of wall time                        = 106.455916
+The maximum resident set size (KB)                   = 668932
 
 Test 035 control_restart_qr_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_decomp_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1735,14 +1735,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 189.929111
-The maximum resident set size (KB)                   = 1483672
+The total amount of wall time                        = 185.031872
+The maximum resident set size (KB)                   = 1480892
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_2threads_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1785,14 +1785,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 163.472832
-The maximum resident set size (KB)                   = 1576496
+The total amount of wall time                        = 161.028810
+The maximum resident set size (KB)                   = 1580128
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_lndp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_p8_lndp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_lndp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_p8_lndp
 Checking test 038 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1811,14 +1811,14 @@ Checking test 038 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 325.541017
-The maximum resident set size (KB)                   = 1484864
+The total amount of wall time                        = 326.122373
+The maximum resident set size (KB)                   = 1488496
 
 Test 038 control_p8_lndp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_rrtmgp
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_p8_rrtmgp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_rrtmgp
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_p8_rrtmgp
 Checking test 039 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1865,14 +1865,14 @@ Checking test 039 control_p8_rrtmgp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 238.872188
-The maximum resident set size (KB)                   = 1553944
+The total amount of wall time                        = 237.143516
+The maximum resident set size (KB)                   = 1552912
 
 Test 039 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_mynn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_p8_mynn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_mynn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_p8_mynn
 Checking test 040 control_p8_mynn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1919,14 +1919,14 @@ Checking test 040 control_p8_mynn results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 184.321927
-The maximum resident set size (KB)                   = 1487100
+The total amount of wall time                        = 185.817188
+The maximum resident set size (KB)                   = 1498356
 
 Test 040 control_p8_mynn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/merra2_thompson
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/merra2_thompson
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/merra2_thompson
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/merra2_thompson
 Checking test 041 merra2_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1973,14 +1973,14 @@ Checking test 041 merra2_thompson results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 207.764186
-The maximum resident set size (KB)                   = 1494004
+The total amount of wall time                        = 207.517773
+The maximum resident set size (KB)                   = 1497712
 
 Test 041 merra2_thompson PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_control
 Checking test 042 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1991,28 +1991,28 @@ Checking test 042 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 301.770632
-The maximum resident set size (KB)                   = 655356
+The total amount of wall time                        = 295.553442
+The maximum resident set size (KB)                   = 654984
 
 Test 042 regional_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_restart
 Checking test 043 regional_restart results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 160.398966
-The maximum resident set size (KB)                   = 654072
+The total amount of wall time                        = 165.770434
+The maximum resident set size (KB)                   = 654668
 
 Test 043 regional_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_control_qr
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_control_qr
 Checking test 044 regional_control_qr results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2023,28 +2023,28 @@ Checking test 044 regional_control_qr results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 298.933992
-The maximum resident set size (KB)                   = 658440
+The total amount of wall time                        = 297.004404
+The maximum resident set size (KB)                   = 658960
 
 Test 044 regional_control_qr PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_restart_qr
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_restart_qr
 Checking test 045 regional_restart_qr results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 162.110107
-The maximum resident set size (KB)                   = 655136
+The total amount of wall time                        = 162.120116
+The maximum resident set size (KB)                   = 656648
 
 Test 045 regional_restart_qr PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_decomp
 Checking test 046 regional_decomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2055,14 +2055,14 @@ Checking test 046 regional_decomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 312.052297
-The maximum resident set size (KB)                   = 657244
+The total amount of wall time                        = 309.831781
+The maximum resident set size (KB)                   = 657888
 
 Test 046 regional_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_2threads
 Checking test 047 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2073,14 +2073,14 @@ Checking test 047 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 192.504411
-The maximum resident set size (KB)                   = 703984
+The total amount of wall time                        = 181.769729
+The maximum resident set size (KB)                   = 699376
 
 Test 047 regional_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_noquilt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_noquilt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_noquilt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_noquilt
 Checking test 048 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2088,28 +2088,28 @@ Checking test 048 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 321.027519
-The maximum resident set size (KB)                   = 648476
+The total amount of wall time                        = 320.261202
+The maximum resident set size (KB)                   = 651836
 
 Test 048 regional_noquilt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_netcdf_parallel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_netcdf_parallel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_netcdf_parallel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_netcdf_parallel
 Checking test 049 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-The total amount of wall time                        = 296.101275
-The maximum resident set size (KB)                   = 656716
+The total amount of wall time                        = 291.600475
+The maximum resident set size (KB)                   = 652788
 
 Test 049 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_2dwrtdecomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_2dwrtdecomp
 Checking test 050 regional_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2120,14 +2120,14 @@ Checking test 050 regional_2dwrtdecomp results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 295.058797
-The maximum resident set size (KB)                   = 660424
+The total amount of wall time                        = 294.322291
+The maximum resident set size (KB)                   = 660604
 
 Test 050 regional_2dwrtdecomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/fv3_regional_wofs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_wofs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/fv3_regional_wofs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_wofs
 Checking test 051 regional_wofs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2138,14 +2138,14 @@ Checking test 051 regional_wofs results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 376.263792
-The maximum resident set size (KB)                   = 344112
+The total amount of wall time                        = 366.997199
+The maximum resident set size (KB)                   = 346556
 
 Test 051 regional_wofs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_control
 Checking test 052 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2192,14 +2192,14 @@ Checking test 052 rap_control results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 423.778369
-The maximum resident set size (KB)                   = 895888
+The total amount of wall time                        = 428.165826
+The maximum resident set size (KB)                   = 897940
 
 Test 052 rap_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_spp_sppt_shum_skeb
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_spp_sppt_shum_skeb
 Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 053 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 246.648289
-The maximum resident set size (KB)                   = 991328
+The total amount of wall time                        = 271.996801
+The maximum resident set size (KB)                   = 993068
 
 Test 053 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_decomp
 Checking test 054 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 054 rap_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 434.934476
-The maximum resident set size (KB)                   = 898276
+The total amount of wall time                        = 453.028244
+The maximum resident set size (KB)                   = 899620
 
 Test 054 rap_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_2threads
 Checking test 055 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 055 rap_2threads results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 389.411756
-The maximum resident set size (KB)                   = 976620
+The total amount of wall time                        = 400.256927
+The maximum resident set size (KB)                   = 970144
 
 Test 055 rap_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_restart
 Checking test 056 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2364,14 +2364,14 @@ Checking test 056 rap_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 216.646515
-The maximum resident set size (KB)                   = 650656
+The total amount of wall time                        = 223.253069
+The maximum resident set size (KB)                   = 649936
 
 Test 056 rap_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_sfcdiff
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_sfcdiff
 Checking test 057 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2418,14 +2418,14 @@ Checking test 057 rap_sfcdiff results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 424.608915
-The maximum resident set size (KB)                   = 893632
+The total amount of wall time                        = 436.798465
+The maximum resident set size (KB)                   = 895868
 
 Test 057 rap_sfcdiff PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_sfcdiff_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_sfcdiff_decomp
 Checking test 058 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2472,14 +2472,14 @@ Checking test 058 rap_sfcdiff_decomp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 442.934827
-The maximum resident set size (KB)                   = 899888
+The total amount of wall time                        = 455.891893
+The maximum resident set size (KB)                   = 896528
 
 Test 058 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_sfcdiff_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_sfcdiff_restart
 Checking test 059 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2518,14 +2518,14 @@ Checking test 059 rap_sfcdiff_restart results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 322.942428
-The maximum resident set size (KB)                   = 643672
+The total amount of wall time                        = 317.735779
+The maximum resident set size (KB)                   = 644152
 
 Test 059 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control
 Checking test 060 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2572,14 +2572,14 @@ Checking test 060 hrrr_control results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 392.620269
-The maximum resident set size (KB)                   = 892840
+The total amount of wall time                        = 406.265512
+The maximum resident set size (KB)                   = 892724
 
 Test 060 hrrr_control PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_decomp
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_decomp
 Checking test 061 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2626,14 +2626,14 @@ Checking test 061 hrrr_control_decomp results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 406.906598
-The maximum resident set size (KB)                   = 893416
+The total amount of wall time                        = 424.636451
+The maximum resident set size (KB)                   = 894008
 
 Test 061 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_2threads
 Checking test 062 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2680,28 +2680,28 @@ Checking test 062 hrrr_control_2threads results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 352.392920
-The maximum resident set size (KB)                   = 961220
+The total amount of wall time                        = 374.324920
+The maximum resident set size (KB)                   = 960024
 
 Test 062 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_restart
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_restart
 Checking test 063 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 289.593144
-The maximum resident set size (KB)                   = 645352
+The total amount of wall time                        = 296.216911
+The maximum resident set size (KB)                   = 643532
 
 Test 063 hrrr_control_restart PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_v1beta
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_v1beta
 Checking test 064 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2748,14 +2748,14 @@ Checking test 064 rrfs_v1beta results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 420.017947
-The maximum resident set size (KB)                   = 896528
+The total amount of wall time                        = 445.267129
+The maximum resident set size (KB)                   = 894968
 
 Test 064 rrfs_v1beta PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_v1nssl
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_v1nssl
 Checking test 065 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2770,14 +2770,14 @@ Checking test 065 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 483.439529
-The maximum resident set size (KB)                   = 584008
+The total amount of wall time                        = 500.278632
+The maximum resident set size (KB)                   = 587144
 
 Test 065 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_v1nssl_nohailnoccn
 Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2792,14 +2792,14 @@ Checking test 066 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 471.147966
-The maximum resident set size (KB)                   = 572940
+The total amount of wall time                        = 484.930903
+The maximum resident set size (KB)                   = 572608
 
 Test 066 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_smoke_conus13km_hrrr_warm
 Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2808,14 +2808,14 @@ Checking test 067 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 154.344815
-The maximum resident set size (KB)                   = 807072
+The total amount of wall time                        = 161.934291
+The maximum resident set size (KB)                   = 800284
 
 Test 067 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_smoke_conus13km_hrrr_warm_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_smoke_conus13km_hrrr_warm_2threads
 Checking test 068 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2824,14 +2824,14 @@ Checking test 068 rrfs_smoke_conus13km_hrrr_warm_2threads results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 113.362983
-The maximum resident set size (KB)                   = 804568
+The total amount of wall time                        = 111.249905
+The maximum resident set size (KB)                   = 802348
 
 Test 068 rrfs_smoke_conus13km_hrrr_warm_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_conus13km_hrrr_warm
 Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2840,14 +2840,14 @@ Checking test 069 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 142.390336
-The maximum resident set size (KB)                   = 799436
+The total amount of wall time                        = 143.554730
+The maximum resident set size (KB)                   = 796728
 
 Test 069 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_smoke_conus13km_radar_tten_warm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_radar_tten
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_smoke_conus13km_radar_tten_warm
 Checking test 070 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2856,26 +2856,26 @@ Checking test 070 rrfs_smoke_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 157.346356
-The maximum resident set size (KB)                   = 804076
+The total amount of wall time                        = 158.467419
+The maximum resident set size (KB)                   = 803516
 
 Test 070 rrfs_smoke_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_conus13km_hrrr_warm_restart_mismatch
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_restart_mismatch
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_conus13km_hrrr_warm_restart_mismatch
 Checking test 071 rrfs_conus13km_hrrr_warm_restart_mismatch results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 73.132399
-The maximum resident set size (KB)                   = 773692
+The total amount of wall time                        = 76.642200
+The maximum resident set size (KB)                   = 770284
 
 Test 071 rrfs_conus13km_hrrr_warm_restart_mismatch PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_csawmg
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_csawmg
 Checking test 072 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2886,14 +2886,14 @@ Checking test 072 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 352.846855
-The maximum resident set size (KB)                   = 589792
+The total amount of wall time                        = 354.233216
+The maximum resident set size (KB)                   = 587268
 
 Test 072 control_csawmg PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_csawmgt
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_csawmgt
 Checking test 073 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2904,14 +2904,14 @@ Checking test 073 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 348.207494
-The maximum resident set size (KB)                   = 586104
+The total amount of wall time                        = 351.122749
+The maximum resident set size (KB)                   = 588408
 
 Test 073 control_csawmgt PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_ras
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_ras
 Checking test 074 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2922,26 +2922,26 @@ Checking test 074 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 184.105062
-The maximum resident set size (KB)                   = 551996
+The total amount of wall time                        = 183.408696
+The maximum resident set size (KB)                   = 552292
 
 Test 074 control_ras PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_wam
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_wam
 Checking test 075 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 118.869201
-The maximum resident set size (KB)                   = 353176
+The total amount of wall time                        = 118.477384
+The maximum resident set size (KB)                   = 275704
 
 Test 075 control_wam PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_p8_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_p8_faster
 Checking test 076 control_p8_faster results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2988,14 +2988,14 @@ Checking test 076 control_p8_faster results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 177.191349
-The maximum resident set size (KB)                   = 1485980
+The total amount of wall time                        = 183.343949
+The maximum resident set size (KB)                   = 1492928
 
 Test 076 control_p8_faster PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_control_faster
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_control_faster
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_control_faster
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_control_faster
 Checking test 077 regional_control_faster results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3006,56 +3006,56 @@ Checking test 077 regional_control_faster results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 286.967719
-The maximum resident set size (KB)                   = 657024
+The total amount of wall time                        = 286.112647
+The maximum resident set size (KB)                   = 656628
 
 Test 077 regional_control_faster PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_smoke_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_smoke_conus13km_hrrr_warm_debug
 Checking test 078 rrfs_smoke_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 915.039664
-The maximum resident set size (KB)                   = 833360
+The total amount of wall time                        = 919.367188
+The maximum resident set size (KB)                   = 836804
 
 Test 078 rrfs_smoke_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_smoke_conus13km_hrrr_warm_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_smoke_conus13km_hrrr_warm_debug_2threads
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_debug_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 531.469910
-The maximum resident set size (KB)                   = 830712
+The total amount of wall time                        = 535.793600
+The maximum resident set size (KB)                   = 831072
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_debug_2threads PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_conus13km_hrrr_warm_debugs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_conus13km_hrrr_warm_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_conus13km_hrrr_warm_debugs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_conus13km_hrrr_warm_debug
 Checking test 080 rrfs_conus13km_hrrr_warm_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 822.453615
-The maximum resident set size (KB)                   = 820684
+The total amount of wall time                        = 831.433366
+The maximum resident set size (KB)                   = 821944
 
 Test 080 rrfs_conus13km_hrrr_warm_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_CubedSphereGrid_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_CubedSphereGrid_debug
 Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3082,348 +3082,348 @@ Checking test 081 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 161.740805
-The maximum resident set size (KB)                   = 679896
+The total amount of wall time                        = 164.276115
+The maximum resident set size (KB)                   = 679376
 
 Test 081 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_wrtGauss_netcdf_parallel_debug
 Checking test 082 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.119718
-The maximum resident set size (KB)                   = 682036
+The total amount of wall time                        = 167.158077
+The maximum resident set size (KB)                   = 679024
 
 Test 082 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_stochy_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_stochy_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_stochy_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_stochy_debug
 Checking test 083 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.069919
-The maximum resident set size (KB)                   = 684156
+The total amount of wall time                        = 187.154591
+The maximum resident set size (KB)                   = 681480
 
 Test 083 control_stochy_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_lndp_debug
 Checking test 084 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.723667
-The maximum resident set size (KB)                   = 684112
+The total amount of wall time                        = 168.242890
+The maximum resident set size (KB)                   = 686312
 
 Test 084 control_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmg_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_csawmg_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmg_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_csawmg_debug
 Checking test 085 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 259.655226
-The maximum resident set size (KB)                   = 723636
+The total amount of wall time                        = 266.238582
+The maximum resident set size (KB)                   = 721776
 
 Test 085 control_csawmg_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_csawmgt_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_csawmgt_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_csawmgt_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_csawmgt_debug
 Checking test 086 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 255.550516
-The maximum resident set size (KB)                   = 723576
+The total amount of wall time                        = 264.164676
+The maximum resident set size (KB)                   = 723484
 
 Test 086 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_ras_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_ras_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_ras_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_ras_debug
 Checking test 087 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.489807
-The maximum resident set size (KB)                   = 695028
+The total amount of wall time                        = 167.516480
+The maximum resident set size (KB)                   = 694196
 
 Test 087 control_ras_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_diag_debug
 Checking test 088 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.936110
-The maximum resident set size (KB)                   = 738644
+The total amount of wall time                        = 170.633367
+The maximum resident set size (KB)                   = 740524
 
 Test 088 control_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_debug_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_debug_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_debug_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_debug_p8
 Checking test 089 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 188.113277
-The maximum resident set size (KB)                   = 1508260
+The total amount of wall time                        = 196.678161
+The maximum resident set size (KB)                   = 1502648
 
 Test 089 control_debug_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1051.672229
-The maximum resident set size (KB)                   = 677576
+The total amount of wall time                        = 1058.940359
+The maximum resident set size (KB)                   = 677488
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.277453
-The maximum resident set size (KB)                   = 1056952
+The total amount of wall time                        = 303.870034
+The maximum resident set size (KB)                   = 1058076
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_debug
 Checking test 092 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.661237
-The maximum resident set size (KB)                   = 1049740
+The total amount of wall time                        = 297.183289
+The maximum resident set size (KB)                   = 1051652
 
 Test 092 hrrr_control_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_unified_drag_suite_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_unified_drag_suite_debug
 Checking test 093 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.250413
-The maximum resident set size (KB)                   = 1051760
+The total amount of wall time                        = 306.328783
+The maximum resident set size (KB)                   = 1056364
 
 Test 093 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_diag_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_diag_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_diag_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_diag_debug
 Checking test 094 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 312.331009
-The maximum resident set size (KB)                   = 1142656
+The total amount of wall time                        = 311.933041
+The maximum resident set size (KB)                   = 1142264
 
 Test 094 rap_diag_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_cires_ugwp_debug
 Checking test 095 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.911304
-The maximum resident set size (KB)                   = 1057860
+The total amount of wall time                        = 307.950442
+The maximum resident set size (KB)                   = 1057972
 
 Test 095 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_unified_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_unified_ugwp_debug
 Checking test 096 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.361875
-The maximum resident set size (KB)                   = 1057708
+The total amount of wall time                        = 312.102196
+The maximum resident set size (KB)                   = 1051436
 
 Test 096 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_lndp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_lndp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_lndp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_lndp_debug
 Checking test 097 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.479569
-The maximum resident set size (KB)                   = 1054732
+The total amount of wall time                        = 303.329101
+The maximum resident set size (KB)                   = 1056564
 
 Test 097 rap_lndp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_progcld_thompson_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_progcld_thompson_debug
 Checking test 098 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.086381
-The maximum resident set size (KB)                   = 1055364
+The total amount of wall time                        = 300.786262
+The maximum resident set size (KB)                   = 1051244
 
 Test 098 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_noah_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_noah_debug
 Checking test 099 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.438678
-The maximum resident set size (KB)                   = 1053344
+The total amount of wall time                        = 295.879195
+The maximum resident set size (KB)                   = 1055432
 
 Test 099 rap_noah_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_sfcdiff_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_sfcdiff_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_sfcdiff_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_sfcdiff_debug
 Checking test 100 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.430663
-The maximum resident set size (KB)                   = 1055640
+The total amount of wall time                        = 302.033735
+The maximum resident set size (KB)                   = 1055112
 
 Test 100 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 101 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 492.027880
-The maximum resident set size (KB)                   = 1054144
+The total amount of wall time                        = 494.643655
+The maximum resident set size (KB)                   = 1057524
 
 Test 101 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rrfs_v1beta_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rrfs_v1beta_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rrfs_v1beta_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rrfs_v1beta_debug
 Checking test 102 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.800427
-The maximum resident set size (KB)                   = 1054064
+The total amount of wall time                        = 296.726192
+The maximum resident set size (KB)                   = 1053636
 
 Test 102 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_clm_lake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_clm_lake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_clm_lake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_clm_lake_debug
 Checking test 103 rap_clm_lake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 358.171747
-The maximum resident set size (KB)                   = 1058236
+The total amount of wall time                        = 360.711035
+The maximum resident set size (KB)                   = 1060176
 
 Test 103 rap_clm_lake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_flake_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_flake_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_flake_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_flake_debug
 Checking test 104 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.870088
-The maximum resident set size (KB)                   = 1055500
+The total amount of wall time                        = 305.842882
+The maximum resident set size (KB)                   = 1059488
 
 Test 104 rap_flake_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_wam_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_wam_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_wam_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 298.135807
-The maximum resident set size (KB)                   = 303504
+The total amount of wall time                        = 296.505707
+The maximum resident set size (KB)                   = 304656
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_spp_sppt_shum_skeb_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_spp_sppt_shum_skeb_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_spp_sppt_shum_skeb_dyn32_phy32
 Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3434,14 +3434,14 @@ Checking test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 241.012645
-The maximum resident set size (KB)                   = 893684
+The total amount of wall time                        = 279.322845
+The maximum resident set size (KB)                   = 900176
 
 Test 106 regional_spp_sppt_shum_skeb_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_control_dyn32_phy32
 Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3488,14 +3488,14 @@ Checking test 107 rap_control_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 354.841327
-The maximum resident set size (KB)                   = 777600
+The total amount of wall time                        = 383.837354
+The maximum resident set size (KB)                   = 780800
 
 Test 107 rap_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_dyn32_phy32
 Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3542,14 +3542,14 @@ Checking test 108 hrrr_control_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 181.699875
-The maximum resident set size (KB)                   = 778440
+The total amount of wall time                        = 196.177197
+The maximum resident set size (KB)                   = 779640
 
 Test 108 hrrr_control_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_2threads_dyn32_phy32
 Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3596,14 +3596,14 @@ Checking test 109 rap_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 333.095353
-The maximum resident set size (KB)                   = 832272
+The total amount of wall time                        = 349.419498
+The maximum resident set size (KB)                   = 832468
 
 Test 109 rap_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_2threads_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_2threads_dyn32_phy32
 Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3650,14 +3650,14 @@ Checking test 110 hrrr_control_2threads_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 163.362284
-The maximum resident set size (KB)                   = 827460
+The total amount of wall time                        = 176.828342
+The maximum resident set size (KB)                   = 824064
 
 Test 110 hrrr_control_2threads_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_decomp_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_decomp_dyn32_phy32
 Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3704,14 +3704,14 @@ Checking test 111 hrrr_control_decomp_dyn32_phy32 results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 187.941536
-The maximum resident set size (KB)                   = 775980
+The total amount of wall time                        = 219.928292
+The maximum resident set size (KB)                   = 776520
 
 Test 111 hrrr_control_decomp_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_restart_dyn32_phy32
 Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3750,28 +3750,28 @@ Checking test 112 rap_restart_dyn32_phy32 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 260.894289
-The maximum resident set size (KB)                   = 614088
+The total amount of wall time                        = 260.540394
+The maximum resident set size (KB)                   = 612696
 
 Test 112 rap_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_restart_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_restart_dyn32_phy32
 Checking test 113 hrrr_control_restart_dyn32_phy32 results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 93.596011
-The maximum resident set size (KB)                   = 609908
+The total amount of wall time                        = 104.798999
+The maximum resident set size (KB)                   = 610456
 
 Test 113 hrrr_control_restart_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_control_dyn64_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_control_dyn64_phy32
 Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3818,81 +3818,81 @@ Checking test 114 rap_control_dyn64_phy32 results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 237.587747
-The maximum resident set size (KB)                   = 797556
+The total amount of wall time                        = 244.505632
+The maximum resident set size (KB)                   = 796064
 
 Test 114 rap_control_dyn64_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_control_debug_dyn32_phy32
 Checking test 115 rap_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.982600
-The maximum resident set size (KB)                   = 936712
+The total amount of wall time                        = 295.660525
+The maximum resident set size (KB)                   = 939332
 
 Test 115 rap_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hrrr_control_debug_dyn32_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hrrr_control_debug_dyn32_phy32
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hrrr_control_debug_dyn32_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hrrr_control_debug_dyn32_phy32
 Checking test 116 hrrr_control_debug_dyn32_phy32 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.924716
-The maximum resident set size (KB)                   = 937424
+The total amount of wall time                        = 288.374951
+The maximum resident set size (KB)                   = 938176
 
 Test 116 hrrr_control_debug_dyn32_phy32 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/rap_control_debug_dyn64_phy32
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/rap_control_dyn64_phy32_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/rap_control_debug_dyn64_phy32
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/rap_control_dyn64_phy32_debug
 Checking test 117 rap_control_dyn64_phy32_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.366841
-The maximum resident set size (KB)                   = 960740
+The total amount of wall time                        = 307.520716
+The maximum resident set size (KB)                   = 956344
 
 Test 117 rap_control_dyn64_phy32_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_atm
 Checking test 118 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 275.277628
-The maximum resident set size (KB)                   = 826348
+The total amount of wall time                        = 299.774348
+The maximum resident set size (KB)                   = 824396
 
 Test 118 hafs_regional_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_atm_thompson_gfdlsf
 Checking test 119 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 327.528635
-The maximum resident set size (KB)                   = 1179940
+The total amount of wall time                        = 383.000767
+The maximum resident set size (KB)                   = 1182532
 
 Test 119 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_atm_ocn
 Checking test 120 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3901,14 +3901,14 @@ Checking test 120 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 393.985610
-The maximum resident set size (KB)                   = 861380
+The total amount of wall time                        = 429.418335
+The maximum resident set size (KB)                   = 861136
 
 Test 120 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_atm_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_atm_wav
 Checking test 121 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3917,14 +3917,14 @@ Checking test 121 hafs_regional_atm_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 713.903441
-The maximum resident set size (KB)                   = 891964
+The total amount of wall time                        = 733.268326
+The maximum resident set size (KB)                   = 891468
 
 Test 121 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_atm_ocn_wav
 Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3935,28 +3935,28 @@ Checking test 122 hafs_regional_atm_ocn_wav results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 906.217369
-The maximum resident set size (KB)                   = 915476
+The total amount of wall time                        = 934.879564
+The maximum resident set size (KB)                   = 919296
 
 Test 122 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_1nest_atm
 Checking test 123 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 332.782126
-The maximum resident set size (KB)                   = 396208
+The total amount of wall time                        = 337.504476
+The maximum resident set size (KB)                   = 395704
 
 Test 123 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_telescopic_2nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_telescopic_2nests_atm
 Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3965,28 +3965,28 @@ Checking test 124 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 406.973801
-The maximum resident set size (KB)                   = 403488
+The total amount of wall time                        = 416.203348
+The maximum resident set size (KB)                   = 424700
 
 Test 124 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_global_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_global_1nest_atm
 Checking test 125 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 174.362822
-The maximum resident set size (KB)                   = 293824
+The total amount of wall time                        = 177.893053
+The maximum resident set size (KB)                   = 264168
 
 Test 125 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_global_multiple_4nests_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_global_multiple_4nests_atm
 Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4004,14 +4004,14 @@ Checking test 126 hafs_global_multiple_4nests_atm results ....
  Comparing HURPRS.GrbF06.nest04 .........OK
  Comparing HURPRS.GrbF06.nest05 .........OK
 
-The total amount of wall time                        = 491.949312
-The maximum resident set size (KB)                   = 353176
+The total amount of wall time                        = 496.223714
+The maximum resident set size (KB)                   = 348760
 
 Test 126 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_specified_moving_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_specified_moving_1nest_atm
 Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4020,28 +4020,28 @@ Checking test 127 hafs_regional_specified_moving_1nest_atm results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 221.325827
-The maximum resident set size (KB)                   = 415760
+The total amount of wall time                        = 226.658168
+The maximum resident set size (KB)                   = 411604
 
 Test 127 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_storm_following_1nest_atm
 Checking test 128 hafs_regional_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 209.639637
-The maximum resident set size (KB)                   = 411744
+The total amount of wall time                        = 212.513848
+The maximum resident set size (KB)                   = 406672
 
 Test 128 hafs_regional_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4050,42 +4050,42 @@ Checking test 129 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 255.367371
-The maximum resident set size (KB)                   = 477464
+The total amount of wall time                        = 271.700744
+The maximum resident set size (KB)                   = 472612
 
 Test 129 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_global_storm_following_1nest_atm
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_global_storm_following_1nest_atm
 Checking test 130 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 87.116885
-The maximum resident set size (KB)                   = 294048
+The total amount of wall time                        = 87.900047
+The maximum resident set size (KB)                   = 283108
 
 Test 130 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_storm_following_1nest_atm_ocn_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_storm_following_1nest_atm_ocn_debug
 Checking test 131 hafs_regional_storm_following_1nest_atm_ocn_debug results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 800.566765
-The maximum resident set size (KB)                   = 495540
+The total amount of wall time                        = 805.302226
+The maximum resident set size (KB)                   = 492996
 
 Test 131 hafs_regional_storm_following_1nest_atm_ocn_debug PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4096,14 +4096,14 @@ Checking test 132 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 506.485461
-The maximum resident set size (KB)                   = 529592
+The total amount of wall time                        = 508.311707
+The maximum resident set size (KB)                   = 528328
 
 Test 132 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/control_p8_atmlnd_sbs
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/control_p8_atmlnd_sbs
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/control_p8_atmlnd_sbs
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/control_p8_atmlnd_sbs
 Checking test 133 control_p8_atmlnd_sbs results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4188,14 +4188,14 @@ Checking test 133 control_p8_atmlnd_sbs results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 243.594305
-The maximum resident set size (KB)                   = 1550220
+The total amount of wall time                        = 242.986567
+The maximum resident set size (KB)                   = 1540284
 
 Test 133 control_p8_atmlnd_sbs PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/atmaero_control_p8
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/atmaero_control_p8
 Checking test 134 atmaero_control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4239,14 +4239,14 @@ Checking test 134 atmaero_control_p8 results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 250.219427
-The maximum resident set size (KB)                   = 2815536
+The total amount of wall time                        = 252.394425
+The maximum resident set size (KB)                   = 2814224
 
 Test 134 atmaero_control_p8 PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/atmaero_control_p8_rad
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/atmaero_control_p8_rad
 Checking test 135 atmaero_control_p8_rad results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4290,14 +4290,14 @@ Checking test 135 atmaero_control_p8_rad results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 295.530872
-The maximum resident set size (KB)                   = 2877260
+The total amount of wall time                        = 286.015177
+The maximum resident set size (KB)                   = 2878236
 
 Test 135 atmaero_control_p8_rad PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/atmaero_control_p8_rad_micro
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/atmaero_control_p8_rad_micro
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/atmaero_control_p8_rad_micro
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/atmaero_control_p8_rad_micro
 Checking test 136 atmaero_control_p8_rad_micro results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4341,14 +4341,14 @@ Checking test 136 atmaero_control_p8_rad_micro results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 302.120297
-The maximum resident set size (KB)                   = 2886428
+The total amount of wall time                        = 296.506912
+The maximum resident set size (KB)                   = 2886276
 
 Test 136 atmaero_control_p8_rad_micro PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_atmaq
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_atmaq
 Checking test 137 regional_atmaq results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4364,14 +4364,14 @@ Checking test 137 regional_atmaq results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 712.159180
-The maximum resident set size (KB)                   = 1260008
+The total amount of wall time                        = 700.298163
+The maximum resident set size (KB)                   = 1269112
 
 Test 137 regional_atmaq PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230504/INTEL/regional_atmaq_debug
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_4714/regional_atmaq_debug
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230510/INTEL/regional_atmaq_debug
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_165694/regional_atmaq_debug
 Checking test 138 regional_atmaq_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4385,12 +4385,12 @@ Checking test 138 regional_atmaq_debug results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1304.633230
-The maximum resident set size (KB)                   = 1295680
+The total amount of wall time                        = 1316.722101
+The maximum resident set size (KB)                   = 1291936
 
 Test 138 regional_atmaq_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue May  9 00:30:00 UTC 2023
-Elapsed time: 01h:10m:53s. Have a nice day!
+Thu May 11 12:18:09 UTC 2023
+Elapsed time: 01h:12m:14s. Have a nice day!

--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -27,7 +27,6 @@ case $(hostname -f) in
   alogin01.acorn.wcoss2.ncep.noaa.gov)  MACHINE_ID=acorn ;; ### acorn
   alogin02.acorn.wcoss2.ncep.noaa.gov)  MACHINE_ID=acorn ;; ### acorn
 
-  gaea9)                   MACHINE_ID=gaea ;; ### gaea9
   gaea10)                  MACHINE_ID=gaea ;; ### gaea10
   gaea11)                  MACHINE_ID=gaea ;; ### gaea11
   gaea12)                  MACHINE_ID=gaea ;; ### gaea12
@@ -35,7 +34,6 @@ case $(hostname -f) in
   gaea14)                  MACHINE_ID=gaea ;; ### gaea14
   gaea15)                  MACHINE_ID=gaea ;; ### gaea15
   gaea16)                  MACHINE_ID=gaea ;; ### gaea16
-  gaea9.ncrc.gov)          MACHINE_ID=gaea ;; ### gaea9
   gaea10.ncrc.gov)         MACHINE_ID=gaea ;; ### gaea10
   gaea11.ncrc.gov)         MACHINE_ID=gaea ;; ### gaea11
   gaea12.ncrc.gov)         MACHINE_ID=gaea ;; ### gaea12

--- a/tests/fv3_conf/compile_slurm.IN_gaea
+++ b/tests/fv3_conf/compile_slurm.IN_gaea
@@ -5,6 +5,7 @@
 ##SBATCH --qos=@[QUEUE]
 #SBATCH --clusters=es
 #SBATCH --partition=eslogin
+#SBATCH --exclude=gaea9
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=8
 #SBATCH --time=180

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -468,7 +468,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
 fi
 
 
-BL_DATE=20230504
+BL_DATE=20230510
 
 RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- Issue: PR #1731 contained minor changes of ccpp physics commits during the review process. However, user's ccpp fork branch not fully synced to those newly committed changes when the develop-20230504 baseline was created. 
- Fix: As develop branch code base is correct, new baseline, develop-20230510 is needed to be created. 
- Gaea baselines are regenerated with hpc stack update (intel-classic-2022.0.2) and removed node option of gaea9 (dedicated for old c3 image)

### Top of commit queue on: TBD
<!-- Please have sub-component Code Managers ready for merging sub-component PR's on the date above and the day after the date above -->

### Input data additions/changes
- [x] No changes are expected to input data.
- [ ] There will be new input data. <!-- Add "input data change" Label -->
- [ ] Input data will be updated. <!-- Add "New Input Data Req'd" Label -->

### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test. <!-- Add "No Baseline Change" Label -->
- [x] Changes are expected to the following tests: <!-- Add "Baseline Change" Label -->
<!-- Please insert what RT's change and why you expect them to change -->
Needs to update all cases affected from #1731:
INTEL FAILED TESTS:
Test cpld_control_p8_mixedmode 001 failed in run_test failed
Test cpld_control_gfsv17 002 failed in run_test failed
Test cpld_control_p8 003 failed in run_test failed
Test cpld_control_qr_p8 005 failed in run_test failed
Test cpld_2threads_p8 007 failed in run_test failed
Test cpld_decomp_p8 008 failed in run_test failed
Test cpld_mpi_p8 009 failed in run_test failed
Test cpld_control_ciceC_p8 010 failed in run_test failed
Test cpld_control_c192_p8 011 failed in run_test failed
Test cpld_control_noaero_p8 013 failed in run_test failed
Test cpld_debug_p8 015 failed in run_test failed
Test cpld_debug_noaero_p8 016 failed in run_test failed
Test control_flake 021 failed in run_test failed
Test control_latlon 024 failed in run_test failed
Test control_wrtGauss_netcdf_parallel 025 failed in run_test failed
Test control_c192 027 failed in run_test failed
Test control_c384 028 failed in run_test failed
Test control_c384gdas 029 failed in run_test failed
Test control_stochy 030 failed in run_test failed
Test control_lndp 032 failed in run_test failed
Test control_iovr4 033 failed in run_test failed
Test control_iovr5 034 failed in run_test failed
Test control_p8 035 failed in run_test failed
Test control_qr_p8 037 failed in run_test failed
Test control_decomp_p8 039 failed in run_test failed
Test control_2threads_p8 040 failed in run_test failed
Test control_p8_lndp 041 failed in run_test failed
Test control_p8_rrtmgp 042 failed in run_test failed
Test control_p8_mynn 043 failed in run_test failed
Test merra2_thompson 044 failed in run_test failed
Test control_csawmg 075 failed in run_test failed
Test control_csawmgt 076 failed in run_test failed
Test control_ras 077 failed in run_test failed
Test control_p8_faster 079 failed in run_test failed
Test hafs_regional_atm 121 failed in run_test failed
Test hafs_regional_atm_ocn 123 failed in run_test failed
Test hafs_regional_atm_wav 124 failed in run_test failed
Test hafs_regional_atm_ocn_wav 125 failed in run_test failed
Test hafs_global_multiple_4nests_atm 129 failed in run_test failed
Test hafs_regional_specified_moving_1nest_atm 130 failed in run_test failed
Test hafs_regional_storm_following_1nest_atm_ocn 132 failed in run_test failed
Test hafs_regional_storm_following_1nest_atm_ocn_wav 135 failed in run_test failed
Test atmwav_control_noaero_p8 157 failed in run_test failed
Test control_atmwav 158 failed in run_test failed
Test atmaero_control_p8 159 failed in run_test failed
Test atmaero_control_p8_rad 160 failed in run_test failed
Test atmaero_control_p8_rad_micro 161 failed in run_test failed

GNU FAILED TESTS:
Test control_c48 001 failed in run_test failed
Test control_stochy 002 failed in run_test failed
Test control_ras 003 failed in run_test failed
Test control_p8 004 failed in run_test failed
Test control_flake 005 failed in run_test failed
Test control_diag_debug 023 failed in run_test failed
Test control_ras_debug 031 failed in run_test failed
Test control_stochy_debug 032 failed in run_test failed
Test control_debug_p8 033 failed in run_test failed
Test control_wam_debug 039 failed in run_test failed
Test cpld_control_p8 051 failed in run_test failed
Test cpld_control_nowave_noaero_p8 052 failed in run_test failed
Test cpld_debug_p8 053 failed in run_test failed

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [x] none

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [ ] Link PR's from all sub-components involved
- [ ] Confirm reviews completed in sub-component PR's
- [ ] Add all appropriate labels to this PR.
- [ ] Run full RT suite on either Hera/Cheyenne with both Intel/GNU compilers
- [x] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on NOAA-EMC/fv3atm/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes NOAA-EMC/fv3atm/issues/<issue_number>
-->
Fixes https://github.com/ufs-community/ufs-weather-model/issues/1746, https://github.com/ufs-community/ufs-weather-model/issues/1724, and https://github.com/ufs-community/ufs-weather-model/issues/1232,

## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - Intel
    - [x] Hera
    - [x] Orion
    - [x] Jet
    - [x] Gaea
    - [x] Cheyenne
  - GNU
    - [x] Hera
    - [x] Cheyenne
- WCOSS2
  - [x] Dogwood/Cactus
  - [x] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [x] N/A
  - [ ] Log attached to comment
